### PR TITLE
Preserve activated-ability provenance from lookup through resolution

### DIFF
--- a/backlog/stack-collapse-and-batch-decisions.md
+++ b/backlog/stack-collapse-and-batch-decisions.md
@@ -298,6 +298,10 @@ per-player-maskable.
 
 ## 4. Open questions
 
+- **Triggered-ability provenance:** `TriggerAbilityResolver` can return definition-owned, granted, and synthesized triggers,
+  but `TriggerProcessor` currently derives an identity from the source's current `CardComponent` for all of them. Carry typed
+  provenance from trigger detection/resolution before treating that pair as authoritative. A null `granterId` is not proof of
+  printed ownership: synthesized and non-attached grant paths can also have no granter.
 - **Grouping scope for A:** contiguous-only (safe, proposed) vs all-identical-anywhere (prettier,
   risks implying a false order). Recommend contiguous-only first.
 - **Batch peel-off semantics (B):** is "Yes to this one, ask me about the rest" worth the extra

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -13057,13 +13057,15 @@ Card authors rarely reference these directly; they are created/updated by the ma
 
 `AbilityIdentity(cardDefinitionId, abilityId)` (`mtg-sdk` `scripting/AbilityIdentity.kt`) is the stable, **definition-scoped**
 identity of a *kind* of ability — independent of the stack object or source entity instance. Two permanents printed from the
-same card (and every future instance) share one identity for a given ability, because both halves are definition-scoped:
-`cardDefinitionId` is the source's `CardComponent.cardDefinitionId`, and `abilityId` is the ability's `AbilityId` (generated
-once when the card definition is built). Cards never author it: the engine threads it onto `TriggeredAbilityOnStackComponent`
-/ `ActivatedAbilityOnStackComponent` (via `GameState.abilityIdentityOf(sourceId, abilityId)`) and onto `DecisionContext`, so
-batch decisions can group structurally identical triggers and persistent yields can remember a per-ability answer across all
-copies. Null for synthesized sources with no card definition (e.g. spell copies). See
-`backlog/stack-collapse-and-batch-decisions.md` §C.2.
+same card (and every future instance) share one identity for a given ability, because both halves are definition-scoped.
+Cards never author it. Activated-ability lookup records whether the concrete ability came from the current card definition:
+printed abilities and generated Class level-up abilities receive the corresponding identity, while runtime-, static-, and
+emblem-granted abilities and intrinsic subtype abilities retain their concrete `AbilityId` without claiming definition
+ownership. The engine threads proven
+identities onto `ActivatedAbilityOnStackComponent` and `DecisionContext`, so persistent yields can remember a per-ability
+answer across all copies. The triggered-ability path still derives a provisional key from the current source card definition;
+typed ownership provenance for granted and synthesized triggers remains an explicit follow-up in
+`backlog/stack-collapse-and-batch-decisions.md` §4. See that backlog's §C.2 for the original identity contract.
 
 ### Batched may-question (engine-internal, not authored)
 

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ArlinnKordScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ArlinnKordScenarioTest.kt
@@ -3,13 +3,19 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.state.components.battlefield.AbilityActivatedThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.EntityId
 import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
 class ArlinnKordScenarioTest : ScenarioTestBase() {
 
@@ -48,6 +54,28 @@ class ArlinnKordScenarioTest : ScenarioTestBase() {
             }
             withClue("Arlinn's emblem should make the Bear's damage ability activatable") {
                 granted shouldNotBe null
+            }
+
+            val action = granted.shouldNotBeNull().action.shouldBeInstanceOf<ActivateAbility>()
+            val activation = game.execute(
+                action.copy(targets = listOf(ChosenTarget.Player(game.player2Id)))
+            )
+            withClue("an ability emitted as legal must pass activation validation") {
+                activation.error shouldBe null
+            }
+
+            val onStack = game.state.getEntity(game.state.stack.last())
+                ?.get<ActivatedAbilityOnStackComponent>()
+                .shouldNotBeNull()
+            withClue("the emblem supplies routing, not the Bear's definition identity") {
+                onStack.abilityIdentity shouldBe null
+                onStack.activatedAbilityId shouldBe action.abilityId
+            }
+            game.state.getEntity(bear)?.has<TappedComponent>() shouldBe true
+
+            game.resolveStack()
+            withClue("the Bear deals damage equal to its power") {
+                game.getLifeTotal(2) shouldBe 18
             }
         }
     }

--- a/mtg-sets/2023/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LikenessLooterScenarioTest.kt
+++ b/mtg-sets/2023/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LikenessLooterScenarioTest.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.core.SelectManaSourcesDecision
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.mtg.sets.definitions.woe.cards.LikenessLooter
@@ -110,6 +111,15 @@ class LikenessLooterScenarioTest : ScenarioTestBase() {
                 val again = game.copyFromGraveyard(looter, x = 4, cardName = "Hill Giant")
                 withClue("second activation should succeed: ${again.error}") { again.error shouldBe null }
                 if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+
+                // This activation came from the runtime grant retained by the first copy. Its
+                // concrete id still routes "this ability", but pairing it with Grizzly Bears'
+                // definition would fabricate semantic identity.
+                val secondStackAbility = game.state.getEntity(game.state.stack.last())
+                    ?.get<ActivatedAbilityOnStackComponent>()
+                secondStackAbility?.abilityIdentity shouldBe null
+                secondStackAbility?.activatedAbilityId shouldBe copyAbilityId
+
                 game.resolveStack()
 
                 val card = game.state.getEntity(looter)!!.get<CardComponent>()!!

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -11,7 +11,7 @@ import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityEffec
 import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityFiredEverComponent
 import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityFiredThisTurnComponent
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
-import com.wingedsheep.engine.state.components.stack.abilityIdentityOf
+import com.wingedsheep.engine.state.components.stack.triggerIdentityFromCurrentCardDefinition
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
@@ -179,7 +179,8 @@ class TriggerProcessor(
         // lowering in `withEffectBudgetGate` moves consent to resolution time — but this guard reads
         // the *un-lowered* ability, so it is still load-bearing.
         if (ability.effectOncePerTurn) return null
-        val identity = state.abilityIdentityOf(trigger.sourceId, ability.id) ?: return null
+        val identity = state.triggerIdentityFromCurrentCardDefinition(trigger.sourceId, ability.id)
+            ?: return null
         // Mirror processMayThenTargetTrigger's fizzle guard: a trigger with no legal targets (for a
         // mandatory-target requirement) fizzles without asking, so it must not join a batch.
         val legalTargets = targetFinder.findLegalTargets(
@@ -259,7 +260,7 @@ class TriggerProcessor(
                 sourceId = first.sourceId,
                 sourceName = first.sourceName,
                 phase = DecisionPhase.RESOLUTION,
-                abilityIdentity = state.abilityIdentityOf(first.sourceId, ability.id)
+                abilityIdentity = state.triggerIdentityFromCurrentCardDefinition(first.sourceId, ability.id)
             ),
             count = run.size
         )
@@ -477,7 +478,8 @@ class TriggerProcessor(
         // The gated "may" effect's own text is the prompt (GatedEffect.description renders
         // "You may …" for a Gate.MayDecide).
         val sourceName = trigger.sourceName
-        val abilityIdentity = state.abilityIdentityOf(trigger.sourceId, ability.id)
+        val abilityIdentity =
+            state.triggerIdentityFromCurrentCardDefinition(trigger.sourceId, ability.id)
 
         // Who is asked. Normally the ability's controller, but a card can name someone else —
         // Farrel's Mantle's "its controller may", where "it" is the enchanted creature and the Aura
@@ -613,7 +615,7 @@ class TriggerProcessor(
             yesText = "Pay $manaCost",
             noText = "Don't pay",
             phase = DecisionPhase.RESOLUTION,
-            abilityIdentity = state.abilityIdentityOf(trigger.sourceId, ability.id)
+            abilityIdentity = state.triggerIdentityFromCurrentCardDefinition(trigger.sourceId, ability.id)
         )
 
         if (!decisionResult.isPaused || decisionResult.pendingDecision == null) {
@@ -825,7 +827,7 @@ class TriggerProcessor(
             controllerId = trigger.controllerId,
             effect = ability.effect,
             description = ability.description,
-            abilityIdentity = state.abilityIdentityOf(trigger.sourceId, ability.id),
+            abilityIdentity = state.triggerIdentityFromCurrentCardDefinition(trigger.sourceId, ability.id),
             triggerDamageAmount = trigger.triggerContext.damageAmount,
             triggeringEntityId = trigger.triggerContext.triggeringEntityId,
             triggeringPlayerId = trigger.triggerContext.triggeringPlayerId,
@@ -891,7 +893,7 @@ class TriggerProcessor(
             controllerId = trigger.controllerId,
             effect = effectOverride ?: ability.effect,
             description = ability.description,
-            abilityIdentity = state.abilityIdentityOf(trigger.sourceId, ability.id),
+            abilityIdentity = state.triggerIdentityFromCurrentCardDefinition(trigger.sourceId, ability.id),
             granterId = trigger.granterId,
             // CR 701.28f — freeze the source's face-change clock as the trigger goes on the stack,
             // so an instruction inside it to transform that same permanent is ignored if the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -1642,9 +1642,10 @@ class ConditionEvaluator(
     /**
      * Farrelite Priest's "if this ability has been activated four or more times this turn". The
      * tally lives on the source permanent, keyed by ability id, and the handler increments it
-     * before the effect runs — so the fourth activation reads four. Reads false when the ability
-     * did not opt into bookkeeping (`activatedAbilityId` null), which is the correct answer for
-     * every ability that never asks.
+     * before the effect runs — so the fourth activation reads four. A modern stack object carries
+     * its concrete id whether or not it tracks activations; an untracked ability still reads false
+     * because its source has no tally for that id. Contexts with no concrete activated ability id
+     * also read false.
      */
     private fun evaluateThisAbilityActivatedThisTurnAtLeast(
         state: GameState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -49,16 +49,17 @@ data class EffectContext(
      * Definition-scoped identity of the triggered/activated ability currently resolving, copied
      * from its stack component (see [com.wingedsheep.sdk.scripting.AbilityIdentity]). Lets a
      * resolution-time may-question consult the controller's persistent auto-answer yields without
-     * re-deriving the key. Null for spell resolution and synthesized sources with no card
-     * definition (backlog §C).
+     * re-deriving the key. Null for spell resolution, sources with no card definition, and
+     * activated abilities whose lookup did not prove definition ownership (backlog §C).
      */
     val abilityIdentity: com.wingedsheep.sdk.scripting.AbilityIdentity? = null,
     /**
-     * The id of the *activated* ability currently resolving, as recorded in the source's
-     * `AbilityActivatedThisTurnComponent`. Lets an effect read back how many times its own ability
-     * has been activated this turn (`ThisAbilityActivatedThisTurnAtLeast` — Farrelite Priest).
-     * Null for spells, triggered abilities and any activation whose ability opted out of
-     * bookkeeping.
+     * Concrete id of the *activated* ability currently resolving. Modern activated stack objects
+     * always carry it even when [abilityIdentity] is null, which lets a runtime-granted ability
+     * route "this ability" without inventing a semantic card-definition pair (Likeness Looter).
+     * Off-stack mana abilities carry it through their direct resolution context as well. Null for
+     * spells, triggered abilities, and specialized synthesized activations with no concrete
+     * ability.
      */
     val activatedAbilityId: com.wingedsheep.sdk.scripting.AbilityId? = null,
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -59,6 +59,7 @@ import com.wingedsheep.sdk.scripting.costs.PermanentCostAction
 import com.wingedsheep.sdk.scripting.costs.VariableCostMeasure
 import com.wingedsheep.sdk.scripting.costs.manaCostOrNull
 import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.AbilityIdentity
 import com.wingedsheep.sdk.scripting.ActivatedAbility
 import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.ExtraLoyaltyActivation
@@ -86,6 +87,47 @@ import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.sdk.core.Zone
 import kotlin.reflect.KClass
+
+/**
+ * Result of resolving an activated-ability id on an object.
+ *
+ * The concrete [ability] is not enough to infer semantic identity: runtime, static, and intrinsic
+ * abilities all have ids, but those ids do not belong to the receiving object's card definition.
+ * Keeping the lookup provenance in the result makes the definition-owned cases explicit and keeps
+ * a static granter attached only to the branch that actually supplied the ability.
+ */
+private sealed interface ActivatedAbilityLookup {
+    val ability: ActivatedAbility
+
+    data class DirectDefinition(
+        override val ability: ActivatedAbility,
+        val identity: AbilityIdentity,
+    ) : ActivatedAbilityLookup
+
+    data class DefinitionDerivedClass(
+        override val ability: ActivatedAbility,
+        val identity: AbilityIdentity,
+    ) : ActivatedAbilityLookup
+
+    data class RuntimeGranted(override val ability: ActivatedAbility) : ActivatedAbilityLookup
+
+    data class StaticGranted(
+        override val ability: ActivatedAbility,
+        val granterId: EntityId,
+    ) : ActivatedAbilityLookup
+
+    data class Intrinsic(override val ability: ActivatedAbility) : ActivatedAbilityLookup
+
+    val staticGranterId: EntityId?
+        get() = (this as? StaticGranted)?.granterId
+
+    val definitionIdentity: AbilityIdentity?
+        get() = when (this) {
+            is DirectDefinition -> identity
+            is DefinitionDerivedClass -> identity
+            is RuntimeGranted, is StaticGranted, is Intrinsic -> null
+        }
+}
 
 /**
  * Handler for the ActivateAbility action.
@@ -182,18 +224,14 @@ class ActivateAbilityHandler(
         // bail out when the lookup fails — fall through to those sources instead.
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
 
-        // Look up ability from card definition (including class-level abilities), granted abilities, or static grants
+        // Keep lookup provenance: only definition-owned results can later form AbilityIdentity.
         val classLevel = container.get<ClassLevelComponent>()?.currentLevel
-        val staticGrants = getStaticGrantedAbilitiesWithGranter(action.sourceId, state)
-        val ability = cardDef?.script?.effectiveActivatedAbilities(classLevel)?.find { it.id == action.abilityId }
-            ?: cardDef?.let { findClassLevelUpAbility(it, container, action.abilityId) }
-            ?: state.grantedActivatedAbilities
-                .filter { it.entityId == action.sourceId }
-                .map { it.ability }
-                .find { it.id == action.abilityId }
-            ?: staticGrants.firstOrNull { it.first.id == action.abilityId }?.first
-            ?: resolveIntrinsicManaAbility(state, action.sourceId, action.abilityId)
+        val abilityLookup = lookupActivatedAbility(
+            state, action.sourceId, action.abilityId, container,
+            cardComponent.cardDefinitionId, cardDef
+        )
             ?: return "Ability not found on this card"
+        val ability = abilityLookup.ability
 
         // The mana-payment window (CR 605.3a) opens the door for mana abilities only — everything
         // else still needs priority.
@@ -472,7 +510,7 @@ class ActivateAbilityHandler(
 
         // The granter of a statically-granted ability, so AbilityCost.TapGrantingPermanent can be
         // checked against the *Equipment's* tap state rather than the host creature's.
-        val validationGranterId = staticGrants.firstOrNull { it.first.id == action.abilityId }?.second
+        val validationGranterId = abilityLookup.staticGranterId
 
         if (action.paymentStrategy !is PaymentStrategy.Explicit && !canPayAbilityCostWithSources(state, costAfterConvokeReduction, action.sourceId, action.playerId, abilityPaymentContext, validationGranterId)) {
             return when (effectiveCost) {
@@ -654,20 +692,17 @@ class ActivateAbilityHandler(
         // fall through with a null cardDef and let the granted-ability lookup succeed.
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
 
-        // Look up ability from card definition (including class-level abilities), granted abilities, or static grants
-        val classLevel = container.get<ClassLevelComponent>()?.currentLevel
-        val staticGrants = getStaticGrantedAbilitiesWithGranter(action.sourceId, state)
-        val staticGrantMatch = staticGrants.firstOrNull { it.first.id == action.abilityId }
-        val ability = cardDef?.script?.effectiveActivatedAbilities(classLevel)?.find { it.id == action.abilityId }
-            ?: cardDef?.let { findClassLevelUpAbility(it, container, action.abilityId) }
-            ?: state.grantedActivatedAbilities
-                .filter { it.entityId == action.sourceId }
-                .map { it.ability }
-                .find { it.id == action.abilityId }
-            ?: staticGrantMatch?.first
-            ?: resolveIntrinsicManaAbility(state, action.sourceId, action.abilityId)
+        // Retain which lookup branch supplied the concrete ability. A CardComponent on the
+        // receiving permanent proves only that the object is a card; it does not make a runtime,
+        // static, or intrinsic ability part of that card's definition.
+        val abilityLookup = lookupActivatedAbility(
+            state, action.sourceId, action.abilityId, container,
+            cardComponent.cardDefinitionId, cardDef
+        )
             ?: return ExecutionResult.error(state, "Ability not found")
-        val staticGranterId = staticGrantMatch?.second
+        val ability = abilityLookup.ability
+        val staticGranterId = abilityLookup.staticGranterId
+        val abilityIdentity = abilityLookup.definitionIdentity
 
         // "X can't be 0" abilities (Gogo, Master of Mimicry): reject an engine-direct activation that
         // pre-fills an X below the ability's minimum. The legal-actions submission path enforces the
@@ -1722,9 +1757,11 @@ class ActivateAbilityHandler(
                 // amount resolves to 0 and the ability produces nothing.
                 sacrificedPermanents = sacrificedSnapshots,
                 manaColorChoice = action.manaColorChoice,
-                // The tally above was already incremented for this activation, so a burnout clause
-                // reading "four or more times this turn" sees the fourth activation as the fourth.
-                activatedAbilityId = if (ability.trackActivations) ability.id else null,
+                // Mana abilities resolve without a stack component, so their activation-time
+                // provenance must enter the effect context here. The concrete id remains useful
+                // even when this lookup branch could not prove a definition-scoped identity.
+                abilityIdentity = abilityIdentity,
+                activatedAbilityId = ability.id,
             )
 
             val effectResult = effectExecutorRegistry.execute(currentState, finalEffect, context).toExecutionResult()
@@ -1944,9 +1981,8 @@ class ActivateAbilityHandler(
             lastKnownSourceAttachments = lastKnownSourceAttachments,
             revealedNotedCreatureType = revealedNotedCreatureType,
             descriptionOverride = ability.descriptionOverride,
-            abilityIdentity = com.wingedsheep.sdk.scripting.AbilityIdentity(
-                cardComponent.cardDefinitionId, ability.id
-            ),
+            abilityIdentity = abilityIdentity,
+            activatedAbilityId = ability.id,
             granterId = staticGranterId,
             // CR 701.28f — freeze the source's face-change clock as the ability goes on the stack;
             // an instruction inside it to transform that same permanent is ignored if the permanent
@@ -2053,9 +2089,8 @@ class ActivateAbilityHandler(
                     tappedPermanents = repeatTapSlice,
                     tappedEntitySnapshots = repeatTapSnapshots,
                     descriptionOverride = ability.descriptionOverride,
-                    abilityIdentity = com.wingedsheep.sdk.scripting.AbilityIdentity(
-                        cardComponent.cardDefinitionId, ability.id
-                    ),
+                    abilityIdentity = abilityIdentity,
+                    activatedAbilityId = ability.id,
                     granterId = staticGranterId
                 )
                 val repeatStackResult = stackResolver.putActivatedAbility(
@@ -2793,6 +2828,56 @@ class ActivateAbilityHandler(
         val subtypes = state.projectedState.getSubtypes(sourceId)
         if (expectedSubtype !in subtypes) return null
         return ability
+    }
+
+    /**
+     * Resolve [abilityId] without discarding how the concrete ability was found.
+     *
+     * The order matches legal-action enumeration and the historical handler lookup. In
+     * particular, an id directly declared by the current definition wins over an equal id from a
+     * grant. Only the first two branches prove definition ownership; every other branch retains a
+     * concrete id for execution while remaining semantically identityless.
+     */
+    private fun lookupActivatedAbility(
+        state: GameState,
+        sourceId: EntityId,
+        abilityId: AbilityId,
+        container: com.wingedsheep.engine.state.ComponentContainer,
+        cardDefinitionId: String,
+        cardDef: com.wingedsheep.sdk.model.CardDefinition?,
+    ): ActivatedAbilityLookup? {
+        val classLevel = container.get<ClassLevelComponent>()?.currentLevel
+
+        cardDef?.script?.effectiveActivatedAbilities(classLevel)
+            ?.firstOrNull { it.id == abilityId }
+            ?.let {
+                return ActivatedAbilityLookup.DirectDefinition(
+                    it,
+                    AbilityIdentity(cardDefinitionId, it.id),
+                )
+            }
+
+        cardDef?.let { findClassLevelUpAbility(it, container, abilityId) }
+            ?.let {
+                return ActivatedAbilityLookup.DefinitionDerivedClass(
+                    it,
+                    AbilityIdentity(cardDefinitionId, it.id),
+                )
+            }
+
+        state.grantedActivatedAbilities
+            .firstOrNull { it.entityId == sourceId && it.ability.id == abilityId }
+            ?.ability
+            ?.let { return ActivatedAbilityLookup.RuntimeGranted(it) }
+
+        getStaticGrantedAbilitiesWithGranter(sourceId, state)
+            .firstOrNull { it.first.id == abilityId }
+            ?.let { (ability, granterId) ->
+                return ActivatedAbilityLookup.StaticGranted(ability, granterId)
+            }
+
+        return resolveIntrinsicManaAbility(state, sourceId, abilityId)
+            ?.let { ActivatedAbilityLookup.Intrinsic(it) }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -63,8 +63,6 @@ import com.wingedsheep.sdk.scripting.AbilityIdentity
 import com.wingedsheep.sdk.scripting.ActivatedAbility
 import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.ExtraLoyaltyActivation
-import com.wingedsheep.sdk.scripting.GrantActivatedAbility
-import com.wingedsheep.sdk.scripting.filters.unified.Scope
 import com.wingedsheep.sdk.scripting.targets.TargetChooser
 import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.scripting.effects.LevelUpClassEffect
@@ -91,10 +89,11 @@ import kotlin.reflect.KClass
 /**
  * Result of resolving an activated-ability id on an object.
  *
- * The concrete [ability] is not enough to infer semantic identity: runtime, static, and intrinsic
- * abilities all have ids, but those ids do not belong to the receiving object's card definition.
- * Keeping the lookup provenance in the result makes the definition-owned cases explicit and keeps
- * a static granter attached only to the branch that actually supplied the ability.
+ * The concrete [ability] is not enough to infer semantic identity: runtime, static, emblem-granted,
+ * and intrinsic abilities all have ids, but those ids do not belong to the receiving object's card
+ * definition. Keeping the lookup provenance in the result makes the definition-owned cases
+ * explicit and keeps a static granter attached only to the branch that actually supplied the
+ * ability.
  */
 private sealed interface ActivatedAbilityLookup {
     val ability: ActivatedAbility
@@ -116,6 +115,8 @@ private sealed interface ActivatedAbilityLookup {
         val granterId: EntityId,
     ) : ActivatedAbilityLookup
 
+    data class EmblemGranted(override val ability: ActivatedAbility) : ActivatedAbilityLookup
+
     data class Intrinsic(override val ability: ActivatedAbility) : ActivatedAbilityLookup
 
     val staticGranterId: EntityId?
@@ -125,7 +126,7 @@ private sealed interface ActivatedAbilityLookup {
         get() = when (this) {
             is DirectDefinition -> identity
             is DefinitionDerivedClass -> identity
-            is RuntimeGranted, is StaticGranted, is Intrinsic -> null
+            is RuntimeGranted, is StaticGranted, is EmblemGranted, is Intrinsic -> null
         }
 }
 
@@ -218,18 +219,15 @@ class ActivateAbilityHandler(
         val cardComponent = container.get<CardComponent>()
             ?: return "Source is not a card"
 
-        // Tokens (and other entities without a registered CardDefinition) only have abilities
+        // Tokens (and other entities without a registered CardDefinition) can still have abilities
         // via static grants (e.g., Brightcap Badger granting "{T}: Add {G}" to Saproling tokens),
-        // intrinsic mana abilities (basic-land subtypes), or temporarily granted abilities. Don't
-        // bail out when the lookup fails — fall through to those sources instead.
+        // emblems, intrinsic mana abilities (basic-land subtypes), or temporary grants. Don't bail
+        // out before the provenance-aware lookup has checked those sources.
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
+        val classLevel = container.get<ClassLevelComponent>()?.currentLevel
 
         // Keep lookup provenance: only definition-owned results can later form AbilityIdentity.
-        val classLevel = container.get<ClassLevelComponent>()?.currentLevel
-        val abilityLookup = lookupActivatedAbility(
-            state, action.sourceId, action.abilityId, container,
-            cardComponent.cardDefinitionId, cardDef
-        )
+        val abilityLookup = lookupActivatedAbility(state, action.sourceId, action.abilityId)
             ?: return "Ability not found on this card"
         val ability = abilityLookup.ability
 
@@ -688,17 +686,10 @@ class ActivateAbilityHandler(
         val cardComponent = container.get<CardComponent>()
             ?: return ExecutionResult.error(state, "Source is not a card")
 
-        // Tokens (no registered CardDefinition) reach this path when activating granted abilities;
-        // fall through with a null cardDef and let the granted-ability lookup succeed.
-        val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
-
         // Retain which lookup branch supplied the concrete ability. A CardComponent on the
         // receiving permanent proves only that the object is a card; it does not make a runtime,
-        // static, or intrinsic ability part of that card's definition.
-        val abilityLookup = lookupActivatedAbility(
-            state, action.sourceId, action.abilityId, container,
-            cardComponent.cardDefinitionId, cardDef
-        )
+        // static, emblem-granted, or intrinsic ability part of that card's definition.
+        val abilityLookup = lookupActivatedAbility(state, action.sourceId, action.abilityId)
             ?: return ExecutionResult.error(state, "Ability not found")
         val ability = abilityLookup.ability
         val staticGranterId = abilityLookup.staticGranterId
@@ -2836,16 +2827,18 @@ class ActivateAbilityHandler(
      * The order matches legal-action enumeration and the historical handler lookup. In
      * particular, an id directly declared by the current definition wins over an equal id from a
      * grant. Only the first two branches prove definition ownership; every other branch retains a
-     * concrete id for execution while remaining semantically identityless.
+     * concrete id for execution while remaining semantically identityless. Static and emblem
+     * grants come from the same shared resolvers used by legal-action enumeration, so the engine
+     * cannot advertise one grant set and validate another.
      */
     private fun lookupActivatedAbility(
         state: GameState,
         sourceId: EntityId,
         abilityId: AbilityId,
-        container: com.wingedsheep.engine.state.ComponentContainer,
-        cardDefinitionId: String,
-        cardDef: com.wingedsheep.sdk.model.CardDefinition?,
     ): ActivatedAbilityLookup? {
+        val container = state.getEntity(sourceId) ?: return null
+        val cardDefinitionId = container.get<CardComponent>()?.cardDefinitionId ?: return null
+        val cardDef = cardRegistry.getCard(cardDefinitionId)
         val classLevel = container.get<ClassLevelComponent>()?.currentLevel
 
         cardDef?.script?.effectiveActivatedAbilities(classLevel)
@@ -2870,11 +2863,15 @@ class ActivateAbilityHandler(
             ?.ability
             ?.let { return ActivatedAbilityLookup.RuntimeGranted(it) }
 
-        getStaticGrantedAbilitiesWithGranter(sourceId, state)
-            .firstOrNull { it.first.id == abilityId }
-            ?.let { (ability, granterId) ->
-                return ActivatedAbilityLookup.StaticGranted(ability, granterId)
+        castPermissionUtils.getStaticGrantedAbilitiesWithGranter(sourceId, state)
+            .firstOrNull { it.ability.id == abilityId }
+            ?.let {
+                return ActivatedAbilityLookup.StaticGranted(it.ability, it.granterId)
             }
+
+        castPermissionUtils.getEmblemGrantedActivatedAbilities(sourceId, state)
+            .firstOrNull { it.id == abilityId }
+            ?.let { return ActivatedAbilityLookup.EmblemGranted(it) }
 
         return resolveIntrinsicManaAbility(state, sourceId, abilityId)
             ?.let { ActivatedAbilityLookup.Intrinsic(it) }
@@ -2903,155 +2900,6 @@ class ActivateAbilityHandler(
             descriptionOverride = "Level up to level $targetLevel"
         )
     }
-
-    /**
-     * Get activated abilities granted to an entity by static abilities on battlefield permanents,
-     * paired with the EntityId of the permanent that granted each ability.
-     * E.g., Spectral Sliver grants a pump ability to all Sliver creatures via
-     * GrantActivatedAbility. The Dominion Bracelet grants its activated
-     * ability to the equipped creature via GrantActivatedAbility; the
-     * granter ID is needed to resolve AbilityCost.ExileGrantingPermanent.
-     */
-    private fun getStaticGrantedAbilitiesWithGranter(
-        entityId: EntityId,
-        state: GameState
-    ): List<Pair<ActivatedAbility, EntityId>> {
-        if (state.getEntity(entityId) == null) return emptyList()
-
-        val result = mutableListOf<Pair<ActivatedAbility, EntityId>>()
-
-        for (permanentId in state.getBattlefield()) {
-            val container = state.getEntity(permanentId) ?: continue
-            val card = container.get<CardComponent>() ?: continue
-            if (container.has<FaceDownComponent>()) continue
-
-            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            val classLevel = container.get<com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent>()?.currentLevel
-            for (rawAbility in cardDef.script.effectiveStaticAbilities(classLevel)) {
-                // A grant can be gated by a ConditionalStaticAbility (Nature's Embrace: the land host
-                // gains "{T}: Add two mana of any one color" only while it is a land). Unwrap the
-                // condition against the granter here so the actual-activation path agrees with the
-                // enumerator; skip when the gate is currently false.
-                val ability = when (rawAbility) {
-                    is com.wingedsheep.sdk.scripting.ConditionalStaticAbility -> {
-                        val granterController = state.projectedState.getController(permanentId)
-                            ?: container.get<ControllerComponent>()?.playerId
-                            ?: continue
-                        val ctx = EffectContext(sourceId = permanentId, controllerId = granterController)
-                        if (!conditionEvaluator.evaluate(state, rawAbility.condition, ctx)) continue
-                        rawAbility.ability
-                    }
-                    else -> rawAbility
-                }
-                // "[receivedBy] have all activated abilities of the [cardFilter] cards exiled with/to
-                // craft this / in your graveyard" (Territory Forge / Locus of Enlightenment /
-                // Thranduil = Self; Agatha's Soul Cauldron = creatures you control with a +1/+1
-                // counter). Mirror CastPermissionUtils.getStaticGrantedAbilitiesWithGranter: grant each
-                // donor ability (per `ability.donors`) to every matching permanent, recording the
-                // *receiver* as the granter so `{T}`/self-references bind to the permanent that gained
-                // the ability. When `oncePerTurnEach` is set (Locus), the util re-stamps each ability
-                // with a donor-derived AbilityId + once-per-turn cap.
-                if (ability is com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfCards) {
-                    val receives = when (val scope = ability.receivedBy.scope) {
-                        is Scope.Self -> permanentId == entityId
-                        is Scope.Specific -> scope.entityId == entityId
-                        is Scope.AttachedTo -> container.get<AttachedToComponent>()?.targetId == entityId
-                        is Scope.SoulbondPair ->
-                            com.wingedsheep.engine.mechanics.SoulbondPairing.isInPairOf(state, permanentId, entityId)
-                        is Scope.Battlefield -> {
-                            if (ability.receivedBy.excludeSelf && permanentId == entityId) false
-                            else {
-                                val granterController = state.projectedState.getController(permanentId)
-                                granterController != null && predicateEvaluator.matches(
-                                    state, state.projectedState, entityId, ability.receivedBy.baseFilter,
-                                    PredicateContext(controllerId = granterController, sourceId = permanentId)
-                                )
-                            }
-                        }
-                    }
-                    if (receives) {
-                        for (granted in com.wingedsheep.engine.legalactions.utils.donorCardsActivatedAbilities(
-                            state, permanentId, cardRegistry, predicateEvaluator,
-                            ability.donors, ability.cardFilter, ability.oncePerTurnEach
-                        )) {
-                            result.add(granted to entityId)
-                        }
-                    }
-                    continue
-                }
-                // "This permanent has all activated and triggered abilities of the last chosen card
-                // exiled with it" (Koh, the Face Stealer). Self-scoped: only the source receives the
-                // chosen card's *activated* abilities here (triggered ones flow through
-                // TriggerAbilityResolver), with the source recorded as granter so `{T}`/self-references
-                // bind to it.
-                if (ability is com.wingedsheep.sdk.scripting.HasAbilitiesOfChosenLinkedExiledCard) {
-                    if (ability.grantActivated && permanentId == entityId) {
-                        for (granted in com.wingedsheep.engine.legalactions.utils.chosenLinkedExiledActivatedAbilities(state, permanentId, cardRegistry)) {
-                            result.add(granted to entityId)
-                        }
-                    }
-                    continue
-                }
-                if (ability !is GrantActivatedAbility) continue
-                when (ability.filter.scope) {
-                    is Scope.Battlefield -> {
-                        if (ability.filter.excludeSelf && permanentId == entityId) continue
-                        val granterController = state.projectedState.getController(permanentId) ?: continue
-                        val matches = predicateEvaluator.matches(
-                            state,
-                            state.projectedState,
-                            entityId,
-                            ability.filter.baseFilter,
-                            PredicateContext(controllerId = granterController, sourceId = permanentId)
-                        )
-                        if (matches) {
-                            result.add(ability.ability to permanentId)
-                        }
-                    }
-                    is Scope.AttachedTo -> {
-                        val attachedTo = container.get<AttachedToComponent>()
-                        if (attachedTo != null && attachedTo.targetId == entityId) {
-                            result.add(ability.ability to permanentId)
-                        }
-                    }
-                    is Scope.Self -> {
-                        if (permanentId == entityId) result.add(ability.ability to permanentId)
-                    }
-                    // Soulbond payoff (CR 702.95b) — must mirror the enumerator's SoulbondPair
-                    // branch in CastPermissionUtils exactly, or the ability shows as a button on the
-                    // paired creature and then fails legality when clicked.
-                    is Scope.SoulbondPair -> {
-                        if (com.wingedsheep.engine.mechanics.SoulbondPairing.isInPairOf(state, permanentId, entityId)) {
-                            result.add(ability.ability to permanentId)
-                        }
-                    }
-                    is Scope.Specific -> {
-                        if ((ability.filter.scope as Scope.Specific).entityId == entityId) {
-                            result.add(ability.ability to permanentId)
-                        }
-                    }
-                }
-            }
-        }
-
-        // Granted GrantActivatedAbility statics (CR 611): a permanent that was itself *granted* an
-        // ability-granting static — e.g. Roar of the Fifth People chapter II. Resolved by the shared
-        // helper so this handler and the enumerators agree on the granted set.
-        castPermissionUtils.getGrantedStaticGrantActivatedAbilities(entityId, state)
-            .forEach { result.add(it.ability to it.granterId) }
-
-        // GainActivatedAbilitiesOfPermanents (Sharkey): copies of opponents' lands' abilities, etc.
-        // Resolved by the shared helper so the enumerator and this handler agree on the gained set.
-        castPermissionUtils.getGainedAbilitiesOfPermanents(entityId, state)
-            .forEach { result.add(it.ability to it.granterId) }
-
-        return result
-    }
-
-    private fun getStaticGrantedActivatedAbilities(
-        entityId: EntityId,
-        state: GameState
-    ): List<ActivatedAbility> = getStaticGrantedAbilitiesWithGranter(entityId, state).map { it.first }
 
     companion object {
         fun create(services: EngineServices): ActivateAbilityHandler {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/EachPermanentBecomesCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/EachPermanentBecomesCopyOfTargetExecutor.kt
@@ -145,21 +145,23 @@ class EachPermanentBecomesCopyOfTargetExecutor(
                 updated
             }
 
-            // "…and this ability": re-grant the activated ability that produced this copy. The
-            // resolving ability's identity carries the *permanent's* card definition id, which has
-            // already drifted to whatever it last copied — so read the granted record first (that's
-            // where the ability lives after the first copy) and fall back to the printed definition
-            // for the very first activation.
+            // "…and this ability": re-grant the concrete activated ability that produced this
+            // copy. After the first copy it lives in the runtime-grant store and intentionally has
+            // no definition-scoped AbilityIdentity, so routing must use activatedAbilityId. Read the
+            // grant first, then use a proven definition identity to recover the first activation's
+            // ability even if the source's characteristics changed before this resolved.
             if (effect.retainActivatingAbility) {
-                val identity = context.abilityIdentity
-                if (identity != null && newState.grantedActivatedAbilities
-                        .none { it.entityId == entityId && it.ability.id == identity.abilityId }
+                val activatedAbilityId = context.activatedAbilityId
+                if (activatedAbilityId != null && newState.grantedActivatedAbilities
+                        .none { it.entityId == entityId && it.ability.id == activatedAbilityId }
                 ) {
                     val ability = state.grantedActivatedAbilities
-                        .firstOrNull { it.entityId == entityId && it.ability.id == identity.abilityId }
+                        .firstOrNull { it.entityId == entityId && it.ability.id == activatedAbilityId }
                         ?.ability
-                        ?: cardRegistry.getCard(identity.cardDefinitionId)
-                            ?.activatedAbilities?.firstOrNull { it.id == identity.abilityId }
+                        ?: context.abilityIdentity
+                            ?.takeIf { it.abilityId == activatedAbilityId }
+                            ?.let { cardRegistry.getCard(it.cardDefinitionId) }
+                            ?.activatedAbilities?.firstOrNull { it.id == activatedAbilityId }
                     if (ability != null) {
                         newState = newState.copy(
                             grantedActivatedAbilities = newState.grantedActivatedAbilities +

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -13,9 +13,6 @@ import com.wingedsheep.engine.state.components.battlefield.*
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.TextReplacementComponent
-import com.wingedsheep.engine.state.components.identity.ControllerComponent
-import com.wingedsheep.engine.state.components.identity.EmblemActivatedAbilityComponent
-import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Zone
@@ -86,24 +83,14 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 .map { it.ability }
             val staticGrants = context.castPermissionUtils.getStaticGrantedAbilitiesWithGranter(entityId, state)
             val staticAbilities = staticGrants.map { it.ability }
-            val emblemAbilities = state.entities.mapNotNull { (emblemId, emblemContainer) ->
-                val grant = emblemContainer.get<EmblemActivatedAbilityComponent>() ?: return@mapNotNull null
-                val controllerId = emblemContainer.get<ControllerComponent>()?.playerId ?: return@mapNotNull null
-                val matches = context.predicateEvaluator.matches(
-                    state,
-                    projected,
-                    entityId,
-                    grant.filter.baseFilter,
-                    PredicateContext(controllerId = controllerId, sourceId = emblemId),
-                ) && (!grant.filter.excludeSelf || entityId != emblemId)
-                grant.takeIf { matches }?.abilities
-            }.flatten()
+            val emblemAbilities =
+                context.castPermissionUtils.getEmblemGrantedActivatedAbilities(entityId, state)
             // Which permanent granted each statically-granted ability, so a cost that names the
             // granter (AbilityCost.TapGrantingPermanent) can be gated on *its* state, not the host's.
             val granterByAbilityId = staticGrants.associate { it.ability.id to it.granterId }
             val allAbilities = grantedAbilities + staticAbilities + emblemAbilities
 
-            // If no card definition (e.g., tokens) and no granted/static abilities, skip
+            // If no card definition (e.g., tokens) and no granted abilities, skip
             if (cardDef == null && allAbilities.isEmpty()) continue
 
             // Get class level for Class enchantments (null for non-Class cards)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.engine.state.components.battlefield.GraveyardPlayPermissi
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.EmblemActivatedAbilityComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.player.CantCastSpellsComponent
 import com.wingedsheep.engine.state.components.player.EquipActivationsThisTurnComponent
@@ -1643,6 +1644,32 @@ class CastPermissionUtils(
         state: GameState
     ): List<com.wingedsheep.sdk.scripting.ActivatedAbility> =
         getStaticGrantedAbilitiesWithGranter(entityId, state).map { it.ability }
+
+    /**
+     * Get activated abilities granted to [entityId] by permanent emblems.
+     *
+     * Emblems live as synthetic, non-zoned entities, so they are not part of the battlefield
+     * static-ability scan above. This method is the shared authority used by legal-action
+     * enumeration and activation lookup: an ability offered from an emblem must be found with the
+     * same controller-relative filter when the submitted action is validated and executed.
+     */
+    fun getEmblemGrantedActivatedAbilities(
+        entityId: EntityId,
+        state: GameState,
+    ): List<ActivatedAbility> = state.entities.flatMap { (emblemId, emblemContainer) ->
+        val grant = emblemContainer.get<EmblemActivatedAbilityComponent>()
+            ?: return@flatMap emptyList()
+        val controllerId = emblemContainer.get<ControllerComponent>()?.playerId
+            ?: return@flatMap emptyList()
+        val matches = predicateEvaluator.matches(
+            state,
+            state.projectedState,
+            entityId,
+            grant.filter.baseFilter,
+            PredicateContext(controllerId = controllerId, sourceId = emblemId),
+        ) && (!grant.filter.excludeSelf || entityId != emblemId)
+        if (matches) grant.abilities else emptyList()
+    }
 }
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2939,6 +2939,7 @@ class StackResolver(
             controllerId = abilityComponent.controllerId,
             granterId = abilityComponent.granterId,
             abilityIdentity = abilityComponent.abilityIdentity,
+            activatedAbilityId = abilityComponent.activatedAbilityId,
             sourceFaceChanges = abilityComponent.sourceFaceChanges,
             targets = activatedTargets,
             alignedTargets = alignedActivatedTargets,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/AbilityIdentityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/AbilityIdentityResolver.kt
@@ -7,16 +7,20 @@ import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.AbilityIdentity
 
 /**
- * Derives the [AbilityIdentity] of an ability whose source permanent/card is [sourceId], by pairing
- * the source's `CardComponent.cardDefinitionId` with the ability's [abilityId].
+ * Transitional trigger-path derivation that pairs [abilityId] with [sourceId]'s current card
+ * definition.
  *
- * Returns `null` when [sourceId] has no [CardComponent] — e.g. synthesized sources such as a spell
- * copy placed on a fresh entity — in which case the ability simply carries no identity and is never
- * grouped or yielded against (correct: a copy of a spell is not a recurring card ability).
+ * This says only how the key was derived; it does not prove that the trigger belongs to that card
+ * definition. [com.wingedsheep.engine.event.TriggerAbilityResolver] can also return granted and
+ * synthesized triggers, so those branches need typed provenance before trigger identity is fully
+ * authoritative. Activated abilities do not use this helper: their lookup records definition
+ * ownership explicitly at activation time.
  *
- * This is the one place the key is computed, so triggered- and activated-ability stack components
- * and the decisions they raise all agree on the same identity.
+ * Returns `null` when [sourceId] has no [CardComponent].
  */
-fun GameState.abilityIdentityOf(sourceId: EntityId, abilityId: AbilityId): AbilityIdentity? =
+fun GameState.triggerIdentityFromCurrentCardDefinition(
+    sourceId: EntityId,
+    abilityId: AbilityId,
+): AbilityIdentity? =
     getEntity(sourceId)?.get<CardComponent>()?.cardDefinitionId
         ?.let { AbilityIdentity(it, abilityId) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -379,10 +379,19 @@ data class ActivatedAbilityOnStackComponent(
     /**
      * Definition-scoped identity of the activated ability, shared by every copy of the same card
      * and every future instance of it. Drives batch decisions and persistent yields (see
-     * [com.wingedsheep.sdk.scripting.AbilityIdentity]). Null for synthesized abilities with no
-     * stable [com.wingedsheep.sdk.scripting.AbilityId] behind them (e.g. crew/saddle).
+     * [com.wingedsheep.sdk.scripting.AbilityIdentity]). Null unless activation lookup proved that
+     * the concrete ability belongs to the source's current card definition; runtime/static grants,
+     * intrinsic mana abilities, and synthesized crew/saddle actions therefore carry no identity.
      */
     val abilityIdentity: com.wingedsheep.sdk.scripting.AbilityIdentity? = null,
+    /**
+     * Concrete activated-ability id used for resolution-time routing and ability-local
+     * bookkeeping. Unlike [abilityIdentity], this need not be definition-scoped: runtime/static
+     * grants retain their id here without claiming that it belongs to the receiver's definition.
+     * Stack copies inherit it with the rest of this component. Null for specialized synthesized
+     * actions such as crew and saddle, which have no [com.wingedsheep.sdk.scripting.ActivatedAbility].
+     */
+    val activatedAbilityId: AbilityId? = null,
     /**
      * The permanent whose static ability granted this activated ability (the Equipment/Aura/permanent
      * bearing the `GrantActivatedAbility` static), captured at activation. Read at resolution into

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -380,8 +380,9 @@ data class ActivatedAbilityOnStackComponent(
      * Definition-scoped identity of the activated ability, shared by every copy of the same card
      * and every future instance of it. Drives batch decisions and persistent yields (see
      * [com.wingedsheep.sdk.scripting.AbilityIdentity]). Null unless activation lookup proved that
-     * the concrete ability belongs to the source's current card definition; runtime/static grants,
-     * intrinsic mana abilities, and synthesized crew/saddle actions therefore carry no identity.
+     * the concrete ability belongs to the source's current card definition; runtime, static, and
+     * emblem grants, intrinsic mana abilities, and synthesized crew/saddle actions therefore carry
+     * no identity.
      */
     val abilityIdentity: com.wingedsheep.sdk.scripting.AbilityIdentity? = null,
     /**
@@ -397,7 +398,8 @@ data class ActivatedAbilityOnStackComponent(
      * bearing the `GrantActivatedAbility` static), captured at activation. Read at resolution into
      * [com.wingedsheep.engine.handlers.EffectContext.granterId] so the granted ability can name its
      * granter via [com.wingedsheep.sdk.scripting.targets.EffectTarget.GrantingSource] — e.g. Trusty
-     * Boomerang's "Return [this Equipment] to its owner's hand". Null for non-granted abilities.
+     * Boomerang's "Return [this Equipment] to its owner's hand". Null for abilities not granted by
+     * a permanent's static ability.
      */
     val granterId: EntityId? = null,
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbilityIdentityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbilityIdentityTest.kt
@@ -14,11 +14,13 @@ import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
-import com.wingedsheep.engine.state.components.stack.abilityIdentityOf
+import com.wingedsheep.engine.state.components.stack.triggerIdentityFromCurrentCardDefinition
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Deck
@@ -29,9 +31,11 @@ import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.AbilityIdentity
 import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.ClassLevelAbility
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.ReplaceLandManaColor
 import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import io.kotest.core.spec.style.FunSpec
@@ -96,6 +100,27 @@ class AbilityIdentityTest : FunSpec({
                 isManaAbility = true,
                 timing = TimingRule.ManaAbility,
             )
+        ),
+    )
+
+    val identityClass = CardDefinition.enchantment(
+        name = "Identity Class",
+        manaCost = ManaCost.parse("{1}"),
+        subtypes = setOf(Subtype.CLASS),
+        script = CardScript(
+            classLevels = listOf(
+                ClassLevelAbility(level = 2, cost = ManaCost.ZERO),
+            ),
+        ),
+    )
+
+    val intrinsicManaChoice = CardDefinition.enchantment(
+        name = "Intrinsic Mana Choice",
+        manaCost = ManaCost.parse("{1}"),
+        script = CardScript(
+            staticAbilities = listOf(
+                ReplaceLandManaColor(filter = GameObjectFilter.BasicLand.youControl()),
+            ),
         ),
     )
 
@@ -290,6 +315,47 @@ class AbilityIdentityTest : FunSpec({
         continuation.baseContext.activatedAbilityId shouldBe grantedId
     }
 
+    test("a generated Class level-up ability receives the current definition identity") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + identityClass)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val source = driver.putPermanentOnBattlefield(player, "Identity Class", classLevel = 1)
+        val levelUpId = AbilityId.classLevelUp(2)
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = source, abilityId = levelUpId)
+        ).isSuccess shouldBe true
+
+        val onStack = driver.state.getEntity(driver.state.stack.last())
+            ?.get<ActivatedAbilityOnStackComponent>()
+            .shouldNotBeNull()
+        onStack.abilityIdentity shouldBe AbilityIdentity("Identity Class", levelUpId)
+        onStack.activatedAbilityId shouldBe levelUpId
+    }
+
+    test("an intrinsic basic-land mana ability retains its id without definition identity") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + intrinsicManaChoice)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        driver.putPermanentOnBattlefield(player, "Intrinsic Mana Choice")
+        val forest = driver.putLandOnBattlefield(player, "Forest")
+        val intrinsicId = AbilityId.intrinsicMana(Color.GREEN.symbol)
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = forest, abilityId = intrinsicId)
+        ).isPaused shouldBe true
+
+        val continuation = driver.state.peekContinuation()
+            .shouldBeInstanceOf<ChooseManaColorContinuation>()
+        continuation.baseContext.abilityIdentity shouldBe null
+        continuation.baseContext.activatedAbilityId shouldBe intrinsicId
+    }
+
     test("triggered abilities from two copies of the same card share one AbilityIdentity") {
         val driver = GameTestDriver()
         driver.registerCards(TestCards.all + listOf(identityBear))
@@ -337,9 +403,9 @@ class AbilityIdentityTest : FunSpec({
         decision.context.abilityIdentity shouldBe identity
     }
 
-    test("abilityIdentityOf returns null for a source with no card definition") {
+    test("the transitional trigger identity derivation returns null without a card definition") {
         // A bare state with no entity for the given id has no CardComponent → no identity, no throw.
         val state = GameState(rng = GameRng.seeded(1L))
-        state.abilityIdentityOf(EntityId.of("ghost"), AbilityId("x")) shouldBe null
+        state.triggerIdentityFromCurrentCardDefinition(EntityId.of("ghost"), AbilityId("x")) shouldBe null
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbilityIdentityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbilityIdentityTest.kt
@@ -1,9 +1,16 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseManaColorContinuation
 import com.wingedsheep.engine.core.DecisionPhase
 import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.event.GrantedActivatedAbility
+import com.wingedsheep.engine.event.GrantedStaticAbility
 import com.wingedsheep.engine.handlers.DecisionHandler
+import com.wingedsheep.engine.handlers.effects.stack.CopyTargetSpellOrAbilityExecutor
+import com.wingedsheep.engine.mechanics.stack.StackResolver
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
@@ -22,9 +29,15 @@ import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.AbilityIdentity
 import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
  * Tests for the shared [AbilityIdentity] key (backlog/stack-collapse-and-batch-decisions.md §C.2).
@@ -32,7 +45,9 @@ import io.kotest.matchers.shouldBe
  * The key is the definition-scoped pair `(cardDefinitionId, abilityId)`. Its load-bearing property
  * — the one batch decisions and persistent yields both rely on — is that two permanents printed
  * from the same card produce the *same* identity for the same ability. These tests pin:
- *  - an activated ability on the stack carries its identity, and two copies of the card share it;
+ *  - a printed activated ability carries semantic identity plus its concrete routing id;
+ *  - runtime- and static-granted abilities retain only their concrete routing id;
+ *  - an activated stack copy preserves both identity fields;
  *  - a triggered ability on the stack carries its identity, and two copies share it;
  *  - the may-question decision raised for an ability carries the identity in its context;
  *  - the resolver returns null (rather than throwing) for a source with no card definition.
@@ -66,6 +81,24 @@ class AbilityIdentityTest : FunSpec({
         toughness = 2
     )
 
+    val printedManaAbilityId = AbilityId("test_printed_identity_mana")
+    val printedManaSource = CardDefinition.creature(
+        name = "Identity Mana Source",
+        manaCost = ManaCost.parse("{1}"),
+        subtypes = emptySet(),
+        power = 1,
+        toughness = 1,
+        script = CardScript.permanent(
+            ActivatedAbility(
+                id = printedManaAbilityId,
+                cost = AbilityCost.Free,
+                effect = Effects.AddAnyColorMana(1),
+                isManaAbility = true,
+                timing = TimingRule.ManaAbility,
+            )
+        ),
+    )
+
     test("an activated ability on the stack carries its AbilityIdentity, shared by two copies") {
         val driver = GameTestDriver()
         driver.registerCards(TestCards.all + listOf(identityPinger))
@@ -89,9 +122,172 @@ class AbilityIdentityTest : FunSpec({
         activatedOnStack.size shouldBe 2
 
         val expected = AbilityIdentity("Identity Pinger", pingerAbilityId)
-        activatedOnStack.forEach { it.abilityIdentity shouldBe expected }
+        activatedOnStack.forEach {
+            it.abilityIdentity shouldBe expected
+            it.activatedAbilityId shouldBe pingerAbilityId
+        }
         // The two copies share one identity — the property batch/yield grouping depends on.
         activatedOnStack[0].abilityIdentity shouldBe activatedOnStack[1].abilityIdentity
+    }
+
+    test("a runtime-granted activated ability keeps its concrete id without definition identity") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(identityBear))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val receiver = driver.putCreatureOnBattlefield(player, "Identity Bear")
+        val grantedId = AbilityId("runtime_granted_identity_test")
+        val grantedAbility = ActivatedAbility(
+            id = grantedId,
+            cost = AbilityCost.Free,
+            effect = Effects.GainLife(1),
+        )
+        driver.replaceState(
+            driver.state.copy(
+                grantedActivatedAbilities = driver.state.grantedActivatedAbilities +
+                    GrantedActivatedAbility(receiver, grantedAbility, Duration.Permanent),
+            )
+        )
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = receiver, abilityId = grantedId)
+        ).isSuccess shouldBe true
+
+        val onStack = driver.state.getEntity(driver.state.stack.last())
+            ?.get<ActivatedAbilityOnStackComponent>()
+            .shouldNotBeNull()
+        onStack.abilityIdentity shouldBe null
+        onStack.activatedAbilityId shouldBe grantedId
+    }
+
+    test("a flattened static-granted ability keeps its concrete id without definition identity") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(identityBear))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val granter = driver.putCreatureOnBattlefield(player, "Identity Bear")
+        val receiver = driver.putCreatureOnBattlefield(player, "Identity Bear")
+        val grantedId = AbilityId("flattened_static_granted_identity_test")
+        val grantedAbility = ActivatedAbility(
+            id = grantedId,
+            cost = AbilityCost.Free,
+            effect = Effects.GainLife(1),
+        )
+        driver.replaceState(
+            driver.state.copy(
+                // Model the flattened GrantStaticAbilityEffect store used after a runtime effect
+                // grants an ability-granting static to a permanent.
+                grantedStaticAbilities = driver.state.grantedStaticAbilities + GrantedStaticAbility(
+                    entityId = granter,
+                    ability = GrantActivatedAbility(
+                        ability = grantedAbility,
+                        filter = GroupFilter(GameObjectFilter.Creature.youControl()),
+                    ),
+                    duration = Duration.Permanent,
+                ),
+            )
+        )
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = receiver, abilityId = grantedId)
+        ).isSuccess shouldBe true
+
+        val onStack = driver.state.getEntity(driver.state.stack.last())
+            ?.get<ActivatedAbilityOnStackComponent>()
+            .shouldNotBeNull()
+        onStack.abilityIdentity shouldBe null
+        onStack.activatedAbilityId shouldBe grantedId
+    }
+
+    test("a copied activated stack object preserves semantic identity and concrete id") {
+        val stackEntityId = EntityId.of("original-activated-ability")
+        val originalController = EntityId.of("original-controller")
+        val copyController = EntityId.of("copy-controller")
+        val identity = AbilityIdentity("Identity Pinger", pingerAbilityId)
+        val component = ActivatedAbilityOnStackComponent(
+            sourceId = EntityId.of("ability-source"),
+            sourceName = "Identity Pinger",
+            controllerId = originalController,
+            effect = Effects.GainLife(1),
+            abilityIdentity = identity,
+            activatedAbilityId = pingerAbilityId,
+        )
+        val state = GameState(
+            rng = GameRng.seeded(2L),
+            entities = mapOf(stackEntityId to ComponentContainer.of(component)),
+            stack = listOf(stackEntityId),
+        )
+
+        val result = CopyTargetSpellOrAbilityExecutor.cloneAndPush(
+            state = state,
+            stackResolver = StackResolver(CardRegistry()),
+            abilityEntityId = stackEntityId,
+            controllerId = copyController,
+        )
+
+        result.isSuccess shouldBe true
+        val copied = result.newState.getEntity(result.newState.stack.last())
+            ?.get<ActivatedAbilityOnStackComponent>()
+            .shouldNotBeNull()
+        copied.controllerId shouldBe copyController
+        copied.abilityIdentity shouldBe identity
+        copied.activatedAbilityId shouldBe pingerAbilityId
+    }
+
+    test("a printed mana ability carries proven identity through off-stack resolution") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + printedManaSource)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val source = driver.putCreatureOnBattlefield(player, "Identity Mana Source")
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = source, abilityId = printedManaAbilityId)
+        ).error shouldBe null
+
+        val continuation = driver.state.peekContinuation()
+            .shouldBeInstanceOf<ChooseManaColorContinuation>()
+        continuation.baseContext.abilityIdentity shouldBe
+            AbilityIdentity("Identity Mana Source", printedManaAbilityId)
+        continuation.baseContext.activatedAbilityId shouldBe printedManaAbilityId
+    }
+
+    test("a runtime-granted mana ability carries routing id without fabricated identity") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + identityBear)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val receiver = driver.putCreatureOnBattlefield(player, "Identity Bear")
+        val grantedId = AbilityId("runtime_granted_identity_mana")
+        val grantedAbility = ActivatedAbility(
+            id = grantedId,
+            cost = AbilityCost.Free,
+            effect = Effects.AddAnyColorMana(1),
+            isManaAbility = true,
+            timing = TimingRule.ManaAbility,
+        )
+        driver.replaceState(
+            driver.state.copy(
+                grantedActivatedAbilities = driver.state.grantedActivatedAbilities +
+                    GrantedActivatedAbility(receiver, grantedAbility, Duration.Permanent),
+            )
+        )
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = receiver, abilityId = grantedId)
+        ).error shouldBe null
+
+        val continuation = driver.state.peekContinuation()
+            .shouldBeInstanceOf<ChooseManaColorContinuation>()
+        continuation.baseContext.abilityIdentity shouldBe null
+        continuation.baseContext.activatedAbilityId shouldBe grantedId
     }
 
     test("triggered abilities from two copies of the same card share one AbilityIdentity") {


### PR DESCRIPTION
An activated ability has two identities that the engine currently conflates: the card definition that semantically owns the ability, and the concrete `AbilityId` needed to execute it.

Likeness Looter makes the distinction visible. Its copy effect says to retain “this ability.” After the first activation turns it into Grizzly Bears, that ability survives as a runtime grant. A second activation still needs Likeness Looter's concrete ability ID so the effect can retain itself again, but the permanent's current card definition is now Grizzly Bears. Pairing those values produces an identity that never existed:

```text
(Grizzly Bears, likeness-looter-copy-ability)
```

Arlinn Kord's emblem exposes the companion failure. Legal-action enumeration offers the emblem's tap ability to creatures you control, but the activation handler previously searched a different set of ability sources. The UI could therefore advertise a legal action that the engine rejected when submitted.

This change records provenance while the engine still knows how an ability was found.

The activation lookup now has explicit results for:

- abilities declared by the current card definition;
- generated Class level-up abilities;
- runtime grants;
- static grants, including their granting permanent;
- emblem grants;
- intrinsic basic-land mana abilities.

Only the first two cases establish definition ownership and receive an `AbilityIdentity`. Every case retains its concrete `AbilityId`, so an identityless grant can still execute, be copied on the stack, perform ability-local bookkeeping, and route “this ability” during resolution.

Static and emblem grant discovery now comes from the same `CastPermissionUtils` resolvers used by legal-action enumeration. This removes the handler's separate static-grant traversal and makes one answer authoritative for both offered and submitted actions.

The resulting data flow is:

```text
activation lookup
  ├─ proven definition ownership → AbilityIdentity
  └─ concrete executable ability → AbilityId

stack / off-stack mana resolution
  └─ EffectContext carries both meanings independently
```

For the motivating cases:

- Likeness Looter can activate again after becoming another card, while remaining correctly identityless as a runtime grant.
- Arlinn's emblem ability is both advertised and executable; the creature taps and deals damage equal to its power without claiming that the ability belongs to the creature's printed definition.
- printed and generated Class abilities retain stable definition identity;
- runtime, static, emblem, and intrinsic abilities retain routing without fabricated ownership;
- copied activated stack objects preserve both fields.

The existing triggered-ability helper made the same ownership inference from a source's current `CardComponent`. This PR renames that helper to `triggerIdentityFromCurrentCardDefinition` and documents its result as transitional. Trigger behavior is unchanged; carrying typed provenance from trigger detection is a separate follow-up because trigger production has its own definition, grant, and synthesized branches.

## Verification

All verification ran at `d3ac9f6b8a`, against upstream `cc3080466a`:

- `just test-class AbilityIdentityTest` — 11 passed
- `just test-class ArlinnKordScenarioTest` — 1 passed
- `just test-class LikenessLooterScenarioTest` — 4 passed
- `just test-class ManaAbilityColorChoicePipelineTest` — 4 passed
- `just test-class FarrelitePriestScenarioTest` — 2 passed
- `just test-rules` — complete rules-engine and card-scenario suite passed
- `git diff --check`

## Stack order

This PR is independently reviewable on upstream `cc3080466a`.

A following stacked contribution will preserve the complete `EffectContext` through modal and `ChooseAction` pauses. It depends on the separate provenance fields established here, but it does not change which ability sources are entitled to definition-scoped identity.
