### PR TITLE
Preserve ability provenance and face-down event visibility

### DIFF
--- a/backlog/stack-collapse-and-batch-decisions.md
+++ b/backlog/stack-collapse-and-batch-decisions.md
@@ -298,6 +298,10 @@ per-player-maskable.
 
 ## 4. Open questions
 
+- **Triggered-ability provenance:** `TriggerAbilityResolver` can return definition-owned, granted, and synthesized triggers,
+  but `TriggerProcessor` currently derives an identity from the source's current `CardComponent` for all of them. Carry typed
+  provenance from trigger detection/resolution before treating that pair as authoritative. A null `granterId` is not proof of
+  printed ownership: synthesized and non-attached grant paths can also have no granter.
 - **Grouping scope for A:** contiguous-only (safe, proposed) vs all-identical-anywhere (prettier,
   risks implying a false order). Recommend contiguous-only first.
 - **Batch peel-off semantics (B):** is "Yes to this one, ask me about the rest" worth the extra

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -13057,13 +13057,15 @@ Card authors rarely reference these directly; they are created/updated by the ma
 
 `AbilityIdentity(cardDefinitionId, abilityId)` (`mtg-sdk` `scripting/AbilityIdentity.kt`) is the stable, **definition-scoped**
 identity of a *kind* of ability — independent of the stack object or source entity instance. Two permanents printed from the
-same card (and every future instance) share one identity for a given ability, because both halves are definition-scoped:
-`cardDefinitionId` is the source's `CardComponent.cardDefinitionId`, and `abilityId` is the ability's `AbilityId` (generated
-once when the card definition is built). Cards never author it: the engine threads it onto `TriggeredAbilityOnStackComponent`
-/ `ActivatedAbilityOnStackComponent` (via `GameState.abilityIdentityOf(sourceId, abilityId)`) and onto `DecisionContext`, so
-batch decisions can group structurally identical triggers and persistent yields can remember a per-ability answer across all
-copies. Null for synthesized sources with no card definition (e.g. spell copies). See
-`backlog/stack-collapse-and-batch-decisions.md` §C.2.
+same card (and every future instance) share one identity for a given ability, because both halves are definition-scoped.
+Cards never author it. Activated-ability lookup records whether the concrete ability came from the current card definition:
+printed abilities and generated Class level-up abilities receive the corresponding identity, while runtime-, static-, and
+emblem-granted abilities and intrinsic subtype abilities retain their concrete `AbilityId` without claiming definition
+ownership. The engine threads proven
+identities onto `ActivatedAbilityOnStackComponent` and `DecisionContext`, so persistent yields can remember a per-ability
+answer across all copies. The triggered-ability path still derives a provisional key from the current source card definition;
+typed ownership provenance for granted and synthesized triggers remains an explicit follow-up in
+`backlog/stack-collapse-and-batch-decisions.md` §4. See that backlog's §C.2 for the original identity contract.
 
 ### Batched may-question (engine-internal, not authored)
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -13099,8 +13099,9 @@ identity of a *kind* of ability — independent of the stack object or source en
 same card (and every future instance) share one identity for a given ability, because both halves are definition-scoped.
 Cards never author it. Activated-ability lookup records whether the concrete ability came from the current card definition:
 printed abilities and generated Class level-up abilities receive the corresponding identity, while runtime-, static-, and
-emblem-granted abilities and intrinsic subtype abilities retain their concrete `AbilityId` without claiming definition
-ownership. The engine threads proven
+emblem-granted abilities and intrinsic subtype abilities retain their concrete `ActivatedAbility` without claiming definition
+ownership. The activation snapshot travels through stack copies and resolution; its `activatedAbilityId` is derived from the
+snapshot, so retaining “this ability” never depends on a grant still existing when the effect resolves. The engine threads proven
 identities onto `ActivatedAbilityOnStackComponent` and `DecisionContext`, so persistent yields can remember a per-ability
 answer across all copies. The triggered-ability path still derives a provisional key from the current source card definition;
 typed ownership provenance for granted and synthesized triggers remains an explicit follow-up in

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ArlinnKordScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ArlinnKordScenarioTest.kt
@@ -3,13 +3,19 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.state.components.battlefield.AbilityActivatedThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.EntityId
 import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
 class ArlinnKordScenarioTest : ScenarioTestBase() {
 
@@ -48,6 +54,28 @@ class ArlinnKordScenarioTest : ScenarioTestBase() {
             }
             withClue("Arlinn's emblem should make the Bear's damage ability activatable") {
                 granted shouldNotBe null
+            }
+
+            val action = granted.shouldNotBeNull().action.shouldBeInstanceOf<ActivateAbility>()
+            val activation = game.execute(
+                action.copy(targets = listOf(ChosenTarget.Player(game.player2Id)))
+            )
+            withClue("an ability emitted as legal must pass activation validation") {
+                activation.error shouldBe null
+            }
+
+            val onStack = game.state.getEntity(game.state.stack.last())
+                ?.get<ActivatedAbilityOnStackComponent>()
+                .shouldNotBeNull()
+            withClue("the emblem supplies routing, not the Bear's definition identity") {
+                onStack.abilityIdentity shouldBe null
+                onStack.activatedAbilityId shouldBe action.abilityId
+            }
+            game.state.getEntity(bear)?.has<TappedComponent>() shouldBe true
+
+            game.resolveStack()
+            withClue("the Bear deals damage equal to its power") {
+                game.getLifeTotal(2) shouldBe 18
             }
         }
     }

--- a/mtg-sets/2023/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LikenessLooterScenarioTest.kt
+++ b/mtg-sets/2023/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LikenessLooterScenarioTest.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.core.SelectManaSourcesDecision
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.mtg.sets.definitions.woe.cards.LikenessLooter
@@ -110,6 +111,15 @@ class LikenessLooterScenarioTest : ScenarioTestBase() {
                 val again = game.copyFromGraveyard(looter, x = 4, cardName = "Hill Giant")
                 withClue("second activation should succeed: ${again.error}") { again.error shouldBe null }
                 if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+
+                // This activation came from the runtime grant retained by the first copy. Its
+                // concrete id still routes "this ability", but pairing it with Grizzly Bears'
+                // definition would fabricate semantic identity.
+                val secondStackAbility = game.state.getEntity(game.state.stack.last())
+                    ?.get<ActivatedAbilityOnStackComponent>()
+                secondStackAbility?.abilityIdentity shouldBe null
+                secondStackAbility?.activatedAbilityId shouldBe copyAbilityId
+
                 game.resolveStack()
 
                 val card = game.state.getEntity(looter)!!.get<CardComponent>()!!

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/EventCardPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/EventCardPresentation.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.engine.core
+
+import com.wingedsheep.sdk.model.EntityId
+import kotlinx.serialization.Serializable
+
+/**
+ * The semantic and public identities of one card at event time, plus the viewers entitled to the
+ * semantic identity.
+ *
+ * This is trusted engine data: [semanticName] may be private and [identityViewers] records private
+ * audience facts. Only the value returned by [nameFor] is safe to expose to the requested
+ * recipient. Client projection must never infer a past audience from a later state.
+ */
+@Serializable
+data class EventCardPresentation(
+    val semanticName: String,
+    val publicName: String,
+    val identityViewers: Set<EntityId> = emptySet(),
+) {
+    /** The name this recipient was entitled to see when the event was emitted. */
+    fun nameFor(viewingPlayerId: EntityId, isSpectator: Boolean = false): String =
+        if (!isSpectator && viewingPlayerId in identityViewers) semanticName else publicName
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -626,12 +626,13 @@ data class SpellCastEvent(
     val targetNames: List<String> = emptyList(),
     val xValue: Int? = null,
     /**
-     * Trusted semantic identity and viewer entitlement snapshot captured from event-time
-     * [com.wingedsheep.engine.view.Visibility]. Rules and knowledge consumers use
-     * [semanticCardName]; client projection selects one safe name through this snapshot.
+     * Trusted underlying card identity and viewer entitlement snapshot captured from event-time
+     * [com.wingedsheep.engine.view.Visibility]. Knowledge bookkeeping uses [underlyingCardName];
+     * client projection selects one safe display name through this snapshot.
      *
      * `null` represents serialized events produced before this field existed. Their [cardName]
-     * remains a safe presentation fallback and the best semantic name that historical event kept.
+     * remains a safe presentation fallback and the only identity information that historical
+     * event retained.
      */
     val cardPresentation: EventCardPresentation? = null,
     /**
@@ -702,8 +703,11 @@ data class SpellCastEvent(
      */
     val sacrificedAsCostNames: List<String> = emptyList()
 ) : GameEvent {
-    /** Exact cast identity when current event-time capture retained it; legacy events kept only [cardName]. */
-    val semanticCardName: String get() = cardPresentation?.semanticName ?: cardName
+    /**
+     * Underlying card-definition identity when current event-time capture retained it; legacy
+     * events kept only [cardName]. This is not the name characteristic of a face-down spell.
+     */
+    val underlyingCardName: String get() = cardPresentation?.semanticName ?: cardName
 }
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -13,7 +13,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * Sealed hierarchy of all game events.
- * Events are emitted by the engine to describe what happened.
+ *
+ * These are trusted engine events, not player-safe transport objects. Events may retain private
+ * rules facts needed by trigger processing and later audience-aware projection. A player-facing
+ * integration must project them through [com.wingedsheep.engine.view.ClientEventTransformer] (or
+ * its own perspective-safe equivalent) rather than serialize them directly.
  */
 @Serializable
 sealed interface GameEvent
@@ -612,10 +616,24 @@ data class CreatureTypeChangedEvent(
 @SerialName("SpellCastEvent")
 data class SpellCastEvent(
     val spellEntityId: EntityId,
+    /**
+     * The name safe to show every audience at the moment of the cast. This remains the historical
+     * serialized contract: an ordinary face-up cast stores its real name, while a face-down cast
+     * stores [com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME].
+     */
     val cardName: String,
     val casterId: EntityId,
     val targetNames: List<String> = emptyList(),
     val xValue: Int? = null,
+    /**
+     * Trusted semantic identity and viewer entitlement snapshot captured from event-time
+     * [com.wingedsheep.engine.view.Visibility]. Rules and knowledge consumers use
+     * [semanticCardName]; client projection selects one safe name through this snapshot.
+     *
+     * `null` represents serialized events produced before this field existed. Their [cardName]
+     * remains a safe presentation fallback and the best semantic name that historical event kept.
+     */
+    val cardPresentation: EventCardPresentation? = null,
     /**
      * Which optional-additional-cost mechanic this cast declared, or null when none — the fact
      * "whenever you cast a kicked spell" filters on (`SpellCastPredicate.WasKicked` matches
@@ -683,7 +701,10 @@ data class SpellCastEvent(
      * [com.wingedsheep.engine.view.CastProvenance.logPhrase].
      */
     val sacrificedAsCostNames: List<String> = emptyList()
-) : GameEvent
+) : GameEvent {
+    /** Exact cast identity when current event-time capture retained it; legacy events kept only [cardName]. */
+    val semanticCardName: String get() = cardPresentation?.semanticName ?: cardName
+}
 
 /**
  * An ability was activated.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TapHelpers.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TapHelpers.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.core
 
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.engine.state.nameVisibleToAll
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.HasBecomeTappedComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
@@ -105,7 +106,7 @@ fun tap(
     // CR 701.26a: only untapped permanents can be tapped, so tapping an already-tapped
     // permanent is not a transition — no event.
     if (container.has<TappedComponent>()) return state to null
-    val cardName = container.get<CardComponent>()?.name ?: "Permanent"
+    val cardName = nameVisibleToAll(state, entityId, container.get<CardComponent>()?.name ?: "Permanent")
     val tapper = tappedById
         ?: state.projectedState.getController(entityId)
         ?: container.get<ControllerComponent>()?.playerId
@@ -203,7 +204,7 @@ fun untapOrConsumeStun(
         return newState to emptyList()
     }
 
-    val cardName = container.get<CardComponent>()?.name ?: "Permanent"
+    val cardName = nameVisibleToAll(state, entityId, container.get<CardComponent>()?.name ?: "Permanent")
 
     // Granted "remove a +1/+1 counter to untap" replacement (untap-step path only).
     if (projected != null && projected.hasKeyword(entityId, AbilityFlag.REMOVE_COUNTER_TO_UNTAP)) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -11,7 +11,7 @@ import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityEffec
 import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityFiredEverComponent
 import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityFiredThisTurnComponent
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
-import com.wingedsheep.engine.state.components.stack.abilityIdentityOf
+import com.wingedsheep.engine.state.components.stack.triggerIdentityFromCurrentCardDefinition
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
@@ -179,7 +179,8 @@ class TriggerProcessor(
         // lowering in `withEffectBudgetGate` moves consent to resolution time — but this guard reads
         // the *un-lowered* ability, so it is still load-bearing.
         if (ability.effectOncePerTurn) return null
-        val identity = state.abilityIdentityOf(trigger.sourceId, ability.id) ?: return null
+        val identity = state.triggerIdentityFromCurrentCardDefinition(trigger.sourceId, ability.id)
+            ?: return null
         // Mirror processMayThenTargetTrigger's fizzle guard: a trigger with no legal targets (for a
         // mandatory-target requirement) fizzles without asking, so it must not join a batch.
         val legalTargets = targetFinder.findLegalTargets(
@@ -259,7 +260,7 @@ class TriggerProcessor(
                 sourceId = first.sourceId,
                 sourceName = first.sourceName,
                 phase = DecisionPhase.RESOLUTION,
-                abilityIdentity = state.abilityIdentityOf(first.sourceId, ability.id)
+                abilityIdentity = state.triggerIdentityFromCurrentCardDefinition(first.sourceId, ability.id)
             ),
             count = run.size
         )
@@ -477,7 +478,8 @@ class TriggerProcessor(
         // The gated "may" effect's own text is the prompt (GatedEffect.description renders
         // "You may …" for a Gate.MayDecide).
         val sourceName = trigger.sourceName
-        val abilityIdentity = state.abilityIdentityOf(trigger.sourceId, ability.id)
+        val abilityIdentity =
+            state.triggerIdentityFromCurrentCardDefinition(trigger.sourceId, ability.id)
 
         // Who is asked. Normally the ability's controller, but a card can name someone else —
         // Farrel's Mantle's "its controller may", where "it" is the enchanted creature and the Aura
@@ -613,7 +615,7 @@ class TriggerProcessor(
             yesText = "Pay $manaCost",
             noText = "Don't pay",
             phase = DecisionPhase.RESOLUTION,
-            abilityIdentity = state.abilityIdentityOf(trigger.sourceId, ability.id)
+            abilityIdentity = state.triggerIdentityFromCurrentCardDefinition(trigger.sourceId, ability.id)
         )
 
         if (!decisionResult.isPaused || decisionResult.pendingDecision == null) {
@@ -825,7 +827,7 @@ class TriggerProcessor(
             controllerId = trigger.controllerId,
             effect = ability.effect,
             description = ability.description,
-            abilityIdentity = state.abilityIdentityOf(trigger.sourceId, ability.id),
+            abilityIdentity = state.triggerIdentityFromCurrentCardDefinition(trigger.sourceId, ability.id),
             triggerDamageAmount = trigger.triggerContext.damageAmount,
             triggeringEntityId = trigger.triggerContext.triggeringEntityId,
             triggeringPlayerId = trigger.triggerContext.triggeringPlayerId,
@@ -891,7 +893,7 @@ class TriggerProcessor(
             controllerId = trigger.controllerId,
             effect = effectOverride ?: ability.effect,
             description = ability.description,
-            abilityIdentity = state.abilityIdentityOf(trigger.sourceId, ability.id),
+            abilityIdentity = state.triggerIdentityFromCurrentCardDefinition(trigger.sourceId, ability.id),
             granterId = trigger.granterId,
             // CR 701.28f — freeze the source's face-change clock as the trigger goes on the stack,
             // so an instruction inside it to transform that same permanent is ignored if the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -1642,9 +1642,10 @@ class ConditionEvaluator(
     /**
      * Farrelite Priest's "if this ability has been activated four or more times this turn". The
      * tally lives on the source permanent, keyed by ability id, and the handler increments it
-     * before the effect runs — so the fourth activation reads four. Reads false when the ability
-     * did not opt into bookkeeping (`activatedAbilityId` null), which is the correct answer for
-     * every ability that never asks.
+     * before the effect runs — so the fourth activation reads four. A modern stack object carries
+     * its concrete id whether or not it tracks activations; an untracked ability still reads false
+     * because its source has no tally for that id. Contexts with no concrete activated ability id
+     * also read false.
      */
     private fun evaluateThisAbilityActivatedThisTurnAtLeast(
         state: GameState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -49,16 +49,17 @@ data class EffectContext(
      * Definition-scoped identity of the triggered/activated ability currently resolving, copied
      * from its stack component (see [com.wingedsheep.sdk.scripting.AbilityIdentity]). Lets a
      * resolution-time may-question consult the controller's persistent auto-answer yields without
-     * re-deriving the key. Null for spell resolution and synthesized sources with no card
-     * definition (backlog §C).
+     * re-deriving the key. Null for spell resolution, sources with no card definition, and
+     * activated abilities whose lookup did not prove definition ownership (backlog §C).
      */
     val abilityIdentity: com.wingedsheep.sdk.scripting.AbilityIdentity? = null,
     /**
-     * The id of the *activated* ability currently resolving, as recorded in the source's
-     * `AbilityActivatedThisTurnComponent`. Lets an effect read back how many times its own ability
-     * has been activated this turn (`ThisAbilityActivatedThisTurnAtLeast` — Farrelite Priest).
-     * Null for spells, triggered abilities and any activation whose ability opted out of
-     * bookkeeping.
+     * Concrete id of the *activated* ability currently resolving. Modern activated stack objects
+     * always carry it even when [abilityIdentity] is null, which lets a runtime-granted ability
+     * route "this ability" without inventing a semantic card-definition pair (Likeness Looter).
+     * Off-stack mana abilities carry it through their direct resolution context as well. Null for
+     * spells, triggered abilities, and specialized synthesized activations with no concrete
+     * ability.
      */
     val activatedAbilityId: com.wingedsheep.sdk.scripting.AbilityId? = null,
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -54,14 +54,11 @@ data class EffectContext(
      */
     val abilityIdentity: com.wingedsheep.sdk.scripting.AbilityIdentity? = null,
     /**
-     * Concrete id of the *activated* ability currently resolving. Modern activated stack objects
-     * always carry it even when [abilityIdentity] is null, which lets a runtime-granted ability
-     * route "this ability" without inventing a semantic card-definition pair (Likeness Looter).
-     * Off-stack mana abilities carry it through their direct resolution context as well. Null for
-     * spells, triggered abilities, and specialized synthesized activations with no concrete
-     * ability.
+     * The concrete ability captured at activation. Resolution must not rediscover it from a
+     * source or grant that can change before resolving (including "retain this ability" copies).
+     * Null for spells, triggers, and synthesized activations without an ActivatedAbility.
      */
-    val activatedAbilityId: com.wingedsheep.sdk.scripting.AbilityId? = null,
+    val activatedAbility: com.wingedsheep.sdk.scripting.ActivatedAbility? = null,
     /**
      * The player currently under consideration as a target, bound while evaluating a
      * `TargetPlayer.restriction` / `TargetOpponent.restriction` (CR 115). Resolves
@@ -411,6 +408,9 @@ data class EffectContext(
      */
     val resolutionDepth: Int = 0
 ) {
+    val activatedAbilityId: com.wingedsheep.sdk.scripting.AbilityId?
+        get() = activatedAbility?.id
+
     /**
      * Resolve a symbolic effect target to a concrete entity id using just the context.
      *

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -59,6 +59,7 @@ import com.wingedsheep.sdk.scripting.costs.PermanentCostAction
 import com.wingedsheep.sdk.scripting.costs.VariableCostMeasure
 import com.wingedsheep.sdk.scripting.costs.manaCostOrNull
 import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.AbilityIdentity
 import com.wingedsheep.sdk.scripting.ActivatedAbility
 import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.ExtraLoyaltyActivation
@@ -86,6 +87,47 @@ import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.sdk.core.Zone
 import kotlin.reflect.KClass
+
+/**
+ * Result of resolving an activated-ability id on an object.
+ *
+ * The concrete [ability] is not enough to infer semantic identity: runtime, static, and intrinsic
+ * abilities all have ids, but those ids do not belong to the receiving object's card definition.
+ * Keeping the lookup provenance in the result makes the definition-owned cases explicit and keeps
+ * a static granter attached only to the branch that actually supplied the ability.
+ */
+private sealed interface ActivatedAbilityLookup {
+    val ability: ActivatedAbility
+
+    data class DirectDefinition(
+        override val ability: ActivatedAbility,
+        val identity: AbilityIdentity,
+    ) : ActivatedAbilityLookup
+
+    data class DefinitionDerivedClass(
+        override val ability: ActivatedAbility,
+        val identity: AbilityIdentity,
+    ) : ActivatedAbilityLookup
+
+    data class RuntimeGranted(override val ability: ActivatedAbility) : ActivatedAbilityLookup
+
+    data class StaticGranted(
+        override val ability: ActivatedAbility,
+        val granterId: EntityId,
+    ) : ActivatedAbilityLookup
+
+    data class Intrinsic(override val ability: ActivatedAbility) : ActivatedAbilityLookup
+
+    val staticGranterId: EntityId?
+        get() = (this as? StaticGranted)?.granterId
+
+    val definitionIdentity: AbilityIdentity?
+        get() = when (this) {
+            is DirectDefinition -> identity
+            is DefinitionDerivedClass -> identity
+            is RuntimeGranted, is StaticGranted, is Intrinsic -> null
+        }
+}
 
 /**
  * Handler for the ActivateAbility action.
@@ -182,18 +224,14 @@ class ActivateAbilityHandler(
         // bail out when the lookup fails — fall through to those sources instead.
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
 
-        // Look up ability from card definition (including class-level abilities), granted abilities, or static grants
+        // Keep lookup provenance: only definition-owned results can later form AbilityIdentity.
         val classLevel = container.get<ClassLevelComponent>()?.currentLevel
-        val staticGrants = getStaticGrantedAbilitiesWithGranter(action.sourceId, state)
-        val ability = cardDef?.script?.effectiveActivatedAbilities(classLevel)?.find { it.id == action.abilityId }
-            ?: cardDef?.let { findClassLevelUpAbility(it, container, action.abilityId) }
-            ?: state.grantedActivatedAbilities
-                .filter { it.entityId == action.sourceId }
-                .map { it.ability }
-                .find { it.id == action.abilityId }
-            ?: staticGrants.firstOrNull { it.first.id == action.abilityId }?.first
-            ?: resolveIntrinsicManaAbility(state, action.sourceId, action.abilityId)
+        val abilityLookup = lookupActivatedAbility(
+            state, action.sourceId, action.abilityId, container,
+            cardComponent.cardDefinitionId, cardDef
+        )
             ?: return "Ability not found on this card"
+        val ability = abilityLookup.ability
 
         // The mana-payment window (CR 605.3a) opens the door for mana abilities only — everything
         // else still needs priority.
@@ -472,7 +510,7 @@ class ActivateAbilityHandler(
 
         // The granter of a statically-granted ability, so AbilityCost.TapGrantingPermanent can be
         // checked against the *Equipment's* tap state rather than the host creature's.
-        val validationGranterId = staticGrants.firstOrNull { it.first.id == action.abilityId }?.second
+        val validationGranterId = abilityLookup.staticGranterId
 
         if (action.paymentStrategy !is PaymentStrategy.Explicit && !canPayAbilityCostWithSources(state, costAfterConvokeReduction, action.sourceId, action.playerId, abilityPaymentContext, validationGranterId)) {
             return when (effectiveCost) {
@@ -654,20 +692,17 @@ class ActivateAbilityHandler(
         // fall through with a null cardDef and let the granted-ability lookup succeed.
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
 
-        // Look up ability from card definition (including class-level abilities), granted abilities, or static grants
-        val classLevel = container.get<ClassLevelComponent>()?.currentLevel
-        val staticGrants = getStaticGrantedAbilitiesWithGranter(action.sourceId, state)
-        val staticGrantMatch = staticGrants.firstOrNull { it.first.id == action.abilityId }
-        val ability = cardDef?.script?.effectiveActivatedAbilities(classLevel)?.find { it.id == action.abilityId }
-            ?: cardDef?.let { findClassLevelUpAbility(it, container, action.abilityId) }
-            ?: state.grantedActivatedAbilities
-                .filter { it.entityId == action.sourceId }
-                .map { it.ability }
-                .find { it.id == action.abilityId }
-            ?: staticGrantMatch?.first
-            ?: resolveIntrinsicManaAbility(state, action.sourceId, action.abilityId)
+        // Retain which lookup branch supplied the concrete ability. A CardComponent on the
+        // receiving permanent proves only that the object is a card; it does not make a runtime,
+        // static, or intrinsic ability part of that card's definition.
+        val abilityLookup = lookupActivatedAbility(
+            state, action.sourceId, action.abilityId, container,
+            cardComponent.cardDefinitionId, cardDef
+        )
             ?: return ExecutionResult.error(state, "Ability not found")
-        val staticGranterId = staticGrantMatch?.second
+        val ability = abilityLookup.ability
+        val staticGranterId = abilityLookup.staticGranterId
+        val abilityIdentity = abilityLookup.definitionIdentity
 
         // "X can't be 0" abilities (Gogo, Master of Mimicry): reject an engine-direct activation that
         // pre-fills an X below the ability's minimum. The legal-actions submission path enforces the
@@ -1722,9 +1757,11 @@ class ActivateAbilityHandler(
                 // amount resolves to 0 and the ability produces nothing.
                 sacrificedPermanents = sacrificedSnapshots,
                 manaColorChoice = action.manaColorChoice,
-                // The tally above was already incremented for this activation, so a burnout clause
-                // reading "four or more times this turn" sees the fourth activation as the fourth.
-                activatedAbilityId = if (ability.trackActivations) ability.id else null,
+                // Mana abilities resolve without a stack component, so their activation-time
+                // provenance must enter the effect context here. The concrete id remains useful
+                // even when this lookup branch could not prove a definition-scoped identity.
+                abilityIdentity = abilityIdentity,
+                activatedAbilityId = ability.id,
             )
 
             val effectResult = effectExecutorRegistry.execute(currentState, finalEffect, context).toExecutionResult()
@@ -1944,9 +1981,8 @@ class ActivateAbilityHandler(
             lastKnownSourceAttachments = lastKnownSourceAttachments,
             revealedNotedCreatureType = revealedNotedCreatureType,
             descriptionOverride = ability.descriptionOverride,
-            abilityIdentity = com.wingedsheep.sdk.scripting.AbilityIdentity(
-                cardComponent.cardDefinitionId, ability.id
-            ),
+            abilityIdentity = abilityIdentity,
+            activatedAbilityId = ability.id,
             granterId = staticGranterId,
             // CR 701.28f — freeze the source's face-change clock as the ability goes on the stack;
             // an instruction inside it to transform that same permanent is ignored if the permanent
@@ -2053,9 +2089,8 @@ class ActivateAbilityHandler(
                     tappedPermanents = repeatTapSlice,
                     tappedEntitySnapshots = repeatTapSnapshots,
                     descriptionOverride = ability.descriptionOverride,
-                    abilityIdentity = com.wingedsheep.sdk.scripting.AbilityIdentity(
-                        cardComponent.cardDefinitionId, ability.id
-                    ),
+                    abilityIdentity = abilityIdentity,
+                    activatedAbilityId = ability.id,
                     granterId = staticGranterId
                 )
                 val repeatStackResult = stackResolver.putActivatedAbility(
@@ -2793,6 +2828,56 @@ class ActivateAbilityHandler(
         val subtypes = state.projectedState.getSubtypes(sourceId)
         if (expectedSubtype !in subtypes) return null
         return ability
+    }
+
+    /**
+     * Resolve [abilityId] without discarding how the concrete ability was found.
+     *
+     * The order matches legal-action enumeration and the historical handler lookup. In
+     * particular, an id directly declared by the current definition wins over an equal id from a
+     * grant. Only the first two branches prove definition ownership; every other branch retains a
+     * concrete id for execution while remaining semantically identityless.
+     */
+    private fun lookupActivatedAbility(
+        state: GameState,
+        sourceId: EntityId,
+        abilityId: AbilityId,
+        container: com.wingedsheep.engine.state.ComponentContainer,
+        cardDefinitionId: String,
+        cardDef: com.wingedsheep.sdk.model.CardDefinition?,
+    ): ActivatedAbilityLookup? {
+        val classLevel = container.get<ClassLevelComponent>()?.currentLevel
+
+        cardDef?.script?.effectiveActivatedAbilities(classLevel)
+            ?.firstOrNull { it.id == abilityId }
+            ?.let {
+                return ActivatedAbilityLookup.DirectDefinition(
+                    it,
+                    AbilityIdentity(cardDefinitionId, it.id),
+                )
+            }
+
+        cardDef?.let { findClassLevelUpAbility(it, container, abilityId) }
+            ?.let {
+                return ActivatedAbilityLookup.DefinitionDerivedClass(
+                    it,
+                    AbilityIdentity(cardDefinitionId, it.id),
+                )
+            }
+
+        state.grantedActivatedAbilities
+            .firstOrNull { it.entityId == sourceId && it.ability.id == abilityId }
+            ?.ability
+            ?.let { return ActivatedAbilityLookup.RuntimeGranted(it) }
+
+        getStaticGrantedAbilitiesWithGranter(sourceId, state)
+            .firstOrNull { it.first.id == abilityId }
+            ?.let { (ability, granterId) ->
+                return ActivatedAbilityLookup.StaticGranted(ability, granterId)
+            }
+
+        return resolveIntrinsicManaAbility(state, sourceId, abilityId)
+            ?.let { ActivatedAbilityLookup.Intrinsic(it) }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -63,8 +63,6 @@ import com.wingedsheep.sdk.scripting.AbilityIdentity
 import com.wingedsheep.sdk.scripting.ActivatedAbility
 import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.ExtraLoyaltyActivation
-import com.wingedsheep.sdk.scripting.GrantActivatedAbility
-import com.wingedsheep.sdk.scripting.filters.unified.Scope
 import com.wingedsheep.sdk.scripting.targets.TargetChooser
 import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.scripting.effects.LevelUpClassEffect
@@ -91,10 +89,11 @@ import kotlin.reflect.KClass
 /**
  * Result of resolving an activated-ability id on an object.
  *
- * The concrete [ability] is not enough to infer semantic identity: runtime, static, and intrinsic
- * abilities all have ids, but those ids do not belong to the receiving object's card definition.
- * Keeping the lookup provenance in the result makes the definition-owned cases explicit and keeps
- * a static granter attached only to the branch that actually supplied the ability.
+ * The concrete [ability] is not enough to infer semantic identity: runtime, static, emblem-granted,
+ * and intrinsic abilities all have ids, but those ids do not belong to the receiving object's card
+ * definition. Keeping the lookup provenance in the result makes the definition-owned cases
+ * explicit and keeps a static granter attached only to the branch that actually supplied the
+ * ability.
  */
 private sealed interface ActivatedAbilityLookup {
     val ability: ActivatedAbility
@@ -116,6 +115,8 @@ private sealed interface ActivatedAbilityLookup {
         val granterId: EntityId,
     ) : ActivatedAbilityLookup
 
+    data class EmblemGranted(override val ability: ActivatedAbility) : ActivatedAbilityLookup
+
     data class Intrinsic(override val ability: ActivatedAbility) : ActivatedAbilityLookup
 
     val staticGranterId: EntityId?
@@ -125,7 +126,7 @@ private sealed interface ActivatedAbilityLookup {
         get() = when (this) {
             is DirectDefinition -> identity
             is DefinitionDerivedClass -> identity
-            is RuntimeGranted, is StaticGranted, is Intrinsic -> null
+            is RuntimeGranted, is StaticGranted, is EmblemGranted, is Intrinsic -> null
         }
 }
 
@@ -218,18 +219,15 @@ class ActivateAbilityHandler(
         val cardComponent = container.get<CardComponent>()
             ?: return "Source is not a card"
 
-        // Tokens (and other entities without a registered CardDefinition) only have abilities
+        // Tokens (and other entities without a registered CardDefinition) can still have abilities
         // via static grants (e.g., Brightcap Badger granting "{T}: Add {G}" to Saproling tokens),
-        // intrinsic mana abilities (basic-land subtypes), or temporarily granted abilities. Don't
-        // bail out when the lookup fails — fall through to those sources instead.
+        // emblems, intrinsic mana abilities (basic-land subtypes), or temporary grants. Don't bail
+        // out before the provenance-aware lookup has checked those sources.
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
+        val classLevel = container.get<ClassLevelComponent>()?.currentLevel
 
         // Keep lookup provenance: only definition-owned results can later form AbilityIdentity.
-        val classLevel = container.get<ClassLevelComponent>()?.currentLevel
-        val abilityLookup = lookupActivatedAbility(
-            state, action.sourceId, action.abilityId, container,
-            cardComponent.cardDefinitionId, cardDef
-        )
+        val abilityLookup = lookupActivatedAbility(state, action.sourceId, action.abilityId)
             ?: return "Ability not found on this card"
         val ability = abilityLookup.ability
 
@@ -688,17 +686,10 @@ class ActivateAbilityHandler(
         val cardComponent = container.get<CardComponent>()
             ?: return ExecutionResult.error(state, "Source is not a card")
 
-        // Tokens (no registered CardDefinition) reach this path when activating granted abilities;
-        // fall through with a null cardDef and let the granted-ability lookup succeed.
-        val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
-
         // Retain which lookup branch supplied the concrete ability. A CardComponent on the
         // receiving permanent proves only that the object is a card; it does not make a runtime,
-        // static, or intrinsic ability part of that card's definition.
-        val abilityLookup = lookupActivatedAbility(
-            state, action.sourceId, action.abilityId, container,
-            cardComponent.cardDefinitionId, cardDef
-        )
+        // static, emblem-granted, or intrinsic ability part of that card's definition.
+        val abilityLookup = lookupActivatedAbility(state, action.sourceId, action.abilityId)
             ?: return ExecutionResult.error(state, "Ability not found")
         val ability = abilityLookup.ability
         val staticGranterId = abilityLookup.staticGranterId
@@ -2836,16 +2827,18 @@ class ActivateAbilityHandler(
      * The order matches legal-action enumeration and the historical handler lookup. In
      * particular, an id directly declared by the current definition wins over an equal id from a
      * grant. Only the first two branches prove definition ownership; every other branch retains a
-     * concrete id for execution while remaining semantically identityless.
+     * concrete id for execution while remaining semantically identityless. Static and emblem
+     * grants come from the same shared resolvers used by legal-action enumeration, so the engine
+     * cannot advertise one grant set and validate another.
      */
     private fun lookupActivatedAbility(
         state: GameState,
         sourceId: EntityId,
         abilityId: AbilityId,
-        container: com.wingedsheep.engine.state.ComponentContainer,
-        cardDefinitionId: String,
-        cardDef: com.wingedsheep.sdk.model.CardDefinition?,
     ): ActivatedAbilityLookup? {
+        val container = state.getEntity(sourceId) ?: return null
+        val cardDefinitionId = container.get<CardComponent>()?.cardDefinitionId ?: return null
+        val cardDef = cardRegistry.getCard(cardDefinitionId)
         val classLevel = container.get<ClassLevelComponent>()?.currentLevel
 
         cardDef?.script?.effectiveActivatedAbilities(classLevel)
@@ -2870,11 +2863,15 @@ class ActivateAbilityHandler(
             ?.ability
             ?.let { return ActivatedAbilityLookup.RuntimeGranted(it) }
 
-        getStaticGrantedAbilitiesWithGranter(sourceId, state)
-            .firstOrNull { it.first.id == abilityId }
-            ?.let { (ability, granterId) ->
-                return ActivatedAbilityLookup.StaticGranted(ability, granterId)
+        castPermissionUtils.getStaticGrantedAbilitiesWithGranter(sourceId, state)
+            .firstOrNull { it.ability.id == abilityId }
+            ?.let {
+                return ActivatedAbilityLookup.StaticGranted(it.ability, it.granterId)
             }
+
+        castPermissionUtils.getEmblemGrantedActivatedAbilities(sourceId, state)
+            .firstOrNull { it.id == abilityId }
+            ?.let { return ActivatedAbilityLookup.EmblemGranted(it) }
 
         return resolveIntrinsicManaAbility(state, sourceId, abilityId)
             ?.let { ActivatedAbilityLookup.Intrinsic(it) }
@@ -2903,155 +2900,6 @@ class ActivateAbilityHandler(
             descriptionOverride = "Level up to level $targetLevel"
         )
     }
-
-    /**
-     * Get activated abilities granted to an entity by static abilities on battlefield permanents,
-     * paired with the EntityId of the permanent that granted each ability.
-     * E.g., Spectral Sliver grants a pump ability to all Sliver creatures via
-     * GrantActivatedAbility. The Dominion Bracelet grants its activated
-     * ability to the equipped creature via GrantActivatedAbility; the
-     * granter ID is needed to resolve AbilityCost.ExileGrantingPermanent.
-     */
-    private fun getStaticGrantedAbilitiesWithGranter(
-        entityId: EntityId,
-        state: GameState
-    ): List<Pair<ActivatedAbility, EntityId>> {
-        if (state.getEntity(entityId) == null) return emptyList()
-
-        val result = mutableListOf<Pair<ActivatedAbility, EntityId>>()
-
-        for (permanentId in state.getBattlefield()) {
-            val container = state.getEntity(permanentId) ?: continue
-            val card = container.get<CardComponent>() ?: continue
-            if (container.has<FaceDownComponent>()) continue
-
-            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            val classLevel = container.get<com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent>()?.currentLevel
-            for (rawAbility in cardDef.script.effectiveStaticAbilities(classLevel)) {
-                // A grant can be gated by a ConditionalStaticAbility (Nature's Embrace: the land host
-                // gains "{T}: Add two mana of any one color" only while it is a land). Unwrap the
-                // condition against the granter here so the actual-activation path agrees with the
-                // enumerator; skip when the gate is currently false.
-                val ability = when (rawAbility) {
-                    is com.wingedsheep.sdk.scripting.ConditionalStaticAbility -> {
-                        val granterController = state.projectedState.getController(permanentId)
-                            ?: container.get<ControllerComponent>()?.playerId
-                            ?: continue
-                        val ctx = EffectContext(sourceId = permanentId, controllerId = granterController)
-                        if (!conditionEvaluator.evaluate(state, rawAbility.condition, ctx)) continue
-                        rawAbility.ability
-                    }
-                    else -> rawAbility
-                }
-                // "[receivedBy] have all activated abilities of the [cardFilter] cards exiled with/to
-                // craft this / in your graveyard" (Territory Forge / Locus of Enlightenment /
-                // Thranduil = Self; Agatha's Soul Cauldron = creatures you control with a +1/+1
-                // counter). Mirror CastPermissionUtils.getStaticGrantedAbilitiesWithGranter: grant each
-                // donor ability (per `ability.donors`) to every matching permanent, recording the
-                // *receiver* as the granter so `{T}`/self-references bind to the permanent that gained
-                // the ability. When `oncePerTurnEach` is set (Locus), the util re-stamps each ability
-                // with a donor-derived AbilityId + once-per-turn cap.
-                if (ability is com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfCards) {
-                    val receives = when (val scope = ability.receivedBy.scope) {
-                        is Scope.Self -> permanentId == entityId
-                        is Scope.Specific -> scope.entityId == entityId
-                        is Scope.AttachedTo -> container.get<AttachedToComponent>()?.targetId == entityId
-                        is Scope.SoulbondPair ->
-                            com.wingedsheep.engine.mechanics.SoulbondPairing.isInPairOf(state, permanentId, entityId)
-                        is Scope.Battlefield -> {
-                            if (ability.receivedBy.excludeSelf && permanentId == entityId) false
-                            else {
-                                val granterController = state.projectedState.getController(permanentId)
-                                granterController != null && predicateEvaluator.matches(
-                                    state, state.projectedState, entityId, ability.receivedBy.baseFilter,
-                                    PredicateContext(controllerId = granterController, sourceId = permanentId)
-                                )
-                            }
-                        }
-                    }
-                    if (receives) {
-                        for (granted in com.wingedsheep.engine.legalactions.utils.donorCardsActivatedAbilities(
-                            state, permanentId, cardRegistry, predicateEvaluator,
-                            ability.donors, ability.cardFilter, ability.oncePerTurnEach
-                        )) {
-                            result.add(granted to entityId)
-                        }
-                    }
-                    continue
-                }
-                // "This permanent has all activated and triggered abilities of the last chosen card
-                // exiled with it" (Koh, the Face Stealer). Self-scoped: only the source receives the
-                // chosen card's *activated* abilities here (triggered ones flow through
-                // TriggerAbilityResolver), with the source recorded as granter so `{T}`/self-references
-                // bind to it.
-                if (ability is com.wingedsheep.sdk.scripting.HasAbilitiesOfChosenLinkedExiledCard) {
-                    if (ability.grantActivated && permanentId == entityId) {
-                        for (granted in com.wingedsheep.engine.legalactions.utils.chosenLinkedExiledActivatedAbilities(state, permanentId, cardRegistry)) {
-                            result.add(granted to entityId)
-                        }
-                    }
-                    continue
-                }
-                if (ability !is GrantActivatedAbility) continue
-                when (ability.filter.scope) {
-                    is Scope.Battlefield -> {
-                        if (ability.filter.excludeSelf && permanentId == entityId) continue
-                        val granterController = state.projectedState.getController(permanentId) ?: continue
-                        val matches = predicateEvaluator.matches(
-                            state,
-                            state.projectedState,
-                            entityId,
-                            ability.filter.baseFilter,
-                            PredicateContext(controllerId = granterController, sourceId = permanentId)
-                        )
-                        if (matches) {
-                            result.add(ability.ability to permanentId)
-                        }
-                    }
-                    is Scope.AttachedTo -> {
-                        val attachedTo = container.get<AttachedToComponent>()
-                        if (attachedTo != null && attachedTo.targetId == entityId) {
-                            result.add(ability.ability to permanentId)
-                        }
-                    }
-                    is Scope.Self -> {
-                        if (permanentId == entityId) result.add(ability.ability to permanentId)
-                    }
-                    // Soulbond payoff (CR 702.95b) — must mirror the enumerator's SoulbondPair
-                    // branch in CastPermissionUtils exactly, or the ability shows as a button on the
-                    // paired creature and then fails legality when clicked.
-                    is Scope.SoulbondPair -> {
-                        if (com.wingedsheep.engine.mechanics.SoulbondPairing.isInPairOf(state, permanentId, entityId)) {
-                            result.add(ability.ability to permanentId)
-                        }
-                    }
-                    is Scope.Specific -> {
-                        if ((ability.filter.scope as Scope.Specific).entityId == entityId) {
-                            result.add(ability.ability to permanentId)
-                        }
-                    }
-                }
-            }
-        }
-
-        // Granted GrantActivatedAbility statics (CR 611): a permanent that was itself *granted* an
-        // ability-granting static — e.g. Roar of the Fifth People chapter II. Resolved by the shared
-        // helper so this handler and the enumerators agree on the granted set.
-        castPermissionUtils.getGrantedStaticGrantActivatedAbilities(entityId, state)
-            .forEach { result.add(it.ability to it.granterId) }
-
-        // GainActivatedAbilitiesOfPermanents (Sharkey): copies of opponents' lands' abilities, etc.
-        // Resolved by the shared helper so the enumerator and this handler agree on the gained set.
-        castPermissionUtils.getGainedAbilitiesOfPermanents(entityId, state)
-            .forEach { result.add(it.ability to it.granterId) }
-
-        return result
-    }
-
-    private fun getStaticGrantedActivatedAbilities(
-        entityId: EntityId,
-        state: GameState
-    ): List<ActivatedAbility> = getStaticGrantedAbilitiesWithGranter(entityId, state).map { it.first }
 
     companion object {
         fun create(services: EngineServices): ActivateAbilityHandler {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -35,6 +35,7 @@ import com.wingedsheep.engine.mechanics.stack.StackResolver
 import com.wingedsheep.engine.mechanics.targeting.TargetValidator
 import com.wingedsheep.engine.legalactions.utils.CastPermissionUtils
 import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.nameVisibleToAll
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
@@ -686,6 +687,8 @@ class ActivateAbilityHandler(
         val cardComponent = container.get<CardComponent>()
             ?: return ExecutionResult.error(state, "Source is not a card")
 
+        val sourceName = nameVisibleToAll(state, action.sourceId, cardComponent.name)
+
         // Retain which lookup branch supplied the concrete ability. A CardComponent on the
         // receiving permanent proves only that the object is a card; it does not make a runtime,
         // static, emblem-granted, or intrinsic ability part of that card's definition.
@@ -701,7 +704,7 @@ class ActivateAbilityHandler(
         if (action.xValue != null && action.xValue < ability.minimumXValue) {
             return ExecutionResult.error(
                 state,
-                "X must be at least ${ability.minimumXValue} for ${cardComponent.name}"
+                "X must be at least ${ability.minimumXValue} for ${sourceName}"
             )
         }
 
@@ -771,7 +774,7 @@ class ActivateAbilityHandler(
             val opponentReqs = fullTargetReqs.filter { it.chooser == TargetChooser.Opponent }
             if (opponentReqs.isNotEmpty()) {
                 return pauseForOpponentChosenTargets(
-                    state, action, cardComponent.name, fullTargetReqs, opponentReqs
+                    state, action, sourceName, fullTargetReqs, opponentReqs
                 )
             }
         }
@@ -801,10 +804,10 @@ class ActivateAbilityHandler(
             val decision = com.wingedsheep.engine.core.ChooseNumberDecision(
                 id = decisionId,
                 playerId = action.playerId,
-                prompt = "Choose X for ${cardComponent.name} (0-$maxX)",
+                prompt = "Choose X for ${sourceName} (0-$maxX)",
                 context = com.wingedsheep.engine.core.DecisionContext(
                     sourceId = action.sourceId,
-                    sourceName = cardComponent.name,
+                    sourceName = sourceName,
                     phase = com.wingedsheep.engine.core.DecisionPhase.CASTING
                 ),
                 minValue = 0,
@@ -847,10 +850,10 @@ class ActivateAbilityHandler(
             val decision = com.wingedsheep.engine.core.ChooseNumberDecision(
                 id = decisionId,
                 playerId = action.playerId,
-                prompt = "Choose X for ${cardComponent.name} ($minX-$maxX)",
+                prompt = "Choose X for ${sourceName} ($minX-$maxX)",
                 context = com.wingedsheep.engine.core.DecisionContext(
                     sourceId = action.sourceId,
-                    sourceName = cardComponent.name,
+                    sourceName = sourceName,
                     phase = com.wingedsheep.engine.core.DecisionPhase.CASTING
                 ),
                 minValue = minX,
@@ -911,9 +914,9 @@ class ActivateAbilityHandler(
                 val decisionId = java.util.UUID.randomUUID().toString()
                 val prompt = if (fixedCount != null) {
                     "Select $fixedCount card${if (fixedCount > 1) "s" else ""} to exile from " +
-                        "graveyard for ${cardComponent.name}"
+                        "graveyard for ${sourceName}"
                 } else {
-                    "Select any number of cards to exile from graveyard for ${cardComponent.name} " +
+                    "Select any number of cards to exile from graveyard for ${sourceName} " +
                         "(X is the number you choose)"
                 }
                 val decision = com.wingedsheep.engine.core.SelectCardsDecision(
@@ -922,7 +925,7 @@ class ActivateAbilityHandler(
                     prompt = prompt,
                     context = com.wingedsheep.engine.core.DecisionContext(
                         sourceId = action.sourceId,
-                        sourceName = cardComponent.name,
+                        sourceName = sourceName,
                         phase = com.wingedsheep.engine.core.DecisionPhase.CASTING
                     ),
                     options = exileXCandidates,
@@ -990,14 +993,14 @@ class ActivateAbilityHandler(
                 }
             if (exileCandidates.size > exileFromGraveyardCost.count) {
                 val decisionId = java.util.UUID.randomUUID().toString()
-                val prompt = "Select ${exileFromGraveyardCost.count} card${if (exileFromGraveyardCost.count > 1) "s" else ""} to exile from graveyard for ${cardComponent.name}"
+                val prompt = "Select ${exileFromGraveyardCost.count} card${if (exileFromGraveyardCost.count > 1) "s" else ""} to exile from graveyard for ${sourceName}"
                 val decision = com.wingedsheep.engine.core.SelectCardsDecision(
                     id = decisionId,
                     playerId = action.playerId,
                     prompt = prompt,
                     context = com.wingedsheep.engine.core.DecisionContext(
                         sourceId = action.sourceId,
-                        sourceName = cardComponent.name,
+                        sourceName = sourceName,
                         phase = com.wingedsheep.engine.core.DecisionPhase.CASTING
                     ),
                     options = exileCandidates,
@@ -1055,14 +1058,14 @@ class ActivateAbilityHandler(
             // pick a distinctly-named set even when candidates == count — so always pause for it.
             if (sacrificeCandidates.size > sacrificeCost.count || sacrificeCost.distinctNames) {
                 val decisionId = java.util.UUID.randomUUID().toString()
-                val prompt = "Select ${sacrificeCost.count} permanent${if (sacrificeCost.count > 1) "s" else ""} to sacrifice for ${cardComponent.name}"
+                val prompt = "Select ${sacrificeCost.count} permanent${if (sacrificeCost.count > 1) "s" else ""} to sacrifice for ${sourceName}"
                 val decision = com.wingedsheep.engine.core.SelectCardsDecision(
                     id = decisionId,
                     playerId = action.playerId,
                     prompt = prompt,
                     context = com.wingedsheep.engine.core.DecisionContext(
                         sourceId = action.sourceId,
-                        sourceName = cardComponent.name,
+                        sourceName = sourceName,
                         phase = com.wingedsheep.engine.core.DecisionPhase.CASTING
                     ),
                     options = sacrificeCandidates,
@@ -1113,17 +1116,17 @@ class ActivateAbilityHandler(
                 .let { if (variablePermanentsCost.excludeSelf) it.filter { id -> id != action.sourceId } else it }
             val minCount = variablePermanentsCost.minCount
             if (candidates.size < minCount) {
-                return ExecutionResult.error(state, "Not enough permanents to $verb for ${cardComponent.name}")
+                return ExecutionResult.error(state, "Not enough permanents to $verb for ${sourceName}")
             }
             val decisionId = java.util.UUID.randomUUID().toString()
-            val prompt = "Choose one or more ${variablePermanentsCost.filter.description}s to $verb for ${cardComponent.name}"
+            val prompt = "Choose one or more ${variablePermanentsCost.filter.description}s to $verb for ${sourceName}"
             val decision = com.wingedsheep.engine.core.SelectCardsDecision(
                 id = decisionId,
                 playerId = action.playerId,
                 prompt = prompt,
                 context = com.wingedsheep.engine.core.DecisionContext(
                     sourceId = action.sourceId,
-                    sourceName = cardComponent.name,
+                    sourceName = sourceName,
                     phase = com.wingedsheep.engine.core.DecisionPhase.CASTING
                 ),
                 options = candidates,
@@ -1178,7 +1181,7 @@ class ActivateAbilityHandler(
                         state, req, action.playerId, action.sourceId, pipelineContext = pipelineContext
                     )
                     if (legal.isEmpty() && req.effectiveMinCount > 0) {
-                        return ExecutionResult.error(state, "No legal target for ${cardComponent.name}")
+                        return ExecutionResult.error(state, "No legal target for ${sourceName}")
                     }
                     legalTargets[index] = legal
                     com.wingedsheep.engine.core.TargetRequirementInfo(
@@ -1189,14 +1192,14 @@ class ActivateAbilityHandler(
                     )
                 }
                 val decisionId = java.util.UUID.randomUUID().toString()
-                val prompt = "Choose ${controllerTargetReqsExec.joinToString(" and ") { it.description }} for ${cardComponent.name}"
+                val prompt = "Choose ${controllerTargetReqsExec.joinToString(" and ") { it.description }} for ${sourceName}"
                 val decision = com.wingedsheep.engine.core.ChooseTargetsDecision(
                     id = decisionId,
                     playerId = action.playerId,
                     prompt = prompt,
                     context = com.wingedsheep.engine.core.DecisionContext(
                         sourceId = action.sourceId,
-                        sourceName = cardComponent.name,
+                        sourceName = sourceName,
                         phase = com.wingedsheep.engine.core.DecisionPhase.CASTING
                     ),
                     targetRequirements = requirementInfos,
@@ -1322,7 +1325,7 @@ class ActivateAbilityHandler(
                     }
                 }
                 else -> {
-                    val autoTapResult = autoTapForManaCost(currentState, action.playerId, manaPool, manaCost, cardComponent.name, manaXValue, selfExcludedSources, executeAbilityContext, ability.xManaRestriction)
+                    val autoTapResult = autoTapForManaCost(currentState, action.playerId, manaPool, manaCost, sourceName, manaXValue, selfExcludedSources, executeAbilityContext, ability.xManaRestriction)
                         ?: return ExecutionResult.error(state, "Not enough mana to activate this ability")
                     currentState = autoTapResult.newState
                     manaPool = autoTapResult.newPool
@@ -1592,7 +1595,7 @@ class ActivateAbilityHandler(
         // only the loyalty change — which payAbilityCost mutates without an event — is emitted here.
         val abilityCost = ability.cost
         if (abilityCost is AbilityCost.Loyalty) {
-            events.add(LoyaltyChangedEvent(action.sourceId, cardComponent.name, abilityCost.change))
+            events.add(LoyaltyChangedEvent(action.sourceId, sourceName, abilityCost.change))
         }
 
         // Snapshot of the activation's cost-side events (cost payment + the {T}/tap/loyalty events
@@ -1684,7 +1687,7 @@ class ActivateAbilityHandler(
             // Adding it to [events] now carries it out through those exits too.
             val manaAbilityActivatedEvent = AbilityActivatedEvent(
                 sourceId = action.sourceId,
-                sourceName = cardComponent.name,
+                sourceName = sourceName,
                 controllerId = action.playerId,
                 abilityEntityId = null,
                 costsTap = hasTapCost(effectiveCost),
@@ -1752,7 +1755,7 @@ class ActivateAbilityHandler(
                 // provenance must enter the effect context here. The concrete id remains useful
                 // even when this lookup branch could not prove a definition-scoped identity.
                 abilityIdentity = abilityIdentity,
-                activatedAbilityId = ability.id,
+                activatedAbility = ability,
             )
 
             val effectResult = effectExecutorRegistry.execute(currentState, finalEffect, context).toExecutionResult()
@@ -1804,7 +1807,7 @@ class ActivateAbilityHandler(
                 ManaAddedEvent(
                     playerId = action.playerId,
                     sourceId = action.sourceId,
-                    sourceName = cardComponent.name,
+                    sourceName = sourceName,
                     colorless = 1
                 )
             } else when (val effect = finalEffect) {
@@ -1813,7 +1816,7 @@ class ActivateAbilityHandler(
                     ManaAddedEvent(
                         playerId = action.playerId,
                         sourceId = action.sourceId,
-                        sourceName = cardComponent.name,
+                        sourceName = sourceName,
                         white = if (effect.color == Color.WHITE) amount else 0,
                         blue = if (effect.color == Color.BLUE) amount else 0,
                         black = if (effect.color == Color.BLACK) amount else 0,
@@ -1827,7 +1830,7 @@ class ActivateAbilityHandler(
                     ManaAddedEvent(
                         playerId = action.playerId,
                         sourceId = action.sourceId,
-                        sourceName = cardComponent.name,
+                        sourceName = sourceName,
                         colorless = amount
                     )
                 }
@@ -1840,7 +1843,7 @@ class ActivateAbilityHandler(
                     ManaAddedEvent(
                         playerId = action.playerId,
                         sourceId = action.sourceId,
-                        sourceName = cardComponent.name,
+                        sourceName = sourceName,
                         white = if (chosenColor == Color.WHITE) amount else 0,
                         blue = if (chosenColor == Color.BLUE) amount else 0,
                         black = if (chosenColor == Color.BLACK) amount else 0,
@@ -1861,7 +1864,7 @@ class ActivateAbilityHandler(
                             ManaAddedEvent(
                                 playerId = action.playerId,
                                 sourceId = action.sourceId,
-                                sourceName = cardComponent.name,
+                                sourceName = sourceName,
                                 white = if (manaEffect.color == Color.WHITE) amount else 0,
                                 blue = if (manaEffect.color == Color.BLUE) amount else 0,
                                 black = if (manaEffect.color == Color.BLACK) amount else 0,
@@ -1875,7 +1878,7 @@ class ActivateAbilityHandler(
                             ManaAddedEvent(
                                 playerId = action.playerId,
                                 sourceId = action.sourceId,
-                                sourceName = cardComponent.name,
+                                sourceName = sourceName,
                                 colorless = amount
                             )
                         }
@@ -1888,7 +1891,7 @@ class ActivateAbilityHandler(
                             ManaAddedEvent(
                                 playerId = action.playerId,
                                 sourceId = action.sourceId,
-                                sourceName = cardComponent.name,
+                                sourceName = sourceName,
                                 white = if (chosenColor == Color.WHITE) amount else 0,
                                 blue = if (chosenColor == Color.BLUE) amount else 0,
                                 black = if (chosenColor == Color.BLACK) amount else 0,
@@ -1953,7 +1956,7 @@ class ActivateAbilityHandler(
         // Non-mana abilities go on the stack
         val abilityOnStack = ActivatedAbilityOnStackComponent(
             sourceId = action.sourceId,
-            sourceName = cardComponent.name,
+            sourceName = sourceName,
             controllerId = action.playerId,
             effect = finalEffect,
             sacrificedPermanents = sacrificedSnapshots,
@@ -1973,7 +1976,7 @@ class ActivateAbilityHandler(
             revealedNotedCreatureType = revealedNotedCreatureType,
             descriptionOverride = ability.descriptionOverride,
             abilityIdentity = abilityIdentity,
-            activatedAbilityId = ability.id,
+            activatedAbility = ability,
             granterId = staticGranterId,
             // CR 701.28f — freeze the source's face-change clock as the ability goes on the stack;
             // an instruction inside it to transform that same permanent is ignored if the permanent
@@ -2022,7 +2025,7 @@ class ActivateAbilityHandler(
 
                 // Auto-tap for mana cost
                 if (manaCost != null) {
-                    val autoTapResult = autoTapForManaCost(currentState, action.playerId, repeatPool, manaCost, cardComponent.name, 0, abilityContext = executeAbilityContext)
+                    val autoTapResult = autoTapForManaCost(currentState, action.playerId, repeatPool, manaCost, sourceName, 0, abilityContext = executeAbilityContext)
                         ?: break // Can't afford — stop early
                     currentState = autoTapResult.newState
                     repeatPool = autoTapResult.newPool
@@ -2072,7 +2075,7 @@ class ActivateAbilityHandler(
                 // Put another ability on the stack
                 val repeatAbilityOnStack = ActivatedAbilityOnStackComponent(
                     sourceId = action.sourceId,
-                    sourceName = cardComponent.name,
+                    sourceName = sourceName,
                     controllerId = action.playerId,
                     effect = finalEffect,
                     sacrificedPermanents = emptyList(),
@@ -2081,7 +2084,7 @@ class ActivateAbilityHandler(
                     tappedEntitySnapshots = repeatTapSnapshots,
                     descriptionOverride = ability.descriptionOverride,
                     abilityIdentity = abilityIdentity,
-                    activatedAbilityId = ability.id,
+                    activatedAbility = ability,
                     granterId = staticGranterId
                 )
                 val repeatStackResult = stackResolver.putActivatedAbility(
@@ -2941,7 +2944,7 @@ class ActivateAbilityHandler(
         return ManaAddedEvent(
             playerId = action.playerId,
             sourceId = action.sourceId,
-            sourceName = cardComponent.name,
+            sourceName = nameVisibleToAll(oldState, action.sourceId, cardComponent.name),
             white = newPool.white - (oldPool?.white ?: 0),
             blue = newPool.blue - (oldPool?.blue ?: 0),
             black = newPool.black - (oldPool?.black ?: 0),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -3673,7 +3673,8 @@ class CastSpellHandler(
             // Every enumerated alternative-cost offer names its mechanic explicitly, so this is the
             // declared choice rather than a guess. Descriptive only — the rules consequences of each
             // mechanic ride the `was*` flags above.
-            alternativeCost = action.alternativeCostType?.takeIf { action.useAlternativeCost }
+            alternativeCost = action.alternativeCostType?.takeIf { action.useAlternativeCost },
+            castOriginState = state
         )
 
         if (!castResult.isSuccess) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -18,6 +18,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.state.nameVisibleToAll
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
@@ -533,7 +534,9 @@ object DamageUtils {
             newState = trackDamageSourceForController(newState, sourceId)
         }
 
-        val sourceName = sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
+        val sourceName = sourceId?.let { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name?.let { nameVisibleToAll(state, id, it) }
+        }
         val targetContainer = newState.getEntity(targetId)
         val targetName = targetContainer?.get<CardComponent>()?.name
         val targetIsPlayer = targetContainer?.get<LifeTotalComponent>() != null
@@ -1710,6 +1713,7 @@ object DamageUtils {
         updatedEffects.removeAt(shieldIndex)
         val newState = state.copy(floatingEffects = updatedEffects)
         val sourceName = state.getEntity(sourceId)?.get<CardComponent>()?.name
+            ?.let { nameVisibleToAll(state, sourceId, it) }
         val event = DamagePreventedEvent(
             sourceId = sourceId,
             recipientId = targetId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
@@ -190,7 +190,7 @@ class PermanentExecutors(
         ChangeColorExecutor(),
         ChangeColorToChosenExecutor(),
         ChangeGroupColorExecutor(),
-        EachPermanentBecomesCopyOfTargetExecutor(cardRegistry),
+        EachPermanentBecomesCopyOfTargetExecutor(),
         BecomeCopyOfLinkedExileExecutor(),
         LoseAllCreatureTypesExecutor(),
         MassAnimateExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/EachPermanentBecomesCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/EachPermanentBecomesCopyOfTargetExecutor.kt
@@ -145,21 +145,23 @@ class EachPermanentBecomesCopyOfTargetExecutor(
                 updated
             }
 
-            // "…and this ability": re-grant the activated ability that produced this copy. The
-            // resolving ability's identity carries the *permanent's* card definition id, which has
-            // already drifted to whatever it last copied — so read the granted record first (that's
-            // where the ability lives after the first copy) and fall back to the printed definition
-            // for the very first activation.
+            // "…and this ability": re-grant the concrete activated ability that produced this
+            // copy. After the first copy it lives in the runtime-grant store and intentionally has
+            // no definition-scoped AbilityIdentity, so routing must use activatedAbilityId. Read the
+            // grant first, then use a proven definition identity to recover the first activation's
+            // ability even if the source's characteristics changed before this resolved.
             if (effect.retainActivatingAbility) {
-                val identity = context.abilityIdentity
-                if (identity != null && newState.grantedActivatedAbilities
-                        .none { it.entityId == entityId && it.ability.id == identity.abilityId }
+                val activatedAbilityId = context.activatedAbilityId
+                if (activatedAbilityId != null && newState.grantedActivatedAbilities
+                        .none { it.entityId == entityId && it.ability.id == activatedAbilityId }
                 ) {
                     val ability = state.grantedActivatedAbilities
-                        .firstOrNull { it.entityId == entityId && it.ability.id == identity.abilityId }
+                        .firstOrNull { it.entityId == entityId && it.ability.id == activatedAbilityId }
                         ?.ability
-                        ?: cardRegistry.getCard(identity.cardDefinitionId)
-                            ?.activatedAbilities?.firstOrNull { it.id == identity.abilityId }
+                        ?: context.abilityIdentity
+                            ?.takeIf { it.abilityId == activatedAbilityId }
+                            ?.let { cardRegistry.getCard(it.cardDefinitionId) }
+                            ?.activatedAbilities?.firstOrNull { it.id == activatedAbilityId }
                     if (ability != null) {
                         newState = newState.copy(
                             grantedActivatedAbilities = newState.grantedActivatedAbilities +

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/EachPermanentBecomesCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/EachPermanentBecomesCopyOfTargetExecutor.kt
@@ -3,7 +3,6 @@ package com.wingedsheep.engine.handlers.effects.permanent.types
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.event.GrantedActivatedAbility
 import com.wingedsheep.engine.handlers.EffectContext
-import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.handlers.effects.BattlefieldFilterUtils
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.copy.CopyExceptionApplier
@@ -44,9 +43,7 @@ import kotlin.reflect.KClass
  * copies. Likeness Looter's "{X}: … becomes a copy of target creature card in your graveyard with
  * mana value X, except it has flying and this ability" is both riders at once.
  */
-class EachPermanentBecomesCopyOfTargetExecutor(
-    private val cardRegistry: CardRegistry
-) : EffectExecutor<EachPermanentBecomesCopyOfTargetEffect> {
+class EachPermanentBecomesCopyOfTargetExecutor : EffectExecutor<EachPermanentBecomesCopyOfTargetEffect> {
 
     override val effectType: KClass<EachPermanentBecomesCopyOfTargetEffect> =
         EachPermanentBecomesCopyOfTargetEffect::class
@@ -145,34 +142,17 @@ class EachPermanentBecomesCopyOfTargetExecutor(
                 updated
             }
 
-            // "…and this ability": re-grant the concrete activated ability that produced this
-            // copy. After the first copy it lives in the runtime-grant store and intentionally has
-            // no definition-scoped AbilityIdentity, so routing must use activatedAbilityId. Read the
-            // grant first, then use a proven definition identity to recover the first activation's
-            // ability even if the source's characteristics changed before this resolved.
-            if (effect.retainActivatingAbility) {
-                val activatedAbilityId = context.activatedAbilityId
-                if (activatedAbilityId != null && newState.grantedActivatedAbilities
-                        .none { it.entityId == entityId && it.ability.id == activatedAbilityId }
-                ) {
-                    val ability = state.grantedActivatedAbilities
-                        .firstOrNull { it.entityId == entityId && it.ability.id == activatedAbilityId }
-                        ?.ability
-                        ?: context.abilityIdentity
-                            ?.takeIf { it.abilityId == activatedAbilityId }
-                            ?.let { cardRegistry.getCard(it.cardDefinitionId) }
-                            ?.activatedAbilities?.firstOrNull { it.id == activatedAbilityId }
-                    if (ability != null) {
-                        newState = newState.copy(
-                            grantedActivatedAbilities = newState.grantedActivatedAbilities +
-                                GrantedActivatedAbility(
-                                    entityId = entityId,
-                                    ability = ability,
-                                    duration = Duration.Permanent
-                                )
-                        )
-                    }
+            // The activation snapshot survives changes to the source and to its granting effect.
+            val retainedAbility = context.activatedAbility
+            if (effect.retainActivatingAbility && retainedAbility != null &&
+                newState.grantedActivatedAbilities.none {
+                    it.entityId == entityId && it.ability.id == retainedAbility.id
                 }
+            ) {
+                newState = newState.copy(
+                    grantedActivatedAbilities = newState.grantedActivatedAbilities +
+                        GrantedActivatedAbility(entityId, retainedAbility, Duration.Permanent)
+                )
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -13,9 +13,6 @@ import com.wingedsheep.engine.state.components.battlefield.*
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.TextReplacementComponent
-import com.wingedsheep.engine.state.components.identity.ControllerComponent
-import com.wingedsheep.engine.state.components.identity.EmblemActivatedAbilityComponent
-import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Zone
@@ -86,24 +83,14 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 .map { it.ability }
             val staticGrants = context.castPermissionUtils.getStaticGrantedAbilitiesWithGranter(entityId, state)
             val staticAbilities = staticGrants.map { it.ability }
-            val emblemAbilities = state.entities.mapNotNull { (emblemId, emblemContainer) ->
-                val grant = emblemContainer.get<EmblemActivatedAbilityComponent>() ?: return@mapNotNull null
-                val controllerId = emblemContainer.get<ControllerComponent>()?.playerId ?: return@mapNotNull null
-                val matches = context.predicateEvaluator.matches(
-                    state,
-                    projected,
-                    entityId,
-                    grant.filter.baseFilter,
-                    PredicateContext(controllerId = controllerId, sourceId = emblemId),
-                ) && (!grant.filter.excludeSelf || entityId != emblemId)
-                grant.takeIf { matches }?.abilities
-            }.flatten()
+            val emblemAbilities =
+                context.castPermissionUtils.getEmblemGrantedActivatedAbilities(entityId, state)
             // Which permanent granted each statically-granted ability, so a cost that names the
             // granter (AbilityCost.TapGrantingPermanent) can be gated on *its* state, not the host's.
             val granterByAbilityId = staticGrants.associate { it.ability.id to it.granterId }
             val allAbilities = grantedAbilities + staticAbilities + emblemAbilities
 
-            // If no card definition (e.g., tokens) and no granted/static abilities, skip
+            // If no card definition (e.g., tokens) and no granted abilities, skip
             if (cardDef == null && allAbilities.isEmpty()) continue
 
             // Get class level for Class enchantments (null for non-Class cards)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.engine.state.components.battlefield.GraveyardPlayPermissi
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.EmblemActivatedAbilityComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.player.CantCastSpellsComponent
 import com.wingedsheep.engine.state.components.player.EquipActivationsThisTurnComponent
@@ -1643,6 +1644,32 @@ class CastPermissionUtils(
         state: GameState
     ): List<com.wingedsheep.sdk.scripting.ActivatedAbility> =
         getStaticGrantedAbilitiesWithGranter(entityId, state).map { it.ability }
+
+    /**
+     * Get activated abilities granted to [entityId] by permanent emblems.
+     *
+     * Emblems live as synthetic, non-zoned entities, so they are not part of the battlefield
+     * static-ability scan above. This method is the shared authority used by legal-action
+     * enumeration and activation lookup: an ability offered from an emblem must be found with the
+     * same controller-relative filter when the submitted action is validated and executed.
+     */
+    fun getEmblemGrantedActivatedAbilities(
+        entityId: EntityId,
+        state: GameState,
+    ): List<ActivatedAbility> = state.entities.flatMap { (emblemId, emblemContainer) ->
+        val grant = emblemContainer.get<EmblemActivatedAbilityComponent>()
+            ?: return@flatMap emptyList()
+        val controllerId = emblemContainer.get<ControllerComponent>()?.playerId
+            ?: return@flatMap emptyList()
+        val matches = predicateEvaluator.matches(
+            state,
+            state.projectedState,
+            entityId,
+            grant.filter.baseFilter,
+            PredicateContext(controllerId = controllerId, sourceId = emblemId),
+        ) && (!grant.filter.excludeSelf || entityId != emblemId)
+        if (matches) grant.abilities else emptyList()
+    }
 }
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/RevealedInHandTracker.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/RevealedInHandTracker.kt
@@ -108,15 +108,15 @@ object RevealedInHandTracker {
     }
 
     private fun onSpellCast(state: GameState, event: SpellCastEvent): GameState {
-        // The cast card is public on the stack regardless; dropping its hand-knowledge also
-        // stops a bounced-then-cast-face-down card from leaking its real identity.
+        // The card has left its hand. Dropping that hand-knowledge also stops a
+        // bounced-then-cast-face-down card from leaking its real identity.
         var newState = LibraryRevealUtils.clearReveals(state, listOf(event.spellEntityId))
         val castFromZone = state.getEntity(event.spellEntityId)
             ?.get<SpellOnStackComponent>()?.castFromZone
         // Only a card played *from hand* makes the known copies of its name ambiguous;
         // casting the same name from the graveyard/exile leaves the hand copy identifiable.
         if (castFromZone == Zone.HAND) {
-            newState = forgetSameNamedInHand(newState, event.casterId, event.cardName)
+            newState = forgetSameNamedInHand(newState, event.casterId, event.semanticCardName)
         }
         return newState
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/RevealedInHandTracker.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/RevealedInHandTracker.kt
@@ -116,7 +116,7 @@ object RevealedInHandTracker {
         // Only a card played *from hand* makes the known copies of its name ambiguous;
         // casting the same name from the graveyard/exile leaves the hand copy identifiable.
         if (castFromZone == Zone.HAND) {
-            newState = forgetSameNamedInHand(newState, event.casterId, event.semanticCardName)
+            newState = forgetSameNamedInHand(newState, event.casterId, event.underlyingCardName)
         }
         return newState
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -206,7 +206,10 @@ class StackResolver(
         spentManaProvenance: com.wingedsheep.engine.mechanics.mana.SpentManaProvenance =
             com.wingedsheep.engine.mechanics.mana.SpentManaProvenance(),
         castTimeFlags: Set<String> = emptySet(),
-        alternativeCost: com.wingedsheep.engine.core.AlternativeCostType? = null
+        alternativeCost: com.wingedsheep.engine.core.AlternativeCostType? = null,
+        // Payment can tap or remove the source that made the origin visible. This immutable
+        // input is consulted only while capturing the event; the event retains no GameState.
+        castOriginState: GameState = state
     ): ExecutionResult {
         val container = state.getEntity(cardId)
             ?: return ExecutionResult.error(state, "Card not found: $cardId")
@@ -519,7 +522,7 @@ class StackResolver(
                 targetNames = targetNames,
                 xValue = boundXValue,
                 cardPresentation = eventPresentationFactory.castSpellIdentity(
-                    beforeCast = state,
+                    beforeCast = castOriginState,
                     onStack = newState,
                     castFromZone = castFromZone,
                     entityId = cardId,
@@ -2950,7 +2953,7 @@ class StackResolver(
             controllerId = abilityComponent.controllerId,
             granterId = abilityComponent.granterId,
             abilityIdentity = abilityComponent.abilityIdentity,
-            activatedAbilityId = abilityComponent.activatedAbilityId,
+            activatedAbility = abilityComponent.activatedAbility,
             sourceFaceChanges = abilityComponent.sourceFaceChanges,
             targets = activatedTargets,
             alignedTargets = alignedActivatedTargets,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2939,6 +2939,7 @@ class StackResolver(
             controllerId = abilityComponent.controllerId,
             granterId = abilityComponent.granterId,
             abilityIdentity = abilityComponent.abilityIdentity,
+            activatedAbilityId = abilityComponent.activatedAbilityId,
             sourceFaceChanges = abilityComponent.sourceFaceChanges,
             targets = activatedTargets,
             alignedTargets = alignedActivatedTargets,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -18,6 +18,7 @@ import com.wingedsheep.engine.mechanics.layers.ContinuousEffectSourceComponent
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
@@ -38,8 +39,9 @@ import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
 import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
 import com.wingedsheep.engine.handlers.effects.library.ChooseCreatureTypePipelineExecutor
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
-import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.nameVisibleToAll
+import com.wingedsheep.engine.view.EventPresentationFactory
+import com.wingedsheep.engine.view.Visibility
 import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
 import com.wingedsheep.engine.state.components.identity.HasMorphAbilityComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
@@ -106,6 +108,7 @@ class StackResolver(
     private val staticAbilityHandler: StaticAbilityHandler = StaticAbilityHandler(cardRegistry),
     private val predicateEvaluator: PredicateEvaluator = PredicateEvaluator()
 ) {
+    private val eventPresentationFactory = EventPresentationFactory(Visibility(cardRegistry))
 
     /**
      * Re-validates a spliced card's own targets as the spell resolves (CR 608.2b via 702.47d): the
@@ -472,9 +475,9 @@ class StackResolver(
         } else {
             cardComponent.name
         }
-        // For face-down creatures, use a generic name in the event (CR 708.2a)
+        // Preserve SpellCastEvent.cardName's historical public-name contract. The trusted
+        // presentation snapshot below separately retains semantic identity and private audiences.
         val eventName = if (castFaceDown) FACE_DOWN_DISPLAY_NAME else spellName
-
         // Collect target names for the cast event log
         val targetNames = effectiveTargets.mapNotNull { target ->
             when (target) {
@@ -515,6 +518,13 @@ class StackResolver(
                 casterId = casterId,
                 targetNames = targetNames,
                 xValue = boundXValue,
+                cardPresentation = eventPresentationFactory.castSpellIdentity(
+                    beforeCast = state,
+                    onStack = newState,
+                    castFromZone = castFromZone,
+                    entityId = cardId,
+                    semanticName = spellName,
+                ),
                 declaredCostSlot = declaredCostSlot,
                 totalManaSpent = totalManaSpent,
                 distinctColorsSpent =
@@ -534,14 +544,14 @@ class StackResolver(
         // Crime detection (CR Outlaws of Thunder Junction). Emit at most once per cast,
         // regardless of how many opponent-controlled targets the spell chose.
         if (CrimeDetector.isCrime(newState, casterId, effectiveTargets)) {
-            events.add(CommitCrimeEvent(casterId, cardId, eventName))
+            events.add(CommitCrimeEvent(casterId, cardId, spellName))
             newState = recordCrime(newState, casterId)
         }
 
         // "Whenever a player chooses one or more targets" (Psychic Battle). Emit once per cast
         // when the spell chose at least one target.
         if (effectiveTargets.isNotEmpty()) {
-            events.add(TargetsChosenEvent(casterId, cardId, eventName))
+            events.add(TargetsChosenEvent(casterId, cardId, spellName))
         }
 
         // Emit BecomesTargetEvent for each permanent, spell, or player target (Rule 601.2c)
@@ -1006,8 +1016,9 @@ class StackResolver(
             events.addAll(permanentResult.events)
             // CR 708.2a — a permanent that entered face down has no name, so neither the
             // "resolved" line nor the "entered the battlefield" line may carry the printed one.
-            // The cast line was already masked at `eventName` above; leaving these two unmasked
-            // made the log contradict it and told the opponent exactly what they were looking at.
+            // The cast line has its own event-time client presentation; leaving these two
+            // audience-agnostic log events unmasked made the log contradict it and told the
+            // opponent exactly what they were looking at.
             // Read the resolved entity rather than `spellComponent.castFaceDown` so every route
             // that lands a permanent face down is covered, not only a face-down cast.
             val permanentName = nameVisibleToAll(newState, spellId, cardComponent?.name ?: "Unknown")

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/FaceDownNaming.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/FaceDownNaming.kt
@@ -27,12 +27,13 @@ const val FACE_DOWN_CARD_DISPLAY_NAME: String = "Face-down card"
 /**
  * The name [entityId] may be shown under to *any* viewer, its controller included.
  *
- * Use this for flat strings with no audience attached — a game-log line, a decision summary. Those
- * reach both players, and [com.wingedsheep.engine.view.ClientEventTransformer] cannot redact them
- * downstream: it maps engine events to text with no `GameState` in hand, so it cannot tell a
- * face-down object from a face-up one. The decision has to be made where the event is emitted.
+ * Use this only for text whose contract genuinely has one public answer, such as an
+ * audience-agnostic decision summary. A typed event that will later be projected for one viewer
+ * must not collapse all viewers to that answer: capture an
+ * [com.wingedsheep.engine.core.EventCardPresentation] through
+ * [com.wingedsheep.engine.view.EventPresentationFactory] while the event-time state still exists.
  *
- * Where the text *does* have an audience, ask
+ * For other text that has an immediate audience, ask
  * [com.wingedsheep.engine.view.Visibility.isCardIdentityVisibleTo] instead and pick the label from
  * its answer. That query knows what this file cannot: explicit reveals, effect-granted access, and
  * the zones CR 708.5 does and does not let a controller look in.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -895,8 +895,9 @@ data class GameState(
      * itself; during a Mindslaver-style hijacked turn this resolves to the hijacker.
      *
      * Resource ownership (mana, cards, life) is unaffected — it always stays with
-     * [playerId]. This helper is only consulted at the input-routing seam: legal
-     * action enumeration, decision validation, and per-action seat checks.
+     * [playerId]. This helper is consulted at input and private-view routing seams: legal action
+     * enumeration, decision validation, per-action seat checks, and the information shown to the
+     * connection acting for that seat.
      *
      * A session-level [com.wingedsheep.engine.state.components.player.HotseatControlComponent]
      * (play-against-yourself) takes precedence over a per-turn hijack: it permanently routes

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/AbilityIdentityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/AbilityIdentityResolver.kt
@@ -7,16 +7,20 @@ import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.AbilityIdentity
 
 /**
- * Derives the [AbilityIdentity] of an ability whose source permanent/card is [sourceId], by pairing
- * the source's `CardComponent.cardDefinitionId` with the ability's [abilityId].
+ * Transitional trigger-path derivation that pairs [abilityId] with [sourceId]'s current card
+ * definition.
  *
- * Returns `null` when [sourceId] has no [CardComponent] — e.g. synthesized sources such as a spell
- * copy placed on a fresh entity — in which case the ability simply carries no identity and is never
- * grouped or yielded against (correct: a copy of a spell is not a recurring card ability).
+ * This says only how the key was derived; it does not prove that the trigger belongs to that card
+ * definition. [com.wingedsheep.engine.event.TriggerAbilityResolver] can also return granted and
+ * synthesized triggers, so those branches need typed provenance before trigger identity is fully
+ * authoritative. Activated abilities do not use this helper: their lookup records definition
+ * ownership explicitly at activation time.
  *
- * This is the one place the key is computed, so triggered- and activated-ability stack components
- * and the decisions they raise all agree on the same identity.
+ * Returns `null` when [sourceId] has no [CardComponent].
  */
-fun GameState.abilityIdentityOf(sourceId: EntityId, abilityId: AbilityId): AbilityIdentity? =
+fun GameState.triggerIdentityFromCurrentCardDefinition(
+    sourceId: EntityId,
+    abilityId: AbilityId,
+): AbilityIdentity? =
     getEntity(sourceId)?.get<CardComponent>()?.cardDefinitionId
         ?.let { AbilityIdentity(it, abilityId) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -386,13 +386,11 @@ data class ActivatedAbilityOnStackComponent(
      */
     val abilityIdentity: com.wingedsheep.sdk.scripting.AbilityIdentity? = null,
     /**
-     * Concrete activated-ability id used for resolution-time routing and ability-local
-     * bookkeeping. Unlike [abilityIdentity], this need not be definition-scoped: runtime/static
-     * grants retain their id here without claiming that it belongs to the receiver's definition.
-     * Stack copies inherit it with the rest of this component. Null for specialized synthesized
-     * actions such as crew and saddle, which have no [com.wingedsheep.sdk.scripting.ActivatedAbility].
+     * Concrete ability captured at activation, independent of definition ownership. Stack copies
+     * retain this snapshot even if the source changes or the grant disappears before resolution.
+     * Null for synthesized actions such as crew and saddle.
      */
-    val activatedAbilityId: AbilityId? = null,
+    val activatedAbility: com.wingedsheep.sdk.scripting.ActivatedAbility? = null,
     /**
      * The permanent whose static ability granted this activated ability (the Equipment/Aura/permanent
      * bearing the `GrantActivatedAbility` static), captured at activation. Read at resolution into
@@ -418,6 +416,9 @@ data class ActivatedAbilityOnStackComponent(
      */
     val damageDistribution: Map<EntityId, Int>? = null
 ) : Component {
+    val activatedAbilityId: AbilityId?
+        get() = activatedAbility?.id
+
     val hasTargets: Boolean = false  // Will be updated based on effect
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -379,10 +379,19 @@ data class ActivatedAbilityOnStackComponent(
     /**
      * Definition-scoped identity of the activated ability, shared by every copy of the same card
      * and every future instance of it. Drives batch decisions and persistent yields (see
-     * [com.wingedsheep.sdk.scripting.AbilityIdentity]). Null for synthesized abilities with no
-     * stable [com.wingedsheep.sdk.scripting.AbilityId] behind them (e.g. crew/saddle).
+     * [com.wingedsheep.sdk.scripting.AbilityIdentity]). Null unless activation lookup proved that
+     * the concrete ability belongs to the source's current card definition; runtime/static grants,
+     * intrinsic mana abilities, and synthesized crew/saddle actions therefore carry no identity.
      */
     val abilityIdentity: com.wingedsheep.sdk.scripting.AbilityIdentity? = null,
+    /**
+     * Concrete activated-ability id used for resolution-time routing and ability-local
+     * bookkeeping. Unlike [abilityIdentity], this need not be definition-scoped: runtime/static
+     * grants retain their id here without claiming that it belongs to the receiver's definition.
+     * Stack copies inherit it with the rest of this component. Null for specialized synthesized
+     * actions such as crew and saddle, which have no [com.wingedsheep.sdk.scripting.ActivatedAbility].
+     */
+    val activatedAbilityId: AbilityId? = null,
     /**
      * The permanent whose static ability granted this activated ability (the Equipment/Aura/permanent
      * bearing the `GrantActivatedAbility` static), captured at activation. Read at resolution into

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -380,8 +380,9 @@ data class ActivatedAbilityOnStackComponent(
      * Definition-scoped identity of the activated ability, shared by every copy of the same card
      * and every future instance of it. Drives batch decisions and persistent yields (see
      * [com.wingedsheep.sdk.scripting.AbilityIdentity]). Null unless activation lookup proved that
-     * the concrete ability belongs to the source's current card definition; runtime/static grants,
-     * intrinsic mana abilities, and synthesized crew/saddle actions therefore carry no identity.
+     * the concrete ability belongs to the source's current card definition; runtime, static, and
+     * emblem grants, intrinsic mana abilities, and synthesized crew/saddle actions therefore carry
+     * no identity.
      */
     val abilityIdentity: com.wingedsheep.sdk.scripting.AbilityIdentity? = null,
     /**
@@ -397,7 +398,8 @@ data class ActivatedAbilityOnStackComponent(
      * bearing the `GrantActivatedAbility` static), captured at activation. Read at resolution into
      * [com.wingedsheep.engine.handlers.EffectContext.granterId] so the granted ability can name its
      * granter via [com.wingedsheep.sdk.scripting.targets.EffectTarget.GrantingSource] — e.g. Trusty
-     * Boomerang's "Return [this Equipment] to its owner's hand". Null for non-granted abilities.
+     * Boomerang's "Return [this Equipment] to its owner's hand". Null for abilities not granted by
+     * a permanent's static ability.
      */
     val granterId: EntityId? = null,
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
@@ -1039,7 +1039,9 @@ object ClientEventTransformer {
 
             is SpellCastEvent -> ClientEvent.SpellCast(
                 spellId = event.spellEntityId,
-                spellName = event.cardName,
+                // Legacy events already stored an event-time public name. Current events select
+                // through the captured audience without consulting a later game state.
+                spellName = event.cardPresentation?.nameFor(viewingPlayerId) ?: event.cardName,
                 casterId = event.casterId,
                 isYours = event.casterId == viewingPlayerId,
                 targetNames = event.targetNames,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -22,6 +22,7 @@ import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.ProtectionScope
 import com.wingedsheep.engine.state.FACE_DOWN_CARD_DISPLAY_NAME
 import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
+import com.wingedsheep.engine.state.nameVisibleToAll
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.*
@@ -463,12 +464,29 @@ class ClientStateTransformer(
             } ?: emptyList()
         }
 
+        // A public ability must not expose the hidden card underneath its face-down source.
+        fun sourceIdentityVisible(sourceId: EntityId): Boolean {
+            val zone = if (sourceId in state.stack) Zone.STACK
+                else findEntityZone(state, sourceId)?.let(Zone::valueOf) ?: return true
+            return visibility.isCardIdentityVisibleTo(state, zone, sourceId, viewingPlayerId, isSpectator)
+        }
+
+        fun sourceColors(sourceId: EntityId, visibleCard: CardComponent?): Set<Color> =
+            if (sourceId in state.getBattlefield()) {
+                state.projectedState.getColors(sourceId).mapNotNull { name ->
+                    Color.entries.firstOrNull { it.name == name }
+                }.toSet()
+            } else visibleCard?.colors.orEmpty()
+
         // Check for activated ability
         val activatedAbility = container.get<ActivatedAbilityOnStackComponent>()
         if (activatedAbility != null) {
             // Get the source card's info to display
+            val identityVisible = sourceIdentityVisible(activatedAbility.sourceId)
             val sourceCard = state.getEntity(activatedAbility.sourceId)?.get<CardComponent>()
-            val cardDef = cardRegistry.getCard(activatedAbility.sourceName)
+                ?.takeIf { identityVisible }
+            val sourceName = nameVisibleToAll(state, activatedAbility.sourceId, activatedAbility.sourceName)
+            val cardDef = cardRegistry.getCard(sourceName).takeIf { identityVisible }
 
             // Get targets for this ability
             val targetsComponent = container.get<TargetsComponent>()
@@ -476,13 +494,13 @@ class ClientStateTransformer(
 
             return ClientCard(
                 id = entityId,
-                name = "${activatedAbility.sourceName} ability",
+                name = "$sourceName ability",
                 manaCost = "",
                 manaValue = 0,
                 typeLine = "Ability",
                 cardTypes = setOf("Ability"),
                 subtypes = emptySet(),
-                colors = sourceCard?.colors ?: emptySet(),
+                colors = sourceColors(activatedAbility.sourceId, sourceCard),
                 oracleText = activatedAbility.descriptionOverride
                     ?: runtimeAbilityText(state, entityId, activatedAbility)
                     ?: effectDisplayText(activatedAbility.effect, selfNounFor(state, activatedAbility.sourceId)),
@@ -510,7 +528,7 @@ class ClientStateTransformer(
                 targets = targets,
                 imageUri = sourceCard?.imageUri ?: cardDef?.metadata?.imageUri,
                 chosenX = activatedAbility.xValue,
-                abilityIdentity = activatedAbility.abilityIdentity?.let {
+                abilityIdentity = activatedAbility.abilityIdentity?.takeIf { identityVisible }?.let {
                     ClientAbilityIdentity(it.cardDefinitionId, it.abilityId.value)
                 }
             )
@@ -519,8 +537,11 @@ class ClientStateTransformer(
         // Check for triggered ability
         val triggeredAbility = container.get<TriggeredAbilityOnStackComponent>()
         if (triggeredAbility != null) {
+            val identityVisible = sourceIdentityVisible(triggeredAbility.sourceId)
             val sourceCard = state.getEntity(triggeredAbility.sourceId)?.get<CardComponent>()
-            val cardDef = cardRegistry.getCard(triggeredAbility.sourceName)
+                ?.takeIf { identityVisible }
+            val sourceName = nameVisibleToAll(state, triggeredAbility.sourceId, triggeredAbility.sourceName)
+            val cardDef = cardRegistry.getCard(sourceName).takeIf { identityVisible }
 
             val targetsComponent = container.get<TargetsComponent>()
             val targets = transformTargets(targetsComponent)
@@ -564,13 +585,13 @@ class ClientStateTransformer(
 
             return ClientCard(
                 id = entityId,
-                name = "${triggeredAbility.sourceName} trigger",
+                name = "$sourceName trigger",
                 manaCost = "",
                 manaValue = 0,
                 typeLine = "Triggered Ability",
                 cardTypes = setOf("Ability"),
                 subtypes = emptySet(),
-                colors = sourceCard?.colors ?: emptySet(),
+                colors = sourceColors(triggeredAbility.sourceId, sourceCard),
                 oracleText = triggeredAbility.descriptionOverride
                     ?: runtimeAbilityText(state, entityId, triggeredAbility)
                     ?: effectDisplayText(triggeredAbility.effect, selfNounFor(state, triggeredAbility.sourceId)),
@@ -600,7 +621,7 @@ class ClientStateTransformer(
                 imageUri = sourceCard?.imageUri ?: cardDef?.metadata?.imageUri,
                 sourceZone = sourceZone,
                 chosenX = triggeredAbility.xValue,
-                abilityIdentity = triggeredAbility.abilityIdentity?.let {
+                abilityIdentity = triggeredAbility.abilityIdentity?.takeIf { identityVisible }?.let {
                     ClientAbilityIdentity(it.cardDefinitionId, it.abilityId.value)
                 },
                 copyIndex = triggeredAbility.copyIndex,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/EventPresentationFactory.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/EventPresentationFactory.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.view
+
+import com.wingedsheep.engine.core.EventCardPresentation
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Captures cast identities while both sides of the authoritative state transition still exist.
+ *
+ * [Visibility] remains the sole authority for every viewer-specific answer. The resulting
+ * [EventCardPresentation] is immutable trusted event data: later projection selects one viewer's
+ * answer from it rather than consulting a potentially changed game state.
+ */
+class EventPresentationFactory(
+    private val visibility: Visibility,
+) {
+    fun castSpellIdentity(
+        beforeCast: GameState,
+        onStack: GameState,
+        castFromZone: Zone?,
+        entityId: EntityId,
+        semanticName: String,
+    ): EventCardPresentation {
+        if (isPublicThroughCast(beforeCast, onStack, castFromZone, entityId)) {
+            return EventCardPresentation(
+                semanticName = semanticName,
+                publicName = semanticName,
+            )
+        }
+
+        val identityViewers = onStack.turnOrder
+            .filter { viewerId ->
+                visibility.isCardIdentityVisibleThroughCast(
+                    beforeCast = beforeCast,
+                    onStack = onStack,
+                    castFromZone = castFromZone,
+                    entityId = entityId,
+                    viewingPlayerId = viewerId,
+                )
+            }
+            .toSet()
+        return EventCardPresentation(
+            semanticName = semanticName,
+            publicName = FACE_DOWN_DISPLAY_NAME,
+            identityViewers = identityViewers,
+        )
+    }
+
+    /** A spectator is entitled only to information [Visibility] calls public, never a seat's view. */
+    private fun isPublicThroughCast(
+        beforeCast: GameState,
+        onStack: GameState,
+        castFromZone: Zone?,
+        entityId: EntityId,
+    ): Boolean {
+        val representativeViewer = onStack.turnOrder.firstOrNull() ?: return false
+        return visibility.isCardIdentityVisibleThroughCast(
+            beforeCast = beforeCast,
+            onStack = onStack,
+            castFromZone = castFromZone,
+            entityId = entityId,
+            viewingPlayerId = representativeViewer,
+            isSpectator = true,
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
@@ -93,6 +93,57 @@ class Visibility(
     )
 
     /**
+     * Whether a recipient can carry [entityId]'s identity through the transition from its cast
+     * origin in [beforeCast] to the spell in [onStack].
+     *
+     * Looking only at the resulting stack object loses legitimate history: a card cast face down
+     * from face-up exile was public immediately before it became a nameless spell. Conversely, an
+     * individual [RevealedToComponent] on a card in an unordered hand does not prove which card
+     * left that hand face down. Existing cast handling deliberately clears those stale per-card
+     * hand reveals. Whole-hand visibility is different: while that effect remains active, the
+     * viewer sees the card actually leave.
+     *
+     * Keeping this distinction here makes [Visibility] the authority for both point-in-time
+     * identity and the one transition whose event presentation must retain it.
+     */
+    fun isCardIdentityVisibleThroughCast(
+        beforeCast: GameState,
+        onStack: GameState,
+        castFromZone: Zone?,
+        entityId: EntityId,
+        viewingPlayerId: EntityId,
+        isSpectator: Boolean = false,
+    ): Boolean {
+        val visibleOnStack = isCardIdentityVisibleTo(
+            state = onStack,
+            zoneType = Zone.STACK,
+            entityId = entityId,
+            viewingPlayerId = viewingPlayerId,
+            isSpectator = isSpectator,
+        )
+        if (visibleOnStack) return true
+
+        val origin = castFromZone ?: return false
+        if (origin == Zone.HAND) {
+            val ownerId = zoneOwnerOf(beforeCast, entityId, origin) ?: return false
+            return isZoneVisibleTo(
+                state = beforeCast,
+                zoneKey = ZoneKey(ownerId, origin),
+                viewingPlayerId = viewingPlayerId,
+                isSpectator = isSpectator,
+            )
+        }
+
+        return isCardIdentityVisibleTo(
+            state = beforeCast,
+            zoneType = origin,
+            entityId = entityId,
+            viewingPlayerId = viewingPlayerId,
+            isSpectator = isSpectator,
+        )
+    }
+
+    /**
      * Whether [viewingPlayerId] may know the identity of [entityId] in [zoneKey].
      *
      * A hidden zone is not all-or-nothing: [RevealedToComponent] and top-of-library effects can
@@ -116,8 +167,13 @@ class Visibility(
             // zone." Exile therefore gets no controller baseline: a card put there by a plain
             // "exile face down" rider is hidden from its owner too. Only an effect that grants
             // access opens one, and every such effect names its grantee — see below.
-            if (zoneKey.zoneType != Zone.EXILE &&
-                playerWhoMayLookAtFaceDown(state, entityId) == viewingPlayerId
+            // Private state is projected to the connection currently acting for a seat as well as
+            // to the seat itself, matching hand/sideboard visibility above. Spectator projection
+            // has already returned false, so acting authority never leaks into the public view.
+            val playerWhoMayLook = playerWhoMayLookAtFaceDown(state, entityId)
+            if (zoneKey.zoneType != Zone.EXILE && playerWhoMayLook != null &&
+                (playerWhoMayLook == viewingPlayerId ||
+                    state.actorFor(playerWhoMayLook) == viewingPlayerId)
             ) return true
             if (isCardRevealedTo(state, entityId, viewingPlayerId)) return true
             if (zoneKey.zoneType == Zone.BATTLEFIELD &&

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbilityIdentityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbilityIdentityTest.kt
@@ -14,11 +14,13 @@ import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
-import com.wingedsheep.engine.state.components.stack.abilityIdentityOf
+import com.wingedsheep.engine.state.components.stack.triggerIdentityFromCurrentCardDefinition
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Deck
@@ -29,9 +31,11 @@ import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.AbilityIdentity
 import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.ClassLevelAbility
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.ReplaceLandManaColor
 import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import io.kotest.core.spec.style.FunSpec
@@ -96,6 +100,27 @@ class AbilityIdentityTest : FunSpec({
                 isManaAbility = true,
                 timing = TimingRule.ManaAbility,
             )
+        ),
+    )
+
+    val identityClass = CardDefinition.enchantment(
+        name = "Identity Class",
+        manaCost = ManaCost.parse("{1}"),
+        subtypes = setOf(Subtype.CLASS),
+        script = CardScript(
+            classLevels = listOf(
+                ClassLevelAbility(level = 2, cost = ManaCost.ZERO),
+            ),
+        ),
+    )
+
+    val intrinsicManaChoice = CardDefinition.enchantment(
+        name = "Intrinsic Mana Choice",
+        manaCost = ManaCost.parse("{1}"),
+        script = CardScript(
+            staticAbilities = listOf(
+                ReplaceLandManaColor(filter = GameObjectFilter.BasicLand.youControl()),
+            ),
         ),
     )
 
@@ -290,6 +315,47 @@ class AbilityIdentityTest : FunSpec({
         continuation.baseContext.activatedAbilityId shouldBe grantedId
     }
 
+    test("a generated Class level-up ability receives the current definition identity") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + identityClass)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val source = driver.putPermanentOnBattlefield(player, "Identity Class", classLevel = 1)
+        val levelUpId = AbilityId.classLevelUp(2)
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = source, abilityId = levelUpId)
+        ).isSuccess shouldBe true
+
+        val onStack = driver.state.getEntity(driver.state.stack.last())
+            ?.get<ActivatedAbilityOnStackComponent>()
+            .shouldNotBeNull()
+        onStack.abilityIdentity shouldBe AbilityIdentity("Identity Class", levelUpId)
+        onStack.activatedAbilityId shouldBe levelUpId
+    }
+
+    test("an intrinsic basic-land mana ability retains its id without definition identity") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + intrinsicManaChoice)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        driver.putPermanentOnBattlefield(player, "Intrinsic Mana Choice")
+        val forest = driver.putLandOnBattlefield(player, "Forest")
+        val intrinsicId = AbilityId.intrinsicMana(Color.GREEN.symbol)
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = forest, abilityId = intrinsicId)
+        ).isPaused shouldBe true
+
+        val continuation = driver.state.peekContinuation()
+            .shouldBeInstanceOf<ChooseManaColorContinuation>()
+        continuation.baseContext.abilityIdentity shouldBe null
+        continuation.baseContext.activatedAbilityId shouldBe intrinsicId
+    }
+
     test("triggered abilities from two copies of the same card share one AbilityIdentity") {
         val driver = GameTestDriver()
         driver.registerCards(TestCards.all + listOf(identityBear))
@@ -337,9 +403,9 @@ class AbilityIdentityTest : FunSpec({
         decision.context.abilityIdentity shouldBe identity
     }
 
-    test("abilityIdentityOf returns null for a source with no card definition") {
+    test("the transitional trigger identity derivation returns null without a card definition") {
         // A bare state with no entity for the given id has no CardComponent → no identity, no throw.
         val state = GameState(rng = GameRng.seeded(1L))
-        state.abilityIdentityOf(EntityId.of("ghost"), AbilityId("x")) shouldBe null
+        state.triggerIdentityFromCurrentCardDefinition(EntityId.of("ghost"), AbilityId("x")) shouldBe null
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbilityIdentityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbilityIdentityTest.kt
@@ -1,9 +1,16 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseManaColorContinuation
 import com.wingedsheep.engine.core.DecisionPhase
 import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.event.GrantedActivatedAbility
+import com.wingedsheep.engine.event.GrantedStaticAbility
 import com.wingedsheep.engine.handlers.DecisionHandler
+import com.wingedsheep.engine.handlers.effects.stack.CopyTargetSpellOrAbilityExecutor
+import com.wingedsheep.engine.mechanics.stack.StackResolver
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
@@ -22,9 +29,15 @@ import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.AbilityIdentity
 import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
  * Tests for the shared [AbilityIdentity] key (backlog/stack-collapse-and-batch-decisions.md §C.2).
@@ -32,7 +45,9 @@ import io.kotest.matchers.shouldBe
  * The key is the definition-scoped pair `(cardDefinitionId, abilityId)`. Its load-bearing property
  * — the one batch decisions and persistent yields both rely on — is that two permanents printed
  * from the same card produce the *same* identity for the same ability. These tests pin:
- *  - an activated ability on the stack carries its identity, and two copies of the card share it;
+ *  - a printed activated ability carries semantic identity plus its concrete routing id;
+ *  - runtime- and static-granted abilities retain only their concrete routing id;
+ *  - an activated stack copy preserves both identity fields;
  *  - a triggered ability on the stack carries its identity, and two copies share it;
  *  - the may-question decision raised for an ability carries the identity in its context;
  *  - the resolver returns null (rather than throwing) for a source with no card definition.
@@ -66,6 +81,24 @@ class AbilityIdentityTest : FunSpec({
         toughness = 2
     )
 
+    val printedManaAbilityId = AbilityId("test_printed_identity_mana")
+    val printedManaSource = CardDefinition.creature(
+        name = "Identity Mana Source",
+        manaCost = ManaCost.parse("{1}"),
+        subtypes = emptySet(),
+        power = 1,
+        toughness = 1,
+        script = CardScript.permanent(
+            ActivatedAbility(
+                id = printedManaAbilityId,
+                cost = AbilityCost.Free,
+                effect = Effects.AddAnyColorMana(1),
+                isManaAbility = true,
+                timing = TimingRule.ManaAbility,
+            )
+        ),
+    )
+
     test("an activated ability on the stack carries its AbilityIdentity, shared by two copies") {
         val driver = GameTestDriver()
         driver.registerCards(TestCards.all + listOf(identityPinger))
@@ -89,9 +122,172 @@ class AbilityIdentityTest : FunSpec({
         activatedOnStack.size shouldBe 2
 
         val expected = AbilityIdentity("Identity Pinger", pingerAbilityId)
-        activatedOnStack.forEach { it.abilityIdentity shouldBe expected }
+        activatedOnStack.forEach {
+            it.abilityIdentity shouldBe expected
+            it.activatedAbilityId shouldBe pingerAbilityId
+        }
         // The two copies share one identity — the property batch/yield grouping depends on.
         activatedOnStack[0].abilityIdentity shouldBe activatedOnStack[1].abilityIdentity
+    }
+
+    test("a runtime-granted activated ability keeps its concrete id without definition identity") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(identityBear))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val receiver = driver.putCreatureOnBattlefield(player, "Identity Bear")
+        val grantedId = AbilityId("runtime_granted_identity_test")
+        val grantedAbility = ActivatedAbility(
+            id = grantedId,
+            cost = AbilityCost.Free,
+            effect = Effects.GainLife(1),
+        )
+        driver.replaceState(
+            driver.state.copy(
+                grantedActivatedAbilities = driver.state.grantedActivatedAbilities +
+                    GrantedActivatedAbility(receiver, grantedAbility, Duration.Permanent),
+            )
+        )
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = receiver, abilityId = grantedId)
+        ).isSuccess shouldBe true
+
+        val onStack = driver.state.getEntity(driver.state.stack.last())
+            ?.get<ActivatedAbilityOnStackComponent>()
+            .shouldNotBeNull()
+        onStack.abilityIdentity shouldBe null
+        onStack.activatedAbilityId shouldBe grantedId
+    }
+
+    test("a flattened static-granted ability keeps its concrete id without definition identity") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(identityBear))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val granter = driver.putCreatureOnBattlefield(player, "Identity Bear")
+        val receiver = driver.putCreatureOnBattlefield(player, "Identity Bear")
+        val grantedId = AbilityId("flattened_static_granted_identity_test")
+        val grantedAbility = ActivatedAbility(
+            id = grantedId,
+            cost = AbilityCost.Free,
+            effect = Effects.GainLife(1),
+        )
+        driver.replaceState(
+            driver.state.copy(
+                // Model the flattened GrantStaticAbilityEffect store used after a runtime effect
+                // grants an ability-granting static to a permanent.
+                grantedStaticAbilities = driver.state.grantedStaticAbilities + GrantedStaticAbility(
+                    entityId = granter,
+                    ability = GrantActivatedAbility(
+                        ability = grantedAbility,
+                        filter = GroupFilter(GameObjectFilter.Creature.youControl()),
+                    ),
+                    duration = Duration.Permanent,
+                ),
+            )
+        )
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = receiver, abilityId = grantedId)
+        ).isSuccess shouldBe true
+
+        val onStack = driver.state.getEntity(driver.state.stack.last())
+            ?.get<ActivatedAbilityOnStackComponent>()
+            .shouldNotBeNull()
+        onStack.abilityIdentity shouldBe null
+        onStack.activatedAbilityId shouldBe grantedId
+    }
+
+    test("a copied activated stack object preserves semantic identity and concrete id") {
+        val stackEntityId = EntityId.of("original-activated-ability")
+        val originalController = EntityId.of("original-controller")
+        val copyController = EntityId.of("copy-controller")
+        val identity = AbilityIdentity("Identity Pinger", pingerAbilityId)
+        val component = ActivatedAbilityOnStackComponent(
+            sourceId = EntityId.of("ability-source"),
+            sourceName = "Identity Pinger",
+            controllerId = originalController,
+            effect = Effects.GainLife(1),
+            abilityIdentity = identity,
+            activatedAbilityId = pingerAbilityId,
+        )
+        val state = GameState(
+            rng = GameRng.seeded(2L),
+            entities = mapOf(stackEntityId to ComponentContainer.of(component)),
+            stack = listOf(stackEntityId),
+        )
+
+        val result = CopyTargetSpellOrAbilityExecutor.cloneAndPush(
+            state = state,
+            stackResolver = StackResolver(CardRegistry()),
+            abilityEntityId = stackEntityId,
+            controllerId = copyController,
+        )
+
+        result.isSuccess shouldBe true
+        val copied = result.newState.getEntity(result.newState.stack.last())
+            ?.get<ActivatedAbilityOnStackComponent>()
+            .shouldNotBeNull()
+        copied.controllerId shouldBe copyController
+        copied.abilityIdentity shouldBe identity
+        copied.activatedAbilityId shouldBe pingerAbilityId
+    }
+
+    test("a printed mana ability carries proven identity through off-stack resolution") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + printedManaSource)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val source = driver.putCreatureOnBattlefield(player, "Identity Mana Source")
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = source, abilityId = printedManaAbilityId)
+        ).error shouldBe null
+
+        val continuation = driver.state.peekContinuation()
+            .shouldBeInstanceOf<ChooseManaColorContinuation>()
+        continuation.baseContext.abilityIdentity shouldBe
+            AbilityIdentity("Identity Mana Source", printedManaAbilityId)
+        continuation.baseContext.activatedAbilityId shouldBe printedManaAbilityId
+    }
+
+    test("a runtime-granted mana ability carries routing id without fabricated identity") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + identityBear)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        val receiver = driver.putCreatureOnBattlefield(player, "Identity Bear")
+        val grantedId = AbilityId("runtime_granted_identity_mana")
+        val grantedAbility = ActivatedAbility(
+            id = grantedId,
+            cost = AbilityCost.Free,
+            effect = Effects.AddAnyColorMana(1),
+            isManaAbility = true,
+            timing = TimingRule.ManaAbility,
+        )
+        driver.replaceState(
+            driver.state.copy(
+                grantedActivatedAbilities = driver.state.grantedActivatedAbilities +
+                    GrantedActivatedAbility(receiver, grantedAbility, Duration.Permanent),
+            )
+        )
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = receiver, abilityId = grantedId)
+        ).error shouldBe null
+
+        val continuation = driver.state.peekContinuation()
+            .shouldBeInstanceOf<ChooseManaColorContinuation>()
+        continuation.baseContext.abilityIdentity shouldBe null
+        continuation.baseContext.activatedAbilityId shouldBe grantedId
     }
 
     test("triggered abilities from two copies of the same card share one AbilityIdentity") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbilityIdentityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbilityIdentityTest.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.core.ChooseManaColorContinuation
 import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.engineSerializersModule
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.event.GrantedActivatedAbility
 import com.wingedsheep.engine.event.GrantedStaticAbility
@@ -10,6 +11,7 @@ import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.effects.stack.CopyTargetSpellOrAbilityExecutor
 import com.wingedsheep.engine.mechanics.stack.StackResolver
 import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
@@ -37,7 +39,11 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantActivatedAbility
 import com.wingedsheep.sdk.scripting.ReplaceLandManaColor
 import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.EachPermanentBecomesCopyOfTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -228,6 +234,53 @@ class AbilityIdentityTest : FunSpec({
         onStack.activatedAbilityId shouldBe grantedId
     }
 
+    for (staticGrant in listOf(false, true)) {
+        test("a ${if (staticGrant) "static" else "runtime"} copy ability retains itself after its grant disappears") {
+            val driver = GameTestDriver()
+            driver.registerCards(TestCards.all + listOf(identityBear, identityPinger))
+            driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+            val player = driver.activePlayer!!
+            val receiver = driver.putCreatureOnBattlefield(player, "Identity Bear")
+            val target = driver.putCreatureOnBattlefield(player, "Identity Pinger")
+            val ability = ActivatedAbility(
+                id = AbilityId("retained_granted_copy"),
+                cost = AbilityCost.Free,
+                effect = EachPermanentBecomesCopyOfTargetEffect(
+                    target = EffectTarget.SpecificEntity(target),
+                    affected = EffectTarget.Self,
+                    retainActivatingAbility = true,
+                ),
+            )
+            driver.replaceState(if (staticGrant) {
+                driver.state.copy(grantedStaticAbilities = listOf(GrantedStaticAbility(
+                    entityId = receiver,
+                    ability = GrantActivatedAbility(ability, GroupFilter(GameObjectFilter.Creature.youControl())),
+                    duration = Duration.Permanent,
+                )))
+            } else {
+                driver.state.copy(grantedActivatedAbilities = listOf(
+                    GrantedActivatedAbility(receiver, ability, Duration.Permanent)
+                ))
+            })
+            driver.submit(ActivateAbility(player, receiver, ability.id)).isSuccess shouldBe true
+            driver.state.getEntity(driver.state.stack.last())
+                ?.get<ActivatedAbilityOnStackComponent>()?.abilityIdentity shouldBe null
+
+            // The resolving ability must be independent of the grant that supplied it.
+            driver.replaceState(driver.state.copy(
+                grantedActivatedAbilities = emptyList(),
+                grantedStaticAbilities = emptyList(),
+            ))
+            driver.bothPass()
+            driver.state.getEntity(receiver)
+                ?.get<CardComponent>()
+                ?.name shouldBe "Identity Pinger"
+            driver.state.grantedActivatedAbilities.single { it.entityId == receiver }.ability shouldBe ability
+            driver.submit(ActivateAbility(player, receiver, ability.id)).isSuccess shouldBe true
+        }
+    }
+
     test("a copied activated stack object preserves semantic identity and concrete id") {
         val stackEntityId = EntityId.of("original-activated-ability")
         val originalController = EntityId.of("original-controller")
@@ -239,7 +292,7 @@ class AbilityIdentityTest : FunSpec({
             controllerId = originalController,
             effect = Effects.GainLife(1),
             abilityIdentity = identity,
-            activatedAbilityId = pingerAbilityId,
+            activatedAbility = identityPinger.activatedAbilities.single(),
         )
         val state = GameState(
             rng = GameRng.seeded(2L),
@@ -261,6 +314,8 @@ class AbilityIdentityTest : FunSpec({
         copied.controllerId shouldBe copyController
         copied.abilityIdentity shouldBe identity
         copied.activatedAbilityId shouldBe pingerAbilityId
+        val json = Json { serializersModule = engineSerializersModule }
+        json.decodeFromString<ActivatedAbilityOnStackComponent>(json.encodeToString(copied)) shouldBe copied
     }
 
     test("a printed mana ability carries proven identity through off-stack resolution") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LookAtHandTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LookAtHandTest.kt
@@ -336,7 +336,7 @@ class LookAtHandTest : FunSpec({
         result.isSuccess shouldBe true
         val castEvent = result.events.filterIsInstance<SpellCastEvent>().single()
         castEvent.cardName shouldBe FACE_DOWN_DISPLAY_NAME
-        castEvent.semanticCardName shouldBe "Test Morph"
+        castEvent.underlyingCardName shouldBe "Test Morph"
         castEvent.cardPresentation?.nameFor(viewer) shouldBe FACE_DOWN_DISPLAY_NAME
         driver.state.getEntity(castMorph)?.get<RevealedToComponent>() shouldBe null
         driver.state.getEntity(otherMorph)?.get<RevealedToComponent>() shouldBe null

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LookAtHandTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LookAtHandTest.kt
@@ -3,6 +3,8 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.HandLookedAtEvent
 import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SpellCastEvent
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
@@ -332,6 +334,10 @@ class LookAtHandTest : FunSpec({
         )
 
         result.isSuccess shouldBe true
+        val castEvent = result.events.filterIsInstance<SpellCastEvent>().single()
+        castEvent.cardName shouldBe FACE_DOWN_DISPLAY_NAME
+        castEvent.semanticCardName shouldBe "Test Morph"
+        castEvent.cardPresentation?.nameFor(viewer) shouldBe FACE_DOWN_DISPLAY_NAME
         driver.state.getEntity(castMorph)?.get<RevealedToComponent>() shouldBe null
         driver.state.getEntity(otherMorph)?.get<RevealedToComponent>() shouldBe null
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/CardIdentityVisibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/CardIdentityVisibilityTest.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.engine.state.components.identity.ForetoldComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.state.components.player.HotseatControlComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.state.permissions.MayPlayPermission
@@ -205,6 +206,60 @@ class CardIdentityVisibilityTest : ScenarioTestBase() {
             visibility.isCardIdentityVisibleTo(
                 game.state, Zone.STACK, game.spell, game.opponent,
             ) shouldBe false
+        }
+
+        test("event presentation captures each stack viewer's visibility at event time") {
+            val game = faceDownGame()
+            // An explicit reveal grants this opponent access, while a spectator remains outside
+            // that private audience. The factory delegates the answer to Visibility rather than
+            // recoding revealed-to or face-down rules locally.
+            val revealed = game.state.updateEntity(game.spell) {
+                it.with(RevealedToComponent.to(game.opponent))
+            }
+            val presentation = EventPresentationFactory(visibility).castSpellIdentity(
+                beforeCast = revealed,
+                onStack = revealed,
+                castFromZone = null,
+                entityId = game.spell,
+                semanticName = "Hill Giant",
+            )
+
+            presentation.nameFor(game.controller) shouldBe "Hill Giant"
+            presentation.nameFor(game.opponent) shouldBe "Hill Giant"
+            presentation.nameFor(EntityId.of("spectator"), isSpectator = true) shouldBe
+                "Face-down creature"
+
+            val laterState = revealed.updateEntity(game.spell) { it.without<RevealedToComponent>() }
+            visibility.isCardIdentityVisibleTo(
+                laterState, Zone.STACK, game.spell, game.opponent,
+            ) shouldBe false
+            // Event projection never reconsiders a later state in which that reveal disappeared.
+            presentation.nameFor(game.opponent) shouldBe "Hill Giant"
+        }
+
+        test("event presentation includes the input actor controlling a face-down spell's seat") {
+            val game = faceDownGame()
+            val controlled = game.state.updateEntity(game.controller) {
+                it.with(HotseatControlComponent(controllerId = game.opponent))
+            }
+
+            withClue("the controlling connection receives the same private identity as the seat") {
+                visibility.isCardIdentityVisibleTo(
+                    controlled, Zone.STACK, game.spell, game.opponent,
+                ) shouldBe true
+            }
+
+            val presentation = EventPresentationFactory(visibility).castSpellIdentity(
+                beforeCast = controlled,
+                onStack = controlled,
+                castFromZone = null,
+                entityId = game.spell,
+                semanticName = "Hill Giant",
+            )
+            presentation.nameFor(game.controller) shouldBe "Hill Giant"
+            presentation.nameFor(game.opponent) shouldBe "Hill Giant"
+            presentation.nameFor(game.opponent, isSpectator = true) shouldBe
+                "Face-down creature"
         }
 
         // CR 708.5: "At any time, you may look at a face-down spell you control on the stack or a

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownGameLogMaskingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownGameLogMaskingTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.view
 
 import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.core.PaymentStrategy
 import com.wingedsheep.engine.core.EventCardPresentation
 import com.wingedsheep.engine.core.GameEvent
@@ -10,10 +11,15 @@ import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
 import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.state.components.battlefield.PhasedOutComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.EmblemActivatedAbilityComponent
+import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
 import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.nameVisibleToAll
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
 import com.wingedsheep.engine.state.permissions.MayPlayPermission
 import com.wingedsheep.engine.state.permissions.addMayPlayPermission
 import com.wingedsheep.engine.support.GameTestDriver
@@ -22,15 +28,27 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
 import com.wingedsheep.sdk.scripting.OpponentsPlayWithHandsRevealed
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.RevealTopOfLibrary
+import com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.targets.TargetCreature
 import io.kotest.assertions.withClue
+import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.collections.shouldNotContain
@@ -223,6 +241,119 @@ class FaceDownGameLogMaskingTest : FunSpec({
             FACE_DOWN_DISPLAY_NAME
     }
 
+    test("cast presentation retains public origin visibility that mana payment disables") {
+        val d = driver()
+        val caster = d.activePlayer!!
+        val opponent = d.getOpponent(caster)
+        val publicTopManaSource = card("Public Top Mana Source") {
+            manaCost = "{1}"
+            typeLine = "Artifact"
+            staticAbility { ability = CastSpellTypesFromTopOfLibrary(Filters.Creature) }
+            staticAbility {
+                ability = ConditionalStaticAbility(
+                    ability = RevealTopOfLibrary,
+                    condition = Conditions.SourceIsUntapped,
+                )
+            }
+            activatedAbility {
+                cost = Costs.Tap
+                effect = Effects.AddColorlessMana(3)
+                manaAbility = true
+            }
+        }
+        d.registerCard(publicTopManaSource)
+        val manaSource = d.putPermanentOnBattlefield(caster, publicTopManaSource.name)
+        val cardId = d.putCardOnTopOfLibrary(caster, disguisedAngel.name)
+        val visibility = Visibility(d.cardRegistry)
+        visibility.isCardIdentityVisibleTo(
+            d.state, Zone.LIBRARY, cardId, opponent, isSpectator = true,
+        ) shouldBe true
+
+        // The origin is public as casting begins. Paying for the spell then taps the only
+        // reveal source, so a snapshot taken after payment would incorrectly forget it.
+        val result = d.submitSuccess(
+            CastSpell(
+                playerId = caster,
+                cardId = cardId,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.Explicit(listOf(manaSource)),
+            )
+        )
+
+        val castEvent = result.events.filterIsInstance<SpellCastEvent>().single()
+        d.state.getEntity(manaSource)?.has<com.wingedsheep.engine.state.components.battlefield.TappedComponent>() shouldBe true
+        visibility.isCardIdentityVisibleTo(
+            d.state, Zone.STACK, cardId, opponent,
+        ) shouldBe false
+        castEvent.cardPresentation?.nameFor(opponent) shouldBe disguisedAngel.name
+        castEvent.cardPresentation?.nameFor(caster, isSpectator = true) shouldBe disguisedAngel.name
+        ClientEventTransformer.transform(listOf(castEvent), opponent)
+            .single().shouldBeInstanceOf<ClientEvent.SpellCast>().spellName shouldBe disguisedAngel.name
+    }
+
+    test("an emblem-granted activation does not reveal its face-down source in events or stack art") {
+        val d = driver()
+        val controller = d.activePlayer!!
+        val opponent = d.getOpponent(controller)
+        val hidden = d.putFaceDown(controller, disguisedAngel.name, FaceDownMode.DISGUISE)
+        d.removeSummoningSickness(hidden)
+        val hiddenImage = "https://example.test/disguised-angel.png"
+        d.replaceState(d.state.updateEntity(hidden) { container ->
+            container.with(container.get<CardComponent>()!!.copy(imageUri = hiddenImage))
+        })
+        val ability = ActivatedAbility(
+            id = AbilityId.generate(),
+            cost = Costs.Tap,
+            targetRequirements = listOf(AnyTarget()),
+            effect = Effects.DealDamage(DynamicAmounts.sourcePower(), EffectTarget.ContextTarget(0)),
+            descriptionOverride = "{T}: This creature deals damage equal to its power to any target.",
+        )
+        d.replaceState(d.state.withEntity(
+            EntityId.of("test-damage-emblem"),
+            ComponentContainer.of(
+                ControllerComponent(controller),
+                EmblemActivatedAbilityComponent(GroupFilter.AllCreaturesYouControl, listOf(ability)),
+            ),
+        ))
+
+        val result = d.submitSuccess(ActivateAbility(
+            playerId = controller,
+            sourceId = hidden,
+            abilityId = ability.id,
+            targets = listOf(ChosenTarget.Player(opponent)),
+        ))
+        val json = Json { serializersModule = engineSerializersModule }
+        val opponentEvents = json.encodeToString(ClientEventTransformer.transform(result.events, opponent))
+        val stackId = d.state.stack.last()
+        val transformer = ClientStateTransformer(d.cardRegistry)
+        val publicStackCards = listOf(
+            transformer.transform(d.state, opponent).cards.getValue(stackId),
+            transformer.transform(d.state, controller, isSpectator = true).cards.getValue(stackId),
+        )
+
+        val resolution = d.bothPass()
+        val resolutionEvents = json.encodeToString(ClientEventTransformer.transform(resolution.events, opponent))
+        val (_, untapEvents) = com.wingedsheep.engine.core.untapOrConsumeStun(d.state, hidden)
+        val publicUntapEvents = json.encodeToString(ClientEventTransformer.transform(untapEvents, opponent))
+
+        assertSoftly {
+            opponentEvents shouldNotContain disguisedAngel.name
+            resolutionEvents shouldNotContain disguisedAngel.name
+            publicUntapEvents shouldNotContain disguisedAngel.name
+            resolution.events.filterIsInstance<com.wingedsheep.engine.core.DamageDealtEvent>()
+                .single().amount shouldBe 2
+            publicStackCards.forEach { stackCard ->
+                stackCard.name shouldBe "Face-down creature ability"
+                stackCard.imageUri shouldBe null
+                stackCard.colors shouldBe emptySet()
+                stackCard.oracleText shouldNotContain disguisedAngel.name
+                stackCard.abilityIdentity shouldBe null
+                json.encodeToString(stackCard) shouldNotContain disguisedAngel.name
+                json.encodeToString(stackCard) shouldNotContain hiddenImage
+            }
+        }
+    }
+
     test("the ward a disguised permanent triggers is not attributed to the hidden card") {
         val d = driver()
         val activePlayer = d.activePlayer!!
@@ -231,6 +362,10 @@ class FaceDownGameLogMaskingTest : FunSpec({
         // The face-down permanent's ward {2} comes from disguise (CR 702.168a), not from any
         // printed ability — a face-down permanent has none (CR 708.2).
         val hidden = d.putFaceDown(opponent, "Disguised Angel", FaceDownMode.DISGUISE)
+        val hiddenImage = "https://example.test/disguised-angel-ward.png"
+        d.replaceState(d.state.updateEntity(hidden) { container ->
+            container.with(container.get<CardComponent>()!!.copy(imageUri = hiddenImage))
+        })
 
         // Exactly {R} for Bolt and nothing left for the ward, so it counters without a prompt.
         d.giveMana(activePlayer, Color.RED, 1)
@@ -238,6 +373,24 @@ class FaceDownGameLogMaskingTest : FunSpec({
         d.castSpellWithTargets(
             activePlayer, bolt, listOf(ChosenTarget.Permanent(hidden))
         ).isSuccess shouldBe true
+
+        val wardId = d.state.stack.single { id ->
+            d.state.getEntity(id)?.has<TriggeredAbilityOnStackComponent>() == true
+        }
+        val transformer = ClientStateTransformer(d.cardRegistry)
+        val publicWardCards = listOf(
+            transformer.transform(d.state, activePlayer).cards.getValue(wardId),
+            transformer.transform(d.state, opponent, isSpectator = true).cards.getValue(wardId),
+        )
+        assertSoftly {
+            publicWardCards.forEach { wardCard ->
+                wardCard.name shouldBe "Face-down creature trigger"
+                wardCard.imageUri shouldBe null
+                wardCard.colors shouldBe emptySet()
+                wardCard.oracleText shouldNotContain disguisedAngel.name
+                wardCard.abilityIdentity shouldBe null
+            }
+        }
 
         d.bothPass()
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownGameLogMaskingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownGameLogMaskingTest.kt
@@ -2,13 +2,20 @@ package com.wingedsheep.engine.view
 
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.EventCardPresentation
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.SpellCastEvent
+import com.wingedsheep.engine.core.engineSerializersModule
 import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
 import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.state.components.battlefield.PhasedOutComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.nameVisibleToAll
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.permissions.MayPlayPermission
+import com.wingedsheep.engine.state.permissions.addMayPlayPermission
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Color
@@ -20,6 +27,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.OpponentsPlayWithHandsRevealed
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.targets.TargetCreature
 import io.kotest.assertions.withClue
@@ -28,12 +36,15 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 /**
  * The game log must never print the name of a card that is face down on the battlefield.
  *
- * CR 708.2a: a face-down permanent has no name. The cast line was masked from the start, but the
- * three lines that follow it were not, so a disguised creature announced itself the moment it
+ * CR 708.2a: a face-down permanent has no name. The public cast line is masked, but the three
+ * lines that follow it were not, so a disguised creature announced itself the moment it
  * resolved:
  *
  * ```
@@ -44,14 +55,14 @@ import io.kotest.matchers.types.shouldBeInstanceOf
  * Opponent's Aurelia's Vindicator triggered: ... unless ... pays {2} <- leak
  * ```
  *
- * [ClientEventTransformer] cannot fix this downstream — it maps engine events to log text with no
- * `GameState` in hand, so it cannot tell a face-down permanent from a face-up one. Every one of
- * these is therefore masked where the event is emitted, in `StackResolver`.
+ * [ClientEventTransformer] cannot reconstruct a past audience from a later `GameState`. The cast
+ * event therefore carries a viewer-aware presentation captured by `StackResolver`; the remaining
+ * audience-agnostic events are masked where they are emitted.
  *
- * The mask applies to *both* players' logs, as the cast line already did: the object genuinely has
- * no name, and a controller who wants to know what their own face-down permanent is looks at the
- * card (CR 708.5) — [ClientStateTransformer] keeps the real name in their card view, which is what
- * [FaceDownHelperCardVisibilityTest] covers.
+ * The later events mask every player's log: the object genuinely has no name after it resolves.
+ * The cast event is viewer-aware instead, so its controller may read the card identity while an
+ * opponent cannot. [ClientStateTransformer] likewise keeps the real name in the controller's card
+ * view, which [FaceDownHelperCardVisibilityTest] covers.
  */
 class FaceDownGameLogMaskingTest : FunSpec({
 
@@ -78,9 +89,15 @@ class FaceDownGameLogMaskingTest : FunSpec({
         }
     }
 
+    val openThoughts = card("Open Thoughts") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        staticAbility { ability = OpponentsPlayWithHandsRevealed }
+    }
+
     fun driver(): GameTestDriver {
         val d = GameTestDriver()
-        d.registerCards(TestCards.all + listOf(disguisedAngel, tapper))
+        d.registerCards(TestCards.all + listOf(disguisedAngel, tapper, openThoughts))
         d.initMirrorMatch(deck = Deck.of("Swamp" to 40))
         d.passPriorityUntil(Step.PRECOMBAT_MAIN)
         return d
@@ -119,6 +136,13 @@ class FaceDownGameLogMaskingTest : FunSpec({
                 paymentStrategy = PaymentStrategy.FromPool,
             )
         )
+        val castEvent = d.events.filterIsInstance<SpellCastEvent>().single()
+        // Keep the historical public-name field safe while the trusted snapshot retains the
+        // semantic identity required by rules and knowledge code.
+        castEvent.cardName shouldBe FACE_DOWN_DISPLAY_NAME
+        castEvent.semanticCardName shouldBe "Disguised Angel"
+        castEvent.cardPresentation?.nameFor(caster) shouldBe "Disguised Angel"
+        castEvent.cardPresentation?.nameFor(opponent) shouldBe FACE_DOWN_DISPLAY_NAME
         d.bothPass()
 
         val opponentLog = d.logAsSeenBy(opponent)
@@ -130,9 +154,73 @@ class FaceDownGameLogMaskingTest : FunSpec({
 
         val casterLog = d.logAsSeenBy(caster)
         withClue("caster's own log: $casterLog") {
-            casterLog.forEach { it shouldNotContain "Disguised Angel" }
+            casterLog.contains("You cast Disguised Angel") shouldBe true
             casterLog.contains("Your Face-down creature entered the battlefield") shouldBe true
         }
+
+        // The event-time snapshot is authoritative even after the stack object has changed zones.
+        ClientEventTransformer.transform(listOf(castEvent), opponent)
+            .single().description shouldBe "Opponent cast Face-down creature"
+    }
+
+    test("a face-down cast from face-up exile retains its public identity") {
+        val d = driver()
+        val caster = d.activePlayer!!
+        val opponent = d.getOpponent(caster)
+        val cardId = d.putCardInExile(caster, "Disguised Angel")
+        d.replaceState(
+            d.state.addMayPlayPermission(
+                MayPlayPermission(
+                    id = EntityId.of("cast-disguised-angel-from-exile"),
+                    cardIds = setOf(cardId),
+                    controllerId = caster,
+                    timestamp = d.state.timestamp,
+                )
+            )
+        )
+        d.giveColorlessMana(caster, 3)
+
+        val result = d.submitSuccess(
+            CastSpell(
+                playerId = caster,
+                cardId = cardId,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+
+        val castEvent = result.events.filterIsInstance<SpellCastEvent>().single()
+        castEvent.cardName shouldBe FACE_DOWN_DISPLAY_NAME
+        castEvent.semanticCardName shouldBe "Disguised Angel"
+        castEvent.cardPresentation?.nameFor(caster) shouldBe "Disguised Angel"
+        castEvent.cardPresentation?.nameFor(opponent) shouldBe "Disguised Angel"
+        castEvent.cardPresentation?.nameFor(EntityId.of("spectator"), isSpectator = true) shouldBe
+            "Disguised Angel"
+        d.logAsSeenBy(opponent).any { it.contains("cast Disguised Angel") } shouldBe true
+    }
+
+    test("continuous hand visibility survives a face-down cast") {
+        val d = driver()
+        val caster = d.activePlayer!!
+        val opponent = d.getOpponent(caster)
+        d.putPermanentOnBattlefield(opponent, openThoughts.name)
+        val cardId = d.putCardInHand(caster, "Disguised Angel")
+        d.giveColorlessMana(caster, 3)
+
+        val result = d.submitSuccess(
+            CastSpell(
+                playerId = caster,
+                cardId = cardId,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+
+        val castEvent = result.events.filterIsInstance<SpellCastEvent>().single()
+        castEvent.cardPresentation?.nameFor(caster) shouldBe "Disguised Angel"
+        castEvent.cardPresentation?.nameFor(opponent) shouldBe "Disguised Angel"
+        castEvent.cardPresentation?.nameFor(EntityId.of("spectator"), isSpectator = true) shouldBe
+            FACE_DOWN_DISPLAY_NAME
     }
 
     test("the ward a disguised permanent triggers is not attributed to the hidden card") {
@@ -190,7 +278,10 @@ class FaceDownGameLogMaskingTest : FunSpec({
 
         val log = d.logAsSeenBy(caster)
         withClue("log: $log") {
-            log.forEach { it shouldNotContain "Disguised Angel" }
+            // The caster's own event-time cast line may name their spell; the counter's target
+            // description remains audience-agnostic and must not repeat that identity.
+            log.filterNot { it == "You cast Disguised Angel" }
+                .forEach { it shouldNotContain "Disguised Angel" }
             log.contains("Opponent cast Counterspell targeting Face-down creature") shouldBe true
         }
     }
@@ -317,5 +408,46 @@ class FaceDownGameLogMaskingTest : FunSpec({
             opponentLog.contains("Disguised Angel resolved") shouldBe true
             opponentLog.contains("Opponent's Disguised Angel entered the battlefield") shouldBe true
         }
+    }
+
+    test("spell-cast presentation round-trips and legacy events retain their safe stored names") {
+        val json = Json { serializersModule = engineSerializersModule }
+        val current: GameEvent = SpellCastEvent(
+            spellEntityId = EntityId.of("spell"),
+            cardName = FACE_DOWN_DISPLAY_NAME,
+            casterId = EntityId.of("caster"),
+            cardPresentation = EventCardPresentation(
+                semanticName = "Disguised Angel",
+                publicName = FACE_DOWN_DISPLAY_NAME,
+                identityViewers = setOf(EntityId.of("caster")),
+            ),
+        )
+        json.decodeFromString<GameEvent>(json.encodeToString(current)) shouldBe current
+
+        // The raw event is trusted multi-recipient data. The transport-facing event contains only
+        // the one projected label and cannot carry the underlying identity or its audience set.
+        val opponentEvent: ClientEvent = ClientEventTransformer.transform(
+            listOf(current), EntityId.of("opponent")
+        ).single()
+        val encodedOpponentEvent = json.encodeToString(opponentEvent)
+        encodedOpponentEvent shouldNotContain "Disguised Angel"
+        encodedOpponentEvent shouldNotContain "identityViewers"
+
+        // Before viewer-specific capture, cardName was already the event-time public name. Keep
+        // ordinary face-up history readable and preserve the generic name stored for face-down
+        // casts rather than treating both legacy shapes as hidden.
+        val legacyFaceUp = """{"type":"SpellCastEvent","spellEntityId":"face-up","cardName":"Disguised Angel","casterId":"caster"}"""
+        val decodedFaceUp = json.decodeFromString<GameEvent>(legacyFaceUp) as SpellCastEvent
+        decodedFaceUp.cardPresentation shouldBe null
+        ClientEventTransformer.transform(listOf(decodedFaceUp), EntityId.of("opponent"))
+            .filterIsInstance<ClientEvent.SpellCast>()
+            .single().spellName shouldBe "Disguised Angel"
+
+        val legacyFaceDown = """{"type":"SpellCastEvent","spellEntityId":"face-down","cardName":"Face-down creature","casterId":"caster"}"""
+        val decodedFaceDown = json.decodeFromString<GameEvent>(legacyFaceDown) as SpellCastEvent
+        decodedFaceDown.cardPresentation shouldBe null
+        ClientEventTransformer.transform(listOf(decodedFaceDown), EntityId.of("opponent"))
+            .filterIsInstance<ClientEvent.SpellCast>()
+            .single().spellName shouldBe FACE_DOWN_DISPLAY_NAME
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownGameLogMaskingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownGameLogMaskingTest.kt
@@ -138,9 +138,9 @@ class FaceDownGameLogMaskingTest : FunSpec({
         )
         val castEvent = d.events.filterIsInstance<SpellCastEvent>().single()
         // Keep the historical public-name field safe while the trusted snapshot retains the
-        // semantic identity required by rules and knowledge code.
+        // underlying identity required by knowledge bookkeeping.
         castEvent.cardName shouldBe FACE_DOWN_DISPLAY_NAME
-        castEvent.semanticCardName shouldBe "Disguised Angel"
+        castEvent.underlyingCardName shouldBe "Disguised Angel"
         castEvent.cardPresentation?.nameFor(caster) shouldBe "Disguised Angel"
         castEvent.cardPresentation?.nameFor(opponent) shouldBe FACE_DOWN_DISPLAY_NAME
         d.bothPass()
@@ -191,7 +191,7 @@ class FaceDownGameLogMaskingTest : FunSpec({
 
         val castEvent = result.events.filterIsInstance<SpellCastEvent>().single()
         castEvent.cardName shouldBe FACE_DOWN_DISPLAY_NAME
-        castEvent.semanticCardName shouldBe "Disguised Angel"
+        castEvent.underlyingCardName shouldBe "Disguised Angel"
         castEvent.cardPresentation?.nameFor(caster) shouldBe "Disguised Angel"
         castEvent.cardPresentation?.nameFor(opponent) shouldBe "Disguised Angel"
         castEvent.cardPresentation?.nameFor(EntityId.of("spectator"), isSpectator = true) shouldBe


### PR DESCRIPTION
Face-down cast logs now preserve the identity each viewer was entitled to know when casting began, and activated abilities retain their execution provenance without claiming they belong to the receiving card’s printed definition. This combines huxinq’s #2233 and #2234 on `main`, preserving the original commits and the Arlinn emblem and repeated Likeness Looter activation fixes.

Review fixes included:

- Close the combined face-down/emblem activation leak: activation, tap/untap, and damage labels use the public source name, and activated/triggered stack DTOs consult visibility before showing the source image or definition identity. Battlefield source colors come from projection. Regressions inspect opponent and spectator payloads for an emblem-granted activation through damage resolution and untapping, plus disguise ward.
- Capture cast-origin visibility before paying costs. If payment taps or removes a reveal source, a previously public card still has the correct public cast log. The event stores only the compact audience snapshot.
- Carry the concrete activated ability through the stack and effect context, deriving its ID from that snapshot. “Retain this ability” still works after a runtime or static grant disappears; resolution no longer tries to reconstruct the ability from the receiver’s current definition.
- Add regressions for both disappearing-grant paths, visibility lost during mana payment, and activated-stack snapshot serialization. Update the SDK reference alongside the provenance contract.

The review retained the shared grant resolver and immutable event presentation design; neither change adds card-specific SDK primitives. Triggered-ability ownership and the already-documented modal/ChooseAction context follow-up remain outside these two contributions. Event masking also does not rotate entity IDs; the existing state-delta correlation limitation described in #2233 remains.

Validation:

- `just test-rules` — 13,360 passed, no failures or skips.
- `just test-server` — 534 passed, 13 skipped (benchmarks, opt-in replay reproductions, and database migration tests).
- `just test-class FaceDownGameLogMaskingTest` — 14 passed, including the complete emblem activation/transport regression.
- `git diff --check origin/main` — clean.

The two disappearing-grant regressions failed against the imported implementation before the snapshot fix. The full transport regression also exposed the tap-cost event leak before the shared naming fix. No manual browser run was performed; viewer-specific client DTO and serialized event assertions cover the transport changes.
