### PR TITLE
Avoid per-card entity-map copies when constructing hidden worlds

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
@@ -92,10 +92,13 @@ class Determinizer internal constructor(
             }
 
             if (definitions.size != hidden.size) continue
+            // No caller observes intermediate identities. Copy once for this player and publish
+            // only after all replacements, without mutating an input or previously sampled world.
+            val sampledEntities = sampled.entities.toMutableMap()
             for ((entityId, cardDef) in hidden.zip(definitions)) {
-                val old = sampled.getEntity(entityId) ?: continue
+                val old = sampledEntities[entityId] ?: continue
                 val ownerId = old.get<OwnerComponent>()?.playerId ?: opponentId
-                sampled = HiddenSlotRewrite.rewrite(sampled, entityId, cardDef, ownerId)
+                sampledEntities[entityId] = HiddenSlotRewrite.rewrite(old, cardDef, ownerId)
             }
 
             val libraryKey = ZoneKey(opponentId, Zone.LIBRARY)
@@ -107,7 +110,10 @@ class Determinizer internal constructor(
             val shuffledLibrary = library.map { id ->
                 if (id in hiddenLibraryIds) iterator.next() else id
             }
-            sampled = sampled.copy(zones = sampled.zones + (libraryKey to shuffledLibrary))
+            sampled = sampled.copy(
+                entities = sampledEntities,
+                zones = sampled.zones + (libraryKey to shuffledLibrary),
+            )
         }
         return sampled
     }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.engine.view.Visibility
 import com.wingedsheep.sdk.model.GameRng
+import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
@@ -21,6 +22,52 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 class DeterminizerInvariantsTest : ScenarioTestBase() {
 
     init {
+        test("sampling retains the pre-batching assignment and library sequence") {
+            val game = scenario().withPlayers().withRngSeed(883L)
+                .withCardInHand(1, "Forest")
+                .withCardInLibrary(1, "Mountain").withCardInLibrary(1, "Hill Giant")
+                .withCardInHand(2, "Mountain").withCardInHand(2, "Hill Giant")
+                .withCardInLibrary(2, "Grizzly Bears").withCardInLibrary(2, "Craw Wurm")
+                .build()
+            val revealed = game.state.getHand(game.player2Id).first()
+            val before = game.state.updateEntity(revealed) { it.with(RevealedToComponent.to(game.player1Id)) }
+            val originalEntities = before.entities.toMap()
+            val originalZones = before.zones.mapValues { it.value.toList() }
+            val models = listOf(
+                emptyMap<EntityId, OpponentModel>(),
+                mapOf(
+                    game.player1Id to OpponentModel.KnownDecklist(
+                        mapOf("Forest" to 1, "Mountain" to 1, "Hill Giant" to 1),
+                    ),
+                    game.player2Id to OpponentModel.KnownDecklist(
+                        mapOf("Mountain" to 1, "Hill Giant" to 1, "Grizzly Bears" to 1, "Craw Wurm" to 1),
+                    ),
+                ),
+            )
+            val sampler = Determinizer(cardRegistry)
+            val signature = buildString {
+                for (model in models) for (viewer in before.turnOrder) for (seed in 1L..16L) {
+                    val world = sampler.sample(before, viewer, model, GameRng.seeded(seed))
+                    world.copy(entities = before.entities, zones = before.zones) shouldBe before
+                    before.entities shouldBe originalEntities
+                    before.zones shouldBe originalZones
+                    world.getEntity(revealed) shouldBe before.getEntity(revealed)
+                    append(viewer.value).append('/').append(seed).append(':')
+                    world.entities.forEach { (id, components) ->
+                        append(id.value).append('=').append(components.get<CardComponent>()?.name).append(';')
+                    }
+                    append(world.zones).append('\n')
+                    val retainedEntities = world.entities.toMap()
+                    sampler.sample(world, viewer, model, GameRng.seeded(seed + 100))
+                    world.entities shouldBe retainedEntities
+                }
+            }
+            // Captured from the per-card-copy implementation at upstream 12589ae4a2.
+            java.security.MessageDigest.getInstance("SHA-256").digest(signature.toByteArray())
+                .joinToString("") { "%02x".format(it) } shouldBe
+                "fe26af39d1fb97c30edbebf726115360a34a390af7d4c15e9c00a80b3ca8620b"
+        }
+
         test("sampling preserves structure and everything visible to the viewer") {
             val game = scenario()
                 .withPlayers()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
@@ -154,10 +154,21 @@ object HiddenSlotRewrite {
         ownerId: EntityId,
     ): GameState {
         val source = state.getEntity(entityId) ?: return state
+        return state.withEntity(entityId, rewrite(source, definition, ownerId))
+    }
+
+    /**
+     * The container-only form lets callers batch several rewrites into one entity-map copy.
+     * As with the state form, callers must first clear [runtimeBlockers] for the source slot.
+     */
+    fun rewrite(
+        source: ComponentContainer,
+        definition: CardDefinition,
+        ownerId: EntityId,
+    ): ComponentContainer {
         val rebuilt = CardEntityFactory.create(definition, ownerId)
-        val withController = source.get<ControllerComponent>()
+        return source.get<ControllerComponent>()
             ?.let { rebuilt.with(it) }
             ?: rebuilt.without<ControllerComponent>()
-        return state.withEntity(entityId, withController)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -113,7 +113,8 @@ class HiddenWorldMaterializer internal constructor(
                 )
             }
         }
-        var materialized = state
+        // Accumulate privately: validation still reads the source, and a refusal publishes nothing.
+        val materializedEntities = state.entities.toMutableMap()
 
         // Slots are independent, so the order only decides *which* obstruction is reported when a
         // request has several. Sorting makes that report stable across equal requests.
@@ -199,11 +200,11 @@ class HiddenWorldMaterializer internal constructor(
                     listOf("replacement definition is not registered: $replacementDefinitionId"),
                 )
             }
-            materialized = HiddenSlotRewrite.rewrite(materialized, entityId, replacementDefinition, ownerId)
+            materializedEntities[entityId] = HiddenSlotRewrite.rewrite(container, replacementDefinition, ownerId)
         }
 
         return HiddenWorldMaterializationResult.Materialized(
-            materialized.copy(rng = request.futureRng)
+            state.copy(entities = materializedEntities, rng = request.futureRng)
         )
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -113,6 +113,9 @@ class HiddenWorldMaterializer internal constructor(
                 )
             }
         }
+        if (request.slotAssignments.isEmpty()) {
+            return HiddenWorldMaterializationResult.Materialized(state.copy(rng = request.futureRng))
+        }
         // Accumulate privately: validation still reads the source, and a refusal publishes nothing.
         val materializedEntities = state.entities.toMutableMap()
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -453,6 +453,7 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
 
             world shouldBe source.copy(rng = futureRng)
+            (world.entities === source.entities) shouldBe true
         }
 
         test("a paused continuation consumes the caller RNG only when its later shuffle executes") {
@@ -560,6 +561,10 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
 
             result.reason.kind shouldBe UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES
             result.reason.entityId shouldBe null
+            rejectingMaterializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(emptyMap(), GameRng.seeded(619L)),
+            ) shouldBe result
             result.reason.details shouldContain "could not traverse pending decision test: forced"
             cardName(source, handId) shouldBe "Grizzly Bears"
             cardName(source, libraryId) shouldBe "Forest"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -123,6 +123,7 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             val assignedIds = listOf(hiddenHandId) + hiddenLibraryIds
             val source = game.state
                 .copy(lastCardDrawnThisTurnByPlayer = mapOf(game.player2Id to hiddenHandId))
+            val sourceEntities = source.entities.toMap()
             val futureRng = GameRng.seeded(202L)
 
             val result = materializer.materialize(
@@ -159,7 +160,42 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             }
             withClue("materialization is purely functional") {
                 game.state.getEntity(hiddenHandId)?.get<CardComponent>()?.name shouldBe "Grizzly Bears"
+                source.entities shouldBe sourceEntities
+                world.entities.keys.toList() shouldBe source.entities.keys.toList()
+                val retainedEntities = world.entities.toMap()
+                materializer.materialize(
+                    world,
+                    HiddenWorldMaterializationRequest(
+                        assignedIds.associateWith { cardRegistry.requireCard("Swamp") },
+                        GameRng.seeded(203L),
+                    ),
+                ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>()
+                world.entities shouldBe retainedEntities
             }
+        }
+
+        test("a refusal after a valid slot leaves the entire input world unchanged") {
+            val game = scenario().withPlayers()
+                .withCardInLibrary(2, "Forest").withCardInLibrary(2, "Mountain")
+                .build()
+            val ids = game.state.getLibrary(game.player2Id).sortedBy { it.value }
+            val source = game.state.updateEntity(ids.last()) {
+                it.with(RevealedToComponent.to(game.player1Id))
+            }
+            val originalEntities = source.entities.toMap()
+            val originalRng = source.rng
+            val result = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    ids.associateWith { cardRegistry.requireCard("Island") },
+                    GameRng.seeded(204L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.RUNTIME_STATE
+            result.reason.entityId shouldBe ids.last()
+            source.entities shouldBe originalEntities
+            source.rng shouldBe originalRng
         }
 
         test("caller-generated assignments are reproducible and do not consume source randomness") {


### PR DESCRIPTION
Hidden-world construction currently copies the entire entity map for each rewritten card. A world with dozens of hidden slots therefore rebuilds the same map dozens of times before any caller can observe the result, adding allocation to repeated search sampling.

In MTGallium's earlier strict known-deck sampler, the same batching strategy produced **3.45× as many samples per unit of thread CPU**, with **69% less allocation**:

| Mean cost per sampled world | Per-card copies | Batched copies | Reduction |
| --- | ---: | ---: | ---: |
| Thread CPU time | 306.95 µs | 88.85 µs | 71.1% |
| Allocated bytes | 1,025,524 | 316,209 | 69.2% |

This comparison used one fixed initial state in one JVM, 1,000 warmup calls per variant, then 10 old/new/new/old rounds with 100 calls per batch: 2,000 measured calls per variant. All 64 parity-check worlds matched exactly. These measurements illustrate the benefit in the earlier sampler; they measure local sampling cost, and have not been repeated on this upstream port or established as an end-to-end search speedup.

Batch the replacements into a private map and publish one immutable state after the batch: once per player in `Determinizer`, and once per request in `HiddenWorldMaterializer`. A container-level overload of `HiddenSlotRewrite.rewrite` keeps the existing card reconstruction and controller-preservation logic shared with the single-slot API.

Sampling choices, RNG use, entity iteration order, and library shuffling retain their existing behavior. Explicit materialization still validates against the original state in sorted slot order and returns the first refusal without publishing a partial world. Empty assignments retain the original entity map after the in-flight completeness check.

Verification: all 28 tests passed across the three focused suites on `55674a017f`. All 14 materializer tests passed again after the empty-assignment fast path was added in `47edcee60d`, including map reuse and unchanged refusal for an incomplete in-flight graph.

```sh
just test-class DeterminizerInvariantsTest :rules-engine:test \
  --tests '*HiddenSlotRewriteTest' --tests '*HiddenWorldMaterializerTest'
```

The sampler regression matches a fingerprint captured from upstream `12589ae4a2` across 64 cases covering identity permutation, known decklists, both viewers, and 16 seeds. The materializer regressions cover input and returned-world immutability, entity iteration order, and refusal after an earlier valid assignment; the existing suites exercise visibility, in-flight pins, controller absence, slot preservation, and future RNG installation.


