### PR TITLE
Analyze in-flight pins once per sampled position

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
@@ -92,10 +92,13 @@ class Determinizer internal constructor(
             }
 
             if (definitions.size != hidden.size) continue
+            // No caller observes intermediate identities. Copy once for this player and publish
+            // only after all replacements, without mutating an input or previously sampled world.
+            val sampledEntities = sampled.entities.toMutableMap()
             for ((entityId, cardDef) in hidden.zip(definitions)) {
-                val old = sampled.getEntity(entityId) ?: continue
+                val old = sampledEntities[entityId] ?: continue
                 val ownerId = old.get<OwnerComponent>()?.playerId ?: opponentId
-                sampled = HiddenSlotRewrite.rewrite(sampled, entityId, cardDef, ownerId)
+                sampledEntities[entityId] = HiddenSlotRewrite.rewrite(old, cardDef, ownerId)
             }
 
             val libraryKey = ZoneKey(opponentId, Zone.LIBRARY)
@@ -107,7 +110,10 @@ class Determinizer internal constructor(
             val shuffledLibrary = library.map { id ->
                 if (id in hiddenLibraryIds) iterator.next() else id
             }
-            sampled = sampled.copy(zones = sampled.zones + (libraryKey to shuffledLibrary))
+            sampled = sampled.copy(
+                entities = sampledEntities,
+                zones = sampled.zones + (libraryKey to shuffledLibrary),
+            )
         }
         return sampled
     }

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
@@ -70,13 +70,20 @@ class Determinizer internal constructor(
         rng: GameRng,
         fallback: OpponentModel = OpponentModel.IdentityPermutation,
     ): GameState {
+        if (state.turnOrder.isEmpty()) return state
+        // Every player is sampled from this same source position, so analyze its references once.
+        val inFlightPins = when (val pins = inFlightPinAnalysis(state)) {
+            is HiddenSlotRewrite.IdentitySensitiveInFlightPins.Complete -> pins.entityIds
+            // An incomplete traversal cannot justify sampling any hidden identity.
+            is HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete -> return state
+        }
         var sampled = state
         var currentRng = rng
 
         // Even the viewer's own library order is hidden. Teammate hands are visible, but teammate
         // libraries are not. Walk every player and let Visibility decide which cards are hidden.
         for (opponentId in state.turnOrder) {
-            val hidden = hiddenCards(state, opponentId, viewerId)
+            val hidden = hiddenCards(state, opponentId, viewerId, inFlightPins)
             if (hidden.isEmpty()) continue
 
             val definitions = when (val model = models[opponentId] ?: fallback) {
@@ -122,17 +129,12 @@ class Determinizer internal constructor(
         state: GameState,
         opponentId: EntityId,
         viewerId: EntityId,
+        inFlightPins: Set<EntityId>,
     ): List<EntityId> {
         val handKey = ZoneKey(opponentId, Zone.HAND)
         val libraryKey = ZoneKey(opponentId, Zone.LIBRARY)
         val library = state.getLibrary(opponentId)
         val candidates = library + state.getHand(opponentId)
-        val inFlightPins = when (val pins = inFlightPinAnalysis(state)) {
-            is HiddenSlotRewrite.IdentitySensitiveInFlightPins.Complete -> pins.entityIds
-            // An incomplete traversal cannot justify sampling any hidden identity. HWM rejects the
-            // corresponding all-or-nothing request; sampling instead keeps every candidate slot.
-            is HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete -> return emptyList()
-        }
         return candidates.filter { id ->
             val zoneKey = if (id in library) libraryKey else handKey
             !visibility.isCardIdentityVisibleTo(state, zoneKey, id, viewerId) &&

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.engine.view.Visibility
 import com.wingedsheep.sdk.model.GameRng
+import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
@@ -21,6 +22,52 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 class DeterminizerInvariantsTest : ScenarioTestBase() {
 
     init {
+        test("sampling retains the pre-batching assignment and library sequence") {
+            val game = scenario().withPlayers().withRngSeed(883L)
+                .withCardInHand(1, "Forest")
+                .withCardInLibrary(1, "Mountain").withCardInLibrary(1, "Hill Giant")
+                .withCardInHand(2, "Mountain").withCardInHand(2, "Hill Giant")
+                .withCardInLibrary(2, "Grizzly Bears").withCardInLibrary(2, "Craw Wurm")
+                .build()
+            val revealed = game.state.getHand(game.player2Id).first()
+            val before = game.state.updateEntity(revealed) { it.with(RevealedToComponent.to(game.player1Id)) }
+            val originalEntities = before.entities.toMap()
+            val originalZones = before.zones.mapValues { it.value.toList() }
+            val models = listOf(
+                emptyMap<EntityId, OpponentModel>(),
+                mapOf(
+                    game.player1Id to OpponentModel.KnownDecklist(
+                        mapOf("Forest" to 1, "Mountain" to 1, "Hill Giant" to 1),
+                    ),
+                    game.player2Id to OpponentModel.KnownDecklist(
+                        mapOf("Mountain" to 1, "Hill Giant" to 1, "Grizzly Bears" to 1, "Craw Wurm" to 1),
+                    ),
+                ),
+            )
+            val sampler = Determinizer(cardRegistry)
+            val signature = buildString {
+                for (model in models) for (viewer in before.turnOrder) for (seed in 1L..16L) {
+                    val world = sampler.sample(before, viewer, model, GameRng.seeded(seed))
+                    world.copy(entities = before.entities, zones = before.zones) shouldBe before
+                    before.entities shouldBe originalEntities
+                    before.zones shouldBe originalZones
+                    world.getEntity(revealed) shouldBe before.getEntity(revealed)
+                    append(viewer.value).append('/').append(seed).append(':')
+                    world.entities.forEach { (id, components) ->
+                        append(id.value).append('=').append(components.get<CardComponent>()?.name).append(';')
+                    }
+                    append(world.zones).append('\n')
+                    val retainedEntities = world.entities.toMap()
+                    sampler.sample(world, viewer, model, GameRng.seeded(seed + 100))
+                    world.entities shouldBe retainedEntities
+                }
+            }
+            // Captured from the per-card-copy implementation at upstream 12589ae4a2.
+            java.security.MessageDigest.getInstance("SHA-256").digest(signature.toByteArray())
+                .joinToString("") { "%02x".format(it) } shouldBe
+                "fe26af39d1fb97c30edbebf726115360a34a390af7d4c15e9c00a80b3ca8620b"
+        }
+
         test("sampling preserves structure and everything visible to the viewer") {
             val game = scenario()
                 .withPlayers()

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
@@ -302,7 +302,9 @@ class DeterminizerInvariantsTest : ScenarioTestBase() {
             val candidateIdentities = candidateIds.associateWith {
                 source.getEntity(it)!!.require<CardComponent>()
             }
+            var analyses = 0
             val determinizer = Determinizer(cardRegistry, Visibility(cardRegistry)) {
+                analyses++
                 HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete("forced for test")
             }
 
@@ -317,6 +319,38 @@ class DeterminizerInvariantsTest : ScenarioTestBase() {
                 sampled.getEntity(entityId)!!.require<CardComponent>() shouldBe identity
             }
             sampled shouldBe source
+            analyses shouldBe 1
+        }
+
+        test("in-flight references are analyzed once for all players in a sample") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInHand(2, "Grizzly Bears")
+                .withCardInLibrary(2, "Hill Giant")
+                .build()
+            var analyses = 0
+            val determinizer = Determinizer(cardRegistry, Visibility(cardRegistry)) { state ->
+                analyses++
+                HiddenSlotRewrite.identitySensitiveInFlightPins(state)
+            }
+            val rng = GameRng.seeded(914L)
+
+            determinizer.sample(game.state, game.player1Id, OpponentModel.IdentityPermutation, rng) shouldBe
+                Determinizer(cardRegistry).sample(game.state, game.player1Id, OpponentModel.IdentityPermutation, rng)
+            analyses shouldBe 1
+        }
+
+        test("a position without players does not analyze in-flight references") {
+            val game = scenario().withPlayers().build()
+            val source = game.state.copy(turnOrder = emptyList())
+            val determinizer = Determinizer(cardRegistry, Visibility(cardRegistry)) {
+                error("There are no players to sample")
+            }
+
+            (determinizer.sample(source, game.player1Id, OpponentModel.IdentityPermutation, GameRng.seeded(915L)) ===
+                source) shouldBe true
         }
 
         test("the viewer does not retain knowledge of their own library order") {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
@@ -154,10 +154,21 @@ object HiddenSlotRewrite {
         ownerId: EntityId,
     ): GameState {
         val source = state.getEntity(entityId) ?: return state
+        return state.withEntity(entityId, rewrite(source, definition, ownerId))
+    }
+
+    /**
+     * The container-only form lets callers batch several rewrites into one entity-map copy.
+     * As with the state form, callers must first clear [runtimeBlockers] for the source slot.
+     */
+    fun rewrite(
+        source: ComponentContainer,
+        definition: CardDefinition,
+        ownerId: EntityId,
+    ): ComponentContainer {
         val rebuilt = CardEntityFactory.create(definition, ownerId)
-        val withController = source.get<ControllerComponent>()
+        return source.get<ControllerComponent>()
             ?.let { rebuilt.with(it) }
             ?: rebuilt.without<ControllerComponent>()
-        return state.withEntity(entityId, withController)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -113,7 +113,8 @@ class HiddenWorldMaterializer internal constructor(
                 )
             }
         }
-        var materialized = state
+        // Accumulate privately: validation still reads the source, and a refusal publishes nothing.
+        val materializedEntities = state.entities.toMutableMap()
 
         // Slots are independent, so the order only decides *which* obstruction is reported when a
         // request has several. Sorting makes that report stable across equal requests.
@@ -199,11 +200,11 @@ class HiddenWorldMaterializer internal constructor(
                     listOf("replacement definition is not registered: $replacementDefinitionId"),
                 )
             }
-            materialized = HiddenSlotRewrite.rewrite(materialized, entityId, replacementDefinition, ownerId)
+            materializedEntities[entityId] = HiddenSlotRewrite.rewrite(container, replacementDefinition, ownerId)
         }
 
         return HiddenWorldMaterializationResult.Materialized(
-            materialized.copy(rng = request.futureRng)
+            state.copy(entities = materializedEntities, rng = request.futureRng)
         )
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -113,6 +113,9 @@ class HiddenWorldMaterializer internal constructor(
                 )
             }
         }
+        if (request.slotAssignments.isEmpty()) {
+            return HiddenWorldMaterializationResult.Materialized(state.copy(rng = request.futureRng))
+        }
         // Accumulate privately: validation still reads the source, and a refusal publishes nothing.
         val materializedEntities = state.entities.toMutableMap()
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -453,6 +453,7 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
 
             world shouldBe source.copy(rng = futureRng)
+            (world.entities === source.entities) shouldBe true
         }
 
         test("a paused continuation consumes the caller RNG only when its later shuffle executes") {
@@ -560,6 +561,10 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
 
             result.reason.kind shouldBe UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES
             result.reason.entityId shouldBe null
+            rejectingMaterializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(emptyMap(), GameRng.seeded(619L)),
+            ) shouldBe result
             result.reason.details shouldContain "could not traverse pending decision test: forced"
             cardName(source, handId) shouldBe "Grizzly Bears"
             cardName(source, libraryId) shouldBe "Forest"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -123,6 +123,7 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             val assignedIds = listOf(hiddenHandId) + hiddenLibraryIds
             val source = game.state
                 .copy(lastCardDrawnThisTurnByPlayer = mapOf(game.player2Id to hiddenHandId))
+            val sourceEntities = source.entities.toMap()
             val futureRng = GameRng.seeded(202L)
 
             val result = materializer.materialize(
@@ -159,7 +160,42 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             }
             withClue("materialization is purely functional") {
                 game.state.getEntity(hiddenHandId)?.get<CardComponent>()?.name shouldBe "Grizzly Bears"
+                source.entities shouldBe sourceEntities
+                world.entities.keys.toList() shouldBe source.entities.keys.toList()
+                val retainedEntities = world.entities.toMap()
+                materializer.materialize(
+                    world,
+                    HiddenWorldMaterializationRequest(
+                        assignedIds.associateWith { cardRegistry.requireCard("Swamp") },
+                        GameRng.seeded(203L),
+                    ),
+                ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>()
+                world.entities shouldBe retainedEntities
             }
+        }
+
+        test("a refusal after a valid slot leaves the entire input world unchanged") {
+            val game = scenario().withPlayers()
+                .withCardInLibrary(2, "Forest").withCardInLibrary(2, "Mountain")
+                .build()
+            val ids = game.state.getLibrary(game.player2Id).sortedBy { it.value }
+            val source = game.state.updateEntity(ids.last()) {
+                it.with(RevealedToComponent.to(game.player1Id))
+            }
+            val originalEntities = source.entities.toMap()
+            val originalRng = source.rng
+            val result = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    ids.associateWith { cardRegistry.requireCard("Island") },
+                    GameRng.seeded(204L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.RUNTIME_STATE
+            result.reason.entityId shouldBe ids.last()
+            source.entities shouldBe originalEntities
+            source.rng shouldBe originalRng
         }
 
         test("caller-generated assignments are reproducible and do not consume source randomness") {


### PR DESCRIPTION
`Determinizer` analyzes the same source position's in-flight references once for every player. A two-player sample therefore traverses a paused decision and its continuations twice before reconstructing hidden cards.

Compute that analysis once per sample and share the resulting pin set across players. Incomplete analysis still returns the original state without sampling, and an empty turn order still bypasses analysis. Candidate selection, visibility, reconstruction, and RNG ordering retain their existing behavior.

Depends on #2238, which batches hidden-card reconstruction. Until it merges, the main-based diff includes its changes. The [follow-on diff](https://github.com/huxinq/argentum-engine/compare/47edcee60d9c25895d00bcf43911f99f26e4e5a7...5fee28bec7ccd0efacc9bdae6d0eba524e65899f) isolates this optimization. The comparison below measures the additional effect on that already-batched sampler.

### Measured example

A short matched comparison used two-player synthetic positions with 8 or 104 hand/library slots, both with ordinary state and paused Mind Rot resolution. It alternated viewers and compared the previous sampler at `47edcee` with this change at `5fee28b`. The baseline implementation ran alongside the candidate in the same JVM, with coverage instrumentation disabled.

| Position | CPU per sample, before → after | Allocated bytes, before → after |
| --- | ---: | ---: |
| Ordinary, 8 slots | 8.651 → 8.614 µs (−0.4%) | 23,227 → 23,137 |
| Ordinary, 104 slots | 83.471 → 87.923 µs (+5.3%) | 340,024 → 339,928 |
| Paused Mind Rot, 8 slots | 26.301 → 15.806 µs (−39.9%) | 87,274 → 52,410 (−39.9%) |
| Paused Mind Rot, 104 slots | 101.240 → 94.172 µs (−7.0%) | 403,720 → 369,304 (−8.5%) |

Each fixture used 1,000 warmup calls per variant followed by ten old/new/new/old rounds of 100 calls per batch: 2,000 measured calls per variant. CPU is current-thread CPU time; allocation uses JVM thread allocation counters. The ordinary 104-slot mean includes a slow candidate batch despite the candidate having lower aggregate CPU in nine of ten rounds. These measurements support reduced work on the paused fixtures; they do not establish an ordinary-position or end-to-end search speedup. This exercises Argentum's built-in sampler, not MTGallium's explicit materializer path.

### Verification

All 12 `DeterminizerInvariantsTest` tests pass. New regressions require one analysis across players, one incomplete analysis with unchanged output, and no analysis for an empty turn order. Existing coverage includes both sampling models, both viewers, sixteen seeds, paused references, and entity/library ordering. The benchmark additionally checked full state equality and entity iteration order for 64 pairs per fixture (256 pairs total), with no failed or excluded samples.
