### PR TITLE
Reduce library membership scans during hidden-card sampling

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
@@ -92,10 +92,13 @@ class Determinizer internal constructor(
             }
 
             if (definitions.size != hidden.size) continue
+            // No caller observes intermediate identities. Copy once for this player and publish
+            // only after all replacements, without mutating an input or previously sampled world.
+            val sampledEntities = sampled.entities.toMutableMap()
             for ((entityId, cardDef) in hidden.zip(definitions)) {
-                val old = sampled.getEntity(entityId) ?: continue
+                val old = sampledEntities[entityId] ?: continue
                 val ownerId = old.get<OwnerComponent>()?.playerId ?: opponentId
-                sampled = HiddenSlotRewrite.rewrite(sampled, entityId, cardDef, ownerId)
+                sampledEntities[entityId] = HiddenSlotRewrite.rewrite(old, cardDef, ownerId)
             }
 
             val libraryKey = ZoneKey(opponentId, Zone.LIBRARY)
@@ -107,7 +110,10 @@ class Determinizer internal constructor(
             val shuffledLibrary = library.map { id ->
                 if (id in hiddenLibraryIds) iterator.next() else id
             }
-            sampled = sampled.copy(zones = sampled.zones + (libraryKey to shuffledLibrary))
+            sampled = sampled.copy(
+                entities = sampledEntities,
+                zones = sampled.zones + (libraryKey to shuffledLibrary),
+            )
         }
         return sampled
     }

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
@@ -103,7 +103,8 @@ class Determinizer internal constructor(
 
             val libraryKey = ZoneKey(opponentId, Zone.LIBRARY)
             val library = sampled.getZone(libraryKey)
-            val hiddenLibraryIds = hidden.filterTo(mutableSetOf()) { it in library }
+            val libraryIds = library.toHashSet()
+            val hiddenLibraryIds = hidden.filterTo(mutableSetOf()) { it in libraryIds }
             val (shuffledHidden, next) = currentRng.shuffle(library.filter { it in hiddenLibraryIds })
             currentRng = next
             val iterator = shuffledHidden.iterator()
@@ -133,8 +134,9 @@ class Determinizer internal constructor(
             // corresponding all-or-nothing request; sampling instead keeps every candidate slot.
             is HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete -> return emptyList()
         }
+        val libraryIds = library.toHashSet()
         return candidates.filter { id ->
-            val zoneKey = if (id in library) libraryKey else handKey
+            val zoneKey = if (id in libraryIds) libraryKey else handKey
             !visibility.isCardIdentityVisibleTo(state, zoneKey, id, viewerId) &&
                 id !in inFlightPins &&
                 isSafeToRewrite(state, id)

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
@@ -103,13 +103,12 @@ class Determinizer internal constructor(
 
             val libraryKey = ZoneKey(opponentId, Zone.LIBRARY)
             val library = sampled.getZone(libraryKey)
-            val libraryIds = library.toHashSet()
-            val hiddenLibraryIds = hidden.filterTo(mutableSetOf()) { it in libraryIds }
-            val (shuffledHidden, next) = currentRng.shuffle(library.filter { it in hiddenLibraryIds })
+            val hiddenIds = hidden.toHashSet()
+            val (shuffledHidden, next) = currentRng.shuffle(library.filter { it in hiddenIds })
             currentRng = next
             val iterator = shuffledHidden.iterator()
             val shuffledLibrary = library.map { id ->
-                if (id in hiddenLibraryIds) iterator.next() else id
+                if (id in hiddenIds) iterator.next() else id
             }
             sampled = sampled.copy(
                 entities = sampledEntities,

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.engine.view.Visibility
 import com.wingedsheep.sdk.model.GameRng
+import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
@@ -21,6 +22,52 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 class DeterminizerInvariantsTest : ScenarioTestBase() {
 
     init {
+        test("sampling retains the pre-batching assignment and library sequence") {
+            val game = scenario().withPlayers().withRngSeed(883L)
+                .withCardInHand(1, "Forest")
+                .withCardInLibrary(1, "Mountain").withCardInLibrary(1, "Hill Giant")
+                .withCardInHand(2, "Mountain").withCardInHand(2, "Hill Giant")
+                .withCardInLibrary(2, "Grizzly Bears").withCardInLibrary(2, "Craw Wurm")
+                .build()
+            val revealed = game.state.getHand(game.player2Id).first()
+            val before = game.state.updateEntity(revealed) { it.with(RevealedToComponent.to(game.player1Id)) }
+            val originalEntities = before.entities.toMap()
+            val originalZones = before.zones.mapValues { it.value.toList() }
+            val models = listOf(
+                emptyMap<EntityId, OpponentModel>(),
+                mapOf(
+                    game.player1Id to OpponentModel.KnownDecklist(
+                        mapOf("Forest" to 1, "Mountain" to 1, "Hill Giant" to 1),
+                    ),
+                    game.player2Id to OpponentModel.KnownDecklist(
+                        mapOf("Mountain" to 1, "Hill Giant" to 1, "Grizzly Bears" to 1, "Craw Wurm" to 1),
+                    ),
+                ),
+            )
+            val sampler = Determinizer(cardRegistry)
+            val signature = buildString {
+                for (model in models) for (viewer in before.turnOrder) for (seed in 1L..16L) {
+                    val world = sampler.sample(before, viewer, model, GameRng.seeded(seed))
+                    world.copy(entities = before.entities, zones = before.zones) shouldBe before
+                    before.entities shouldBe originalEntities
+                    before.zones shouldBe originalZones
+                    world.getEntity(revealed) shouldBe before.getEntity(revealed)
+                    append(viewer.value).append('/').append(seed).append(':')
+                    world.entities.forEach { (id, components) ->
+                        append(id.value).append('=').append(components.get<CardComponent>()?.name).append(';')
+                    }
+                    append(world.zones).append('\n')
+                    val retainedEntities = world.entities.toMap()
+                    sampler.sample(world, viewer, model, GameRng.seeded(seed + 100))
+                    world.entities shouldBe retainedEntities
+                }
+            }
+            // Captured from the per-card-copy implementation at upstream 12589ae4a2.
+            java.security.MessageDigest.getInstance("SHA-256").digest(signature.toByteArray())
+                .joinToString("") { "%02x".format(it) } shouldBe
+                "fe26af39d1fb97c30edbebf726115360a34a390af7d4c15e9c00a80b3ca8620b"
+        }
+
         test("sampling preserves structure and everything visible to the viewer") {
             val game = scenario()
                 .withPlayers()

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
@@ -3,6 +3,8 @@ package com.wingedsheep.ai.engine.hidden
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.hidden.HiddenSlotRewrite
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
@@ -66,6 +68,28 @@ class DeterminizerInvariantsTest : ScenarioTestBase() {
             java.security.MessageDigest.getInstance("SHA-256").digest(signature.toByteArray())
                 .joinToString("") { "%02x".format(it) } shouldBe
                 "fe26af39d1fb97c30edbebf726115360a34a390af7d4c15e9c00a80b3ca8620b"
+        }
+
+        test("library membership lookup retains duplicate occurrences and repeated player traversal") {
+            val game = scenario().withPlayers()
+                .withCardInLibrary(2, "Forest")
+                .withCardInLibrary(2, "Mountain")
+                .withCardInLibrary(2, "Hill Giant")
+                .build()
+            val libraryKey = ZoneKey(game.player2Id, Zone.LIBRARY)
+            val library = game.state.getLibrary(game.player2Id)
+            val duplicated = library + library.first()
+            val source = game.state.copy(
+                zones = game.state.zones + (libraryKey to duplicated),
+                turnOrder = game.state.turnOrder + game.player2Id,
+            )
+            val sampler = Determinizer(cardRegistry)
+            for (seed in 1L..16L) {
+                val world = sampler.sample(source, game.player1Id, OpponentModel.IdentityPermutation, GameRng.seeded(seed))
+                world.getLibrary(game.player2Id).shouldContainExactlyInAnyOrder(duplicated)
+                world.entities.keys.toList() shouldBe source.entities.keys.toList()
+                source.getLibrary(game.player2Id) shouldBe duplicated
+            }
         }
 
         test("sampling preserves structure and everything visible to the viewer") {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
@@ -154,10 +154,21 @@ object HiddenSlotRewrite {
         ownerId: EntityId,
     ): GameState {
         val source = state.getEntity(entityId) ?: return state
+        return state.withEntity(entityId, rewrite(source, definition, ownerId))
+    }
+
+    /**
+     * The container-only form lets callers batch several rewrites into one entity-map copy.
+     * As with the state form, callers must first clear [runtimeBlockers] for the source slot.
+     */
+    fun rewrite(
+        source: ComponentContainer,
+        definition: CardDefinition,
+        ownerId: EntityId,
+    ): ComponentContainer {
         val rebuilt = CardEntityFactory.create(definition, ownerId)
-        val withController = source.get<ControllerComponent>()
+        return source.get<ControllerComponent>()
             ?.let { rebuilt.with(it) }
             ?: rebuilt.without<ControllerComponent>()
-        return state.withEntity(entityId, withController)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -113,7 +113,8 @@ class HiddenWorldMaterializer internal constructor(
                 )
             }
         }
-        var materialized = state
+        // Accumulate privately: validation still reads the source, and a refusal publishes nothing.
+        val materializedEntities = state.entities.toMutableMap()
 
         // Slots are independent, so the order only decides *which* obstruction is reported when a
         // request has several. Sorting makes that report stable across equal requests.
@@ -199,11 +200,11 @@ class HiddenWorldMaterializer internal constructor(
                     listOf("replacement definition is not registered: $replacementDefinitionId"),
                 )
             }
-            materialized = HiddenSlotRewrite.rewrite(materialized, entityId, replacementDefinition, ownerId)
+            materializedEntities[entityId] = HiddenSlotRewrite.rewrite(container, replacementDefinition, ownerId)
         }
 
         return HiddenWorldMaterializationResult.Materialized(
-            materialized.copy(rng = request.futureRng)
+            state.copy(entities = materializedEntities, rng = request.futureRng)
         )
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -113,6 +113,9 @@ class HiddenWorldMaterializer internal constructor(
                 )
             }
         }
+        if (request.slotAssignments.isEmpty()) {
+            return HiddenWorldMaterializationResult.Materialized(state.copy(rng = request.futureRng))
+        }
         // Accumulate privately: validation still reads the source, and a refusal publishes nothing.
         val materializedEntities = state.entities.toMutableMap()
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -453,6 +453,7 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
 
             world shouldBe source.copy(rng = futureRng)
+            (world.entities === source.entities) shouldBe true
         }
 
         test("a paused continuation consumes the caller RNG only when its later shuffle executes") {
@@ -560,6 +561,10 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
 
             result.reason.kind shouldBe UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES
             result.reason.entityId shouldBe null
+            rejectingMaterializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(emptyMap(), GameRng.seeded(619L)),
+            ) shouldBe result
             result.reason.details shouldContain "could not traverse pending decision test: forced"
             cardName(source, handId) shouldBe "Grizzly Bears"
             cardName(source, libraryId) shouldBe "Forest"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -123,6 +123,7 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             val assignedIds = listOf(hiddenHandId) + hiddenLibraryIds
             val source = game.state
                 .copy(lastCardDrawnThisTurnByPlayer = mapOf(game.player2Id to hiddenHandId))
+            val sourceEntities = source.entities.toMap()
             val futureRng = GameRng.seeded(202L)
 
             val result = materializer.materialize(
@@ -159,7 +160,42 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             }
             withClue("materialization is purely functional") {
                 game.state.getEntity(hiddenHandId)?.get<CardComponent>()?.name shouldBe "Grizzly Bears"
+                source.entities shouldBe sourceEntities
+                world.entities.keys.toList() shouldBe source.entities.keys.toList()
+                val retainedEntities = world.entities.toMap()
+                materializer.materialize(
+                    world,
+                    HiddenWorldMaterializationRequest(
+                        assignedIds.associateWith { cardRegistry.requireCard("Swamp") },
+                        GameRng.seeded(203L),
+                    ),
+                ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>()
+                world.entities shouldBe retainedEntities
             }
+        }
+
+        test("a refusal after a valid slot leaves the entire input world unchanged") {
+            val game = scenario().withPlayers()
+                .withCardInLibrary(2, "Forest").withCardInLibrary(2, "Mountain")
+                .build()
+            val ids = game.state.getLibrary(game.player2Id).sortedBy { it.value }
+            val source = game.state.updateEntity(ids.last()) {
+                it.with(RevealedToComponent.to(game.player1Id))
+            }
+            val originalEntities = source.entities.toMap()
+            val originalRng = source.rng
+            val result = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    ids.associateWith { cardRegistry.requireCard("Island") },
+                    GameRng.seeded(204L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.RUNTIME_STATE
+            result.reason.entityId shouldBe ids.last()
+            source.entities shouldBe originalEntities
+            source.rng shouldBe originalRng
         }
 
         test("caller-generated assignments are reproducible and do not consume source randomness") {


### PR DESCRIPTION
`Determinizer` repeatedly searches a library list while classifying hidden cards, then builds a hidden/library intersection before shuffling. As libraries grow, these repeated membership scans do unnecessary work.

Use a local set for library membership during classification. For shuffling, use the hidden-ID set directly: both consumers already iterate the library, so intersecting with it first is redundant. The original lists still determine candidate order, shuffle inputs, and reconstruction order, including duplicate occurrences.

Depends on #2238's batched sampler and remains independent of #2241's in-flight analysis optimization. Until its parents merge, the main-based diff includes their changes. The [follow-on diff](https://github.com/huxinq/argentum-engine/compare/47edcee60d9c25895d00bcf43911f99f26e4e5a7...a554b885d049767918d91f2337f507475a3fec02) isolates this optimization.

### Measured example

A short comparison ran the baseline sampler at `47edcee` alongside the candidate at `a554b88` in one JVM with coverage disabled. It used two-player synthetic positions with 8 or 104 hand/library slots, ordinary state or paused Mind Rot resolution, and alternating viewers.

| Position | CPU per sample, before → after | Allocated bytes, before → after |
| --- | ---: | ---: |
| Ordinary, 8 slots | 9.886 → 10.375 µs (+4.9%) | 23,598 → 23,992 (+1.7%) |
| Ordinary, 104 slots | 88.321 → 80.752 µs (−8.6%) | 340,144 → 342,832 (+0.8%) |
| Paused Mind Rot, 8 slots | 31.206 → 31.597 µs (+1.3%) | 88,606 → 88,781 (+0.2%) |
| Paused Mind Rot, 104 slots | 104.382 → 92.327 µs (−11.5%) | 404,128 → 406,792 (+0.7%) |

The larger fixtures used less CPU at a small allocation cost; the small fixtures regressed. These are current-thread CPU and allocation measurements for these positions, not an end-to-end search speedup. Each fixture had 1,000 warmup calls per variant and ten old/new/new/old rounds of 100 calls per batch, totaling 2,000 measured calls per variant. Larger-fixture CPU favored the candidate in nine of ten ordinary rounds and all ten paused rounds; the ordinary mean includes one slow candidate round.

### Verification

All 11 `DeterminizerInvariantsTest` tests pass, including the existing 64-case sampling fingerprint and a new regression preserving duplicate library entries and repeated player traversal. The benchmark checked full state equality, entity iteration order, and source preservation for 64 pairs per fixture (256 total). All fixtures completed without exclusions. The measurement isolates this change from the other performance PRs.
