### PR TITLE
Reuse source-definition defaults within materialization requests

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
@@ -92,10 +92,13 @@ class Determinizer internal constructor(
             }
 
             if (definitions.size != hidden.size) continue
+            // No caller observes intermediate identities. Copy once for this player and publish
+            // only after all replacements, without mutating an input or previously sampled world.
+            val sampledEntities = sampled.entities.toMutableMap()
             for ((entityId, cardDef) in hidden.zip(definitions)) {
-                val old = sampled.getEntity(entityId) ?: continue
+                val old = sampledEntities[entityId] ?: continue
                 val ownerId = old.get<OwnerComponent>()?.playerId ?: opponentId
-                sampled = HiddenSlotRewrite.rewrite(sampled, entityId, cardDef, ownerId)
+                sampledEntities[entityId] = HiddenSlotRewrite.rewrite(old, cardDef, ownerId)
             }
 
             val libraryKey = ZoneKey(opponentId, Zone.LIBRARY)
@@ -107,7 +110,10 @@ class Determinizer internal constructor(
             val shuffledLibrary = library.map { id ->
                 if (id in hiddenLibraryIds) iterator.next() else id
             }
-            sampled = sampled.copy(zones = sampled.zones + (libraryKey to shuffledLibrary))
+            sampled = sampled.copy(
+                entities = sampledEntities,
+                zones = sampled.zones + (libraryKey to shuffledLibrary),
+            )
         }
         return sampled
     }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.engine.view.Visibility
 import com.wingedsheep.sdk.model.GameRng
+import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
@@ -21,6 +22,52 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 class DeterminizerInvariantsTest : ScenarioTestBase() {
 
     init {
+        test("sampling retains the pre-batching assignment and library sequence") {
+            val game = scenario().withPlayers().withRngSeed(883L)
+                .withCardInHand(1, "Forest")
+                .withCardInLibrary(1, "Mountain").withCardInLibrary(1, "Hill Giant")
+                .withCardInHand(2, "Mountain").withCardInHand(2, "Hill Giant")
+                .withCardInLibrary(2, "Grizzly Bears").withCardInLibrary(2, "Craw Wurm")
+                .build()
+            val revealed = game.state.getHand(game.player2Id).first()
+            val before = game.state.updateEntity(revealed) { it.with(RevealedToComponent.to(game.player1Id)) }
+            val originalEntities = before.entities.toMap()
+            val originalZones = before.zones.mapValues { it.value.toList() }
+            val models = listOf(
+                emptyMap<EntityId, OpponentModel>(),
+                mapOf(
+                    game.player1Id to OpponentModel.KnownDecklist(
+                        mapOf("Forest" to 1, "Mountain" to 1, "Hill Giant" to 1),
+                    ),
+                    game.player2Id to OpponentModel.KnownDecklist(
+                        mapOf("Mountain" to 1, "Hill Giant" to 1, "Grizzly Bears" to 1, "Craw Wurm" to 1),
+                    ),
+                ),
+            )
+            val sampler = Determinizer(cardRegistry)
+            val signature = buildString {
+                for (model in models) for (viewer in before.turnOrder) for (seed in 1L..16L) {
+                    val world = sampler.sample(before, viewer, model, GameRng.seeded(seed))
+                    world.copy(entities = before.entities, zones = before.zones) shouldBe before
+                    before.entities shouldBe originalEntities
+                    before.zones shouldBe originalZones
+                    world.getEntity(revealed) shouldBe before.getEntity(revealed)
+                    append(viewer.value).append('/').append(seed).append(':')
+                    world.entities.forEach { (id, components) ->
+                        append(id.value).append('=').append(components.get<CardComponent>()?.name).append(';')
+                    }
+                    append(world.zones).append('\n')
+                    val retainedEntities = world.entities.toMap()
+                    sampler.sample(world, viewer, model, GameRng.seeded(seed + 100))
+                    world.entities shouldBe retainedEntities
+                }
+            }
+            // Captured from the per-card-copy implementation at upstream 12589ae4a2.
+            java.security.MessageDigest.getInstance("SHA-256").digest(signature.toByteArray())
+                .joinToString("") { "%02x".format(it) } shouldBe
+                "fe26af39d1fb97c30edbebf726115360a34a390af7d4c15e9c00a80b3ca8620b"
+        }
+
         test("sampling preserves structure and everything visible to the viewer") {
             val game = scenario()
                 .withPlayers()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
@@ -125,9 +125,11 @@ object HiddenSlotRewrite {
         container: ComponentContainer,
         currentDefinition: CardDefinition,
         ownerId: EntityId,
-    ): List<String> {
-        val expectedByType = CardEntityFactory.create(currentDefinition, ownerId)
-            .all()
+    ): List<String> = runtimeBlockers(container, CardEntityFactory.create(currentDefinition, ownerId))
+
+    /** Reuse a factory-built expectation while still checking each source container separately. */
+    internal fun runtimeBlockers(container: ComponentContainer, expected: ComponentContainer): List<String> {
+        val expectedByType = expected.all()
             .associateBy { it::class.java }
         return container.all()
             .filterNot { it is CardComponent }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
@@ -154,10 +154,21 @@ object HiddenSlotRewrite {
         ownerId: EntityId,
     ): GameState {
         val source = state.getEntity(entityId) ?: return state
+        return state.withEntity(entityId, rewrite(source, definition, ownerId))
+    }
+
+    /**
+     * The container-only form lets callers batch several rewrites into one entity-map copy.
+     * As with the state form, callers must first clear [runtimeBlockers] for the source slot.
+     */
+    fun rewrite(
+        source: ComponentContainer,
+        definition: CardDefinition,
+        ownerId: EntityId,
+    ): ComponentContainer {
         val rebuilt = CardEntityFactory.create(definition, ownerId)
-        val withController = source.get<ControllerComponent>()
+        return source.get<ControllerComponent>()
             ?.let { rebuilt.with(it) }
             ?: rebuilt.without<ControllerComponent>()
-        return state.withEntity(entityId, withController)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
@@ -165,10 +165,11 @@ object HiddenSlotRewrite {
         source: ComponentContainer,
         definition: CardDefinition,
         ownerId: EntityId,
-    ): ComponentContainer {
-        val rebuilt = CardEntityFactory.create(definition, ownerId)
-        return source.get<ControllerComponent>()
+    ): ComponentContainer = rewrite(source, CardEntityFactory.create(definition, ownerId))
+
+    /** Reuse a factory container already built and validated by the materializer. */
+    internal fun rewrite(source: ComponentContainer, rebuilt: ComponentContainer): ComponentContainer =
+        source.get<ControllerComponent>()
             ?.let { rebuilt.with(it) }
             ?: rebuilt.without<ControllerComponent>()
-    }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.core.InFlightEntityReferences
 import com.wingedsheep.engine.core.InFlightReferenceProjector
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.sdk.core.Zone
@@ -116,6 +117,14 @@ class HiddenWorldMaterializer internal constructor(
         if (request.slotAssignments.isEmpty()) {
             return HiddenWorldMaterializationResult.Materialized(state.copy(rng = request.futureRng))
         }
+        // Preserve each occurrence, including duplicates within one zone. Validation below still
+        // chooses the first obstruction in assignment order; unrelated malformed slots are ignored.
+        val memberships = mutableMapOf<EntityId, MutableList<ZoneKey>>()
+        for ((zoneKey, ids) in state.zones) {
+            for (id in ids) {
+                if (id in request.slotAssignments) memberships.getOrPut(id) { mutableListOf() }.add(zoneKey)
+            }
+        }
         // Accumulate privately: validation still reads the source, and a refusal publishes nothing.
         val materializedEntities = state.entities.toMutableMap()
 
@@ -135,20 +144,20 @@ class HiddenWorldMaterializer internal constructor(
                     listOf("slot is conservatively pinned by in-flight execution"),
                 )
             }
-            val zones = state.zones.filterValues { entityId in it }
-            val occurrences = zones.values.sumOf { zone -> zone.count { it == entityId } }
-            if (occurrences != 1 || zones.keys.singleOrNull()?.zoneType !in SUPPORTED_ZONES) {
+            val zones = memberships[entityId].orEmpty()
+            val occurrences = zones.size
+            if (occurrences != 1 || zones.singleOrNull()?.zoneType !in SUPPORTED_ZONES) {
                 return unsupported(
                     UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
                     entityId,
                     listOf(
                         if (occurrences == 0) "entity is not in a zone"
                         else if (occurrences > 1) "entity occurs in zones $occurrences times"
-                        else "supported slots are HAND/LIBRARY; found ${zones.keys.single().zoneType.name}"
+                        else "supported slots are HAND/LIBRARY; found ${zones.single().zoneType.name}"
                     ),
                 )
             }
-            val zoneKey = zones.keys.single()
+            val zoneKey = zones.single()
 
             val ownerId = container.get<OwnerComponent>()?.playerId
                 ?: return unsupported(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -113,7 +113,8 @@ class HiddenWorldMaterializer internal constructor(
                 )
             }
         }
-        var materialized = state
+        // Accumulate privately: validation still reads the source, and a refusal publishes nothing.
+        val materializedEntities = state.entities.toMutableMap()
 
         // Slots are independent, so the order only decides *which* obstruction is reported when a
         // request has several. Sorting makes that report stable across equal requests.
@@ -199,11 +200,11 @@ class HiddenWorldMaterializer internal constructor(
                     listOf("replacement definition is not registered: $replacementDefinitionId"),
                 )
             }
-            materialized = HiddenSlotRewrite.rewrite(materialized, entityId, replacementDefinition, ownerId)
+            materializedEntities[entityId] = HiddenSlotRewrite.rewrite(container, replacementDefinition, ownerId)
         }
 
         return HiddenWorldMaterializationResult.Materialized(
-            materialized.copy(rng = request.futureRng)
+            state.copy(entities = materializedEntities, rng = request.futureRng)
         )
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.core.InFlightEntityReferences
 import com.wingedsheep.engine.core.InFlightReferenceProjector
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
@@ -131,6 +132,8 @@ class HiddenWorldMaterializer internal constructor(
         } else null
         // Accumulate privately: validation still reads the source, and a refusal publishes nothing.
         val materializedEntities = state.entities.toMutableMap()
+        // Deck copies share factory defaults, but ownership and per-slot runtime state still differ.
+        val expectedContainers = mutableMapOf<Pair<String, EntityId>, ComponentContainer>()
 
         // Slots are independent, so the order only decides *which* obstruction is reported when a
         // request has several. Sorting makes that report stable across equal requests.
@@ -203,7 +206,10 @@ class HiddenWorldMaterializer internal constructor(
                     entityId,
                     listOf("source definition is not registered: ${currentCard.cardDefinitionId}"),
                 )
-            val blockers = HiddenSlotRewrite.runtimeBlockers(container, currentDefinition, ownerId)
+            val expected = expectedContainers.getOrPut(currentCard.cardDefinitionId to ownerId) {
+                CardEntityFactory.create(currentDefinition, ownerId)
+            }
+            val blockers = HiddenSlotRewrite.runtimeBlockers(container, expected)
             if (blockers.isNotEmpty()) {
                 return unsupported(UnsupportedHiddenWorldKind.RUNTIME_STATE, entityId, blockers)
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -119,8 +119,8 @@ class HiddenWorldMaterializer internal constructor(
         }
         // Preserve each occurrence, including duplicates within one zone. Validation below still
         // chooses the first obstruction in assignment order; unrelated malformed slots are ignored.
-        // A single assignment only needs one scan, so it does not pay for an index.
-        val memberships = if (request.slotAssignments.size > 1) {
+        // For one or two assignments the original scan costs less than building an index.
+        val memberships = if (request.slotAssignments.size > 2) {
             mutableMapOf<EntityId, MutableList<ZoneKey>>().also { index ->
                 for ((zoneKey, ids) in state.zones) {
                     for (id in ids) {
@@ -148,24 +148,28 @@ class HiddenWorldMaterializer internal constructor(
                     listOf("slot is conservatively pinned by in-flight execution"),
                 )
             }
-            val zones = if (memberships == null) buildList {
-                for ((zoneKey, ids) in state.zones) {
-                    for (id in ids) if (id == entityId) add(zoneKey)
-                }
-            } else memberships[entityId].orEmpty()
-            val occurrences = zones.size
-            if (occurrences != 1 || zones.singleOrNull()?.zoneType !in SUPPORTED_ZONES) {
+            val zones = if (memberships == null) state.zones.filterValues { entityId in it } else null
+            val indexedZones = memberships?.get(entityId).orEmpty()
+            val occurrences = if (zones != null) zones.values.sumOf { zone -> zone.count { it == entityId } }
+                else indexedZones.size
+            if (occurrences != 1) {
                 return unsupported(
                     UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
                     entityId,
                     listOf(
                         if (occurrences == 0) "entity is not in a zone"
-                        else if (occurrences > 1) "entity occurs in zones $occurrences times"
-                        else "supported slots are HAND/LIBRARY; found ${zones.single().zoneType.name}"
+                        else "entity occurs in zones $occurrences times"
                     ),
                 )
             }
-            val zoneKey = zones.single()
+            val zoneKey = zones?.keys?.single() ?: indexedZones.single()
+            if (zoneKey.zoneType !in SUPPORTED_ZONES) {
+                return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("supported slots are HAND/LIBRARY; found ${zoneKey.zoneType.name}"),
+                )
+            }
 
             val ownerId = container.get<OwnerComponent>()?.playerId
                 ?: return unsupported(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -119,12 +119,16 @@ class HiddenWorldMaterializer internal constructor(
         }
         // Preserve each occurrence, including duplicates within one zone. Validation below still
         // chooses the first obstruction in assignment order; unrelated malformed slots are ignored.
-        val memberships = mutableMapOf<EntityId, MutableList<ZoneKey>>()
-        for ((zoneKey, ids) in state.zones) {
-            for (id in ids) {
-                if (id in request.slotAssignments) memberships.getOrPut(id) { mutableListOf() }.add(zoneKey)
+        // A single assignment only needs one scan, so it does not pay for an index.
+        val memberships = if (request.slotAssignments.size > 1) {
+            mutableMapOf<EntityId, MutableList<ZoneKey>>().also { index ->
+                for ((zoneKey, ids) in state.zones) {
+                    for (id in ids) {
+                        if (id in request.slotAssignments) index.getOrPut(id) { mutableListOf() }.add(zoneKey)
+                    }
+                }
             }
-        }
+        } else null
         // Accumulate privately: validation still reads the source, and a refusal publishes nothing.
         val materializedEntities = state.entities.toMutableMap()
 
@@ -144,7 +148,11 @@ class HiddenWorldMaterializer internal constructor(
                     listOf("slot is conservatively pinned by in-flight execution"),
                 )
             }
-            val zones = memberships[entityId].orEmpty()
+            val zones = if (memberships == null) buildList {
+                for ((zoneKey, ids) in state.zones) {
+                    for (id in ids) if (id == entityId) add(zoneKey)
+                }
+            } else memberships[entityId].orEmpty()
             val occurrences = zones.size
             if (occurrences != 1 || zones.singleOrNull()?.zoneType !in SUPPORTED_ZONES) {
                 return unsupported(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -190,7 +190,8 @@ class HiddenWorldMaterializer internal constructor(
                     listOf("replacement HAND/LIBRARY identity is a DFC back face: ${replacementDefinition.name}"),
                 )
             }
-            val replacementDefinitionId = CardEntityFactory.create(replacementDefinition, ownerId)
+            val replacementContainer = CardEntityFactory.create(replacementDefinition, ownerId)
+            val replacementDefinitionId = replacementContainer
                 .require<CardComponent>()
                 .cardDefinitionId
             if (cardRegistry.getCard(replacementDefinitionId) != replacementDefinition) {
@@ -200,7 +201,7 @@ class HiddenWorldMaterializer internal constructor(
                     listOf("replacement definition is not registered: $replacementDefinitionId"),
                 )
             }
-            materializedEntities[entityId] = HiddenSlotRewrite.rewrite(container, replacementDefinition, ownerId)
+            materializedEntities[entityId] = HiddenSlotRewrite.rewrite(container, replacementContainer)
         }
 
         return HiddenWorldMaterializationResult.Materialized(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -113,6 +113,9 @@ class HiddenWorldMaterializer internal constructor(
                 )
             }
         }
+        if (request.slotAssignments.isEmpty()) {
+            return HiddenWorldMaterializationResult.Materialized(state.copy(rng = request.futureRng))
+        }
         // Accumulate privately: validation still reads the source, and a refusal publishes nothing.
         val materializedEntities = state.entities.toMutableMap()
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -453,6 +453,7 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
 
             world shouldBe source.copy(rng = futureRng)
+            (world.entities === source.entities) shouldBe true
         }
 
         test("a paused continuation consumes the caller RNG only when its later shuffle executes") {
@@ -560,6 +561,10 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
 
             result.reason.kind shouldBe UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES
             result.reason.entityId shouldBe null
+            rejectingMaterializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(emptyMap(), GameRng.seeded(619L)),
+            ) shouldBe result
             result.reason.details shouldContain "could not traverse pending decision test: forced"
             cardName(source, handId) shouldBe "Grizzly Bears"
             cardName(source, libraryId) shouldBe "Forest"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.hidden
 
+import com.wingedsheep.engine.core.CardEntityFactory
 import com.wingedsheep.engine.core.CardsSelectedResponse
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.ChooseOptionDecision
@@ -145,6 +146,10 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             world.zones shouldBe source.zones
             world.lastCardDrawnThisTurnByPlayer shouldBe mapOf(game.player2Id to hiddenHandId)
             cardName(world, hiddenHandId) shouldBe "Fiery Temper"
+            world.getEntity(hiddenHandId)?.get<CardComponent>()?.cardDefinitionId shouldBe
+                CardEntityFactory.create(cardRegistry.requireCard("Fiery Temper"), game.player2Id)
+                    .require<CardComponent>().cardDefinitionId
+            world.getEntity(hiddenHandId)?.get<ControllerComponent>() shouldBe ControllerComponent(game.player2Id)
             cardName(world, hiddenLibraryIds[0]) shouldBe "Mountain"
             cardName(world, hiddenLibraryIds[1]) shouldBe "Island"
             withClue("definition-derived components are rebuilt for the assigned identity") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -103,6 +103,13 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
                     result.reason.kind shouldBe UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT
                     result.reason.entityId shouldBe first
                     result.reason.details shouldBe listOf(expectedDetail)
+                    materializer.materialize(
+                        malformed,
+                        HiddenWorldMaterializationRequest(
+                            mapOf(first to cardRegistry.requireCard("Island")),
+                            GameRng.seeded(901L),
+                        ),
+                    ) shouldBe result
                     malformed.entities shouldBe source.entities
                     malformed.rng shouldBe source.rng
                 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -123,6 +123,7 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             val assignedIds = listOf(hiddenHandId) + hiddenLibraryIds
             val source = game.state
                 .copy(lastCardDrawnThisTurnByPlayer = mapOf(game.player2Id to hiddenHandId))
+            val sourceEntities = source.entities.toMap()
             val futureRng = GameRng.seeded(202L)
 
             val result = materializer.materialize(
@@ -159,7 +160,42 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             }
             withClue("materialization is purely functional") {
                 game.state.getEntity(hiddenHandId)?.get<CardComponent>()?.name shouldBe "Grizzly Bears"
+                source.entities shouldBe sourceEntities
+                world.entities.keys.toList() shouldBe source.entities.keys.toList()
+                val retainedEntities = world.entities.toMap()
+                materializer.materialize(
+                    world,
+                    HiddenWorldMaterializationRequest(
+                        assignedIds.associateWith { cardRegistry.requireCard("Swamp") },
+                        GameRng.seeded(203L),
+                    ),
+                ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>()
+                world.entities shouldBe retainedEntities
             }
+        }
+
+        test("a refusal after a valid slot leaves the entire input world unchanged") {
+            val game = scenario().withPlayers()
+                .withCardInLibrary(2, "Forest").withCardInLibrary(2, "Mountain")
+                .build()
+            val ids = game.state.getLibrary(game.player2Id).sortedBy { it.value }
+            val source = game.state.updateEntity(ids.last()) {
+                it.with(RevealedToComponent.to(game.player1Id))
+            }
+            val originalEntities = source.entities.toMap()
+            val originalRng = source.rng
+            val result = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    ids.associateWith { cardRegistry.requireCard("Island") },
+                    GameRng.seeded(204L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.RUNTIME_STATE
+            result.reason.entityId shouldBe ids.last()
+            source.entities shouldBe originalEntities
+            source.rng shouldBe originalRng
         }
 
         test("caller-generated assignments are reproducible and do not consume source randomness") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.engine.core.SubmitDecision
 import com.wingedsheep.engine.core.PlayLand
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.LastKnownPermanentComponent
@@ -259,6 +260,56 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             result.reason.entityId shouldBe ids.last()
             source.entities shouldBe originalEntities
             source.rng shouldBe originalRng
+        }
+
+        test("repeated source definitions retain owner-specific validation and per-slot blockers") {
+            val game = scenario().withPlayers()
+                .withCardInHand(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInHand(2, "Grizzly Bears")
+                .build()
+            val source = game.state
+            val slots = source.turnOrder.flatMap { source.getHand(it) + source.getLibrary(it) }
+            val request = HiddenWorldMaterializationRequest(
+                slots.associateWith { cardRegistry.requireCard("Forest") }, GameRng.seeded(321L),
+            )
+            val world = materializer.materialize(source, request)
+                .shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
+            for (id in slots) {
+                world.getEntity(id)!!.require<CardComponent>().ownerId shouldBe
+                    source.getEntity(id)!!.require<CardComponent>().ownerId
+            }
+
+            val blockedId = (source.getHand(game.player1Id) + source.getLibrary(game.player1Id))
+                .maxBy { it.value }
+            val blocked = source.updateEntity(blockedId) { it.with(RevealedToComponent.to(game.player2Id)) }
+            val originalEntities = blocked.entities.toMap()
+            val result = materializer.materialize(blocked, request)
+                .shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.RUNTIME_STATE
+            result.reason.entityId shouldBe blockedId
+            result.reason.details shouldBe listOf("RevealedToComponent")
+            blocked.entities shouldBe originalEntities
+            blocked.rng shouldBe source.rng
+        }
+
+        test("source validation observes registry changes between materialization requests") {
+            val game = scenario().withPlayers().withCardInHand(2, "Fiery Temper").build()
+            val registry = CardRegistry(cardRegistry)
+            val localMaterializer = HiddenWorldMaterializer(registry)
+            val id = game.state.getHand(game.player2Id).single()
+            val request = HiddenWorldMaterializationRequest(
+                mapOf(id to cardRegistry.requireCard("Forest")), GameRng.seeded(322L),
+            )
+            localMaterializer.materialize(game.state, request)
+                .shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>()
+
+            registry.register(cardRegistry.requireCard("Fiery Temper").copy(keywordAbilities = emptyList()))
+            val result = localMaterializer.materialize(game.state, request)
+                .shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.RUNTIME_STATE
+            result.reason.entityId shouldBe id
+            result.reason.details shouldBe listOf("MadnessComponent")
         }
 
         test("caller-generated assignments are reproducible and do not consume source randomness") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -66,6 +66,49 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
     init {
         cardRegistry.register(chooseThenShuffle)
 
+        test("zone membership retains multiplicity and sorted refusal order") {
+            val game = scenario().withPlayers()
+                .withCardInLibrary(2, "Forest").withCardInLibrary(2, "Mountain")
+                .build()
+            val ids = game.state.getLibrary(game.player2Id).sortedBy { it.value }
+            val first = ids.first()
+            val later = ids.last()
+            val source = game.state.updateEntity(later) {
+                it.with(RevealedToComponent.to(game.player1Id))
+            }
+            val library = ZoneKey(game.player2Id, Zone.LIBRARY)
+            val hand = ZoneKey(game.player2Id, Zone.HAND)
+            val battlefield = ZoneKey(game.player2Id, Zone.BATTLEFIELD)
+            val withoutFirst = source.zones.mapValues { (_, cards) -> cards.filterNot { it == first } }
+            val cases = listOf(
+                withoutFirst to "entity is not in a zone",
+                (source.zones + (library to (source.zones.getValue(library) + first))) to
+                    "entity occurs in zones 2 times",
+                (source.zones + (hand to listOf(first))) to "entity occurs in zones 2 times",
+                (withoutFirst + (battlefield to listOf(first))) to
+                    "supported slots are HAND/LIBRARY; found BATTLEFIELD",
+            )
+            for ((zones, expectedDetail) in cases) {
+                val malformed = source.copy(zones = zones)
+                val result = materializer.materialize(
+                    malformed,
+                    HiddenWorldMaterializationRequest(
+                        // Insertion order opposes the required sorted failure order. The later
+                        // slot also fails, but its runtime-state refusal must not take precedence.
+                        linkedMapOf(later to cardRegistry.requireCard("Island"), first to cardRegistry.requireCard("Island")),
+                        GameRng.seeded(901L),
+                    ),
+                ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+                withClue(expectedDetail) {
+                    result.reason.kind shouldBe UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT
+                    result.reason.entityId shouldBe first
+                    result.reason.details shouldBe listOf(expectedDetail)
+                    malformed.entities shouldBe source.entities
+                    malformed.rng shouldBe source.rng
+                }
+            }
+        }
+
         test("a Monstrous Emergence hand choice is pinned by the live stack object") {
             val game = scenario()
                 .withPlayers()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -69,6 +69,7 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
         test("zone membership retains multiplicity and sorted refusal order") {
             val game = scenario().withPlayers()
                 .withCardInLibrary(2, "Forest").withCardInLibrary(2, "Mountain")
+                .withCardInLibrary(2, "Swamp")
                 .build()
             val ids = game.state.getLibrary(game.player2Id).sortedBy { it.value }
             val first = ids.first()
@@ -95,7 +96,7 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
                     HiddenWorldMaterializationRequest(
                         // Insertion order opposes the required sorted failure order. The later
                         // slot also fails, but its runtime-state refusal must not take precedence.
-                        linkedMapOf(later to cardRegistry.requireCard("Island"), first to cardRegistry.requireCard("Island")),
+                        ids.reversed().associateWith { cardRegistry.requireCard("Island") },
                         GameRng.seeded(901L),
                     ),
                 ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
@@ -107,6 +108,13 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
                         malformed,
                         HiddenWorldMaterializationRequest(
                             mapOf(first to cardRegistry.requireCard("Island")),
+                            GameRng.seeded(901L),
+                        ),
+                    ) shouldBe result
+                    materializer.materialize(
+                        malformed,
+                        HiddenWorldMaterializationRequest(
+                            linkedMapOf(later to cardRegistry.requireCard("Island"), first to cardRegistry.requireCard("Island")),
                             GameRng.seeded(901L),
                         ),
                     ) shouldBe result


### PR DESCRIPTION
`HiddenWorldMaterializer` reconstructs a source card's factory defaults for every assigned slot to check for runtime components. Multiple copies of the same card under the same owner repeat that construction even though their expected defaults are identical.

Reuse those defaults within one materialization request, keyed by the exact registered source-definition ID and owner. Every slot still resolves its definition and compares its own components against the defaults; a runtime blocker on one copy still refuses the request at that slot. The cache ends with the call, so the next request observes registry updates. Replacement construction and validation remain separate.

Depends on #2240's zone lookup optimization and measures the additional effect on that materializer. Until its parents merge, the main-based diff includes their changes. The [follow-on diff](https://github.com/huxinq/argentum-engine/compare/27e95f23e4bd355211a8b986a9e846e388b99ddf...3a3183f82d9c4d499f3e9379214dda0b16dd5e48) isolates this optimization.

### Measured example

A short matched comparison ran the baseline at `27e95f2` and this change at `3a3183f` in one JVM with coverage disabled. Synthetic two-player positions had 8 or 104 hand/library slots and dense or sparse assignments. The repeated-definition cases use Grizzly Bears in hands and Forest in libraries; the distinct cases give each source slot a separately registered synthetic definition.

With 104 assignments and four source-definition/owner combinations, expected-container construction falls from 104 calls to four. That fixture used **21.0% less CPU and 29.9% less allocation**. Cache misses add overhead, visible in the distinct-definition and single-assignment cases:

| Assigned slots | Source definitions | CPU per request, before → after | Allocated bytes, before → after |
| --- | --- | ---: | ---: |
| 8 of 8 | Repeated | 11.570 → 10.257 µs (-11.3%) | 30,573 → 25,966 (-15.1%) |
| 8 of 8 | Distinct | 6.666 → 6.908 µs (+3.6%) | 30,632 → 31,416 (+2.6%) |
| 104 of 104 | Repeated | 76.163 → 60.170 µs (-21.0%) | 370,056 → 259,464 (-29.9%) |
| 104 of 104 | Distinct | 82.251 → 82.865 µs (+0.7%) | 371,656 → 382,104 (+2.8%) |
| 1 of 104 | Repeated | 3.014 → 3.115 µs (+3.4%) | 9,731 → 9,957 (+2.3%) |
| 1 of 104 | Distinct | 2.777 → 2.823 µs (+1.7%) | 9,704 → 9,928 (+2.3%) |
| 2 of 104 | Repeated | 4.137 → 3.990 µs (-3.6%) | 14,400 → 13,192 (-8.4%) |
| 2 of 104 | Distinct | 4.205 → 4.308 µs (+2.5%) | 14,400 → 14,704 (+2.1%) |

Each fixture had 1,000 warmup calls per variant, then ten old/new/new/old rounds with 100 calls per batch: 2,000 measured calls per variant. CPU and allocation are current-thread JVM counters. These measurements establish the tradeoff for these synthetic fixtures; they do not measure typical deck composition or end-to-end search performance.

### Verification

All 31 focused tests pass across `HiddenWorldMaterializerTest`, `HiddenSlotRewriteTest`, and `DeterminizerInvariantsTest`. New regressions exercise repeated definitions under different owners, a later revealed copy refusing after an earlier valid copy, and a registry overlay changing a definition between requests. The public blocker API retains its definition/owner form; the overload accepting factory defaults is internal to the engine.

The benchmark checked full result equality, entity iteration order, and source preservation for 64 pairs per fixture (512 total). All eight fixtures completed, without failed or excluded samples.
