### PR TITLE
Collect projected type names without intermediate lists

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
@@ -519,10 +519,10 @@ class StateProjector(
     }
 
     private fun extractTypes(card: CardComponent): MutableSet<String> {
-        val types = mutableSetOf<String>()
-        types.addAll(card.typeLine.supertypes.map { it.name })
-        types.addAll(card.typeLine.cardTypes.map { it.name })
-        types.addAll(card.typeLine.subtypes.map { it.value })
+        val types = linkedSetOf<String>()
+        card.typeLine.supertypes.forEach { types.add(it.name) }
+        card.typeLine.cardTypes.forEach { types.add(it.name) }
+        card.typeLine.subtypes.forEach { types.add(it.value) }
         return types
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedTypeNamesTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedTypeNamesTest.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.engine.mechanics.layers
+
+import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.TextReplacement
+import com.wingedsheep.engine.state.components.identity.TextReplacementCategory
+import com.wingedsheep.engine.state.components.identity.TextReplacementComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ProjectedTypeNamesTest : FunSpec({
+    test("projected type names preserve ordered supertypes, card types, and replaced subtypes") {
+        val owner = EntityId.of("owner")
+        val id = EntityId.of("permanent")
+        val definition = card("Type Witness") {
+            manaCost = "{0}"
+            typeLine = "Legendary Artifact Creature — Bear Warrior"
+            power = 2
+            toughness = 2
+        }
+        val source = GameState(
+            entities = mapOf(id to CardEntityFactory.create(definition, owner)),
+            zones = mapOf(ZoneKey(owner, Zone.BATTLEFIELD) to listOf(id)),
+        )
+        val projector = StateProjector()
+        val original = projector.project(source)
+        original.getTypes(id).toList() shouldBe listOf("LEGENDARY", "ARTIFACT", "CREATURE", "Bear", "Warrior")
+        original.getSubtypes(id).toList() shouldBe listOf("Bear", "Warrior")
+
+        val changed = source.updateEntity(id) {
+            it.with(TextReplacementComponent(listOf(TextReplacement("Bear", "Goblin", TextReplacementCategory.CREATURE_TYPE))))
+        }
+        val projected = projector.project(changed)
+        projected.getTypes(id).toList() shouldBe listOf("LEGENDARY", "ARTIFACT", "CREATURE", "Goblin", "Warrior")
+        projected.getSubtypes(id).toList() shouldBe listOf("Goblin", "Warrior")
+        original.getTypes(id).toList() shouldBe listOf("LEGENDARY", "ARTIFACT", "CREATURE", "Bear", "Warrior")
+    }
+})


### PR DESCRIPTION
`StateProjector` creates three temporary lists for each face-up permanent just to insert its supertype, card-type, and subtype names into an ordered set. Add those names directly to the set instead.

Insertion order remains supertype → card type → subtype, with the same duplicate collapse. Subtypes remain part of `types` as well as `subtypes`: text replacement depends on updating both representations together.

### Measured example

A matched comparison ran the baseline projector at `12589ae4` beside the candidate at `a5a2b90` in one JVM with coverage disabled. Four synthetic battlefields mixed basic lands, creatures, and legendary artifact creatures, including subtype text replacements. Calls invoke `StateProjector.project` directly and build a fresh projection each time.

| Battlefield permanents | CPU per projection, before → after | Allocated bytes, before → after |
| --- | ---: | ---: |
| 2 | 2.825 → 2.938 µs (+4.0%) | 5,824 → 5,560 (−4.5%) |
| 8 | 4.788 → 4.598 µs (−4.0%) | 22,400 → 21,320 (−4.8%) |
| 32 | 19.564 → 18.676 µs (−4.5%) | 88,928 → 84,584 (−4.9%) |
| 128 | 77.647 → 75.056 µs (−3.3%) | 354,944 → 337,544 (−4.9%) |

An initial shorter-warmup diagnostic showed large CPU swings, so this comparison used 10,000 warmup calls per variant and fixture before ten old/new/new/old rounds of 500 calls per batch (10,000 measured calls per variant). Inputs were prebuilt, with 100 battlefield-order permutations. CPU and allocation use current-thread JVM counters.

Allocation fell in every round of every fixture. CPU still had isolated slow rounds: the two-permanent aggregate rose despite seven of ten rounds favoring the candidate. The larger fixtures favored the candidate in nine or ten rounds. Allocation is the more consistent result; these measurements do not establish gameplay speedup or performance of cached projection reads.

### Verification

All 82 tests pass across `ProjectedTypeNamesTest`, `LayerSystemTest`, `ClassicLayerScenariosTest`, and `GrantedSupertypeVisibilityTest`. The new regression checks exact type iteration order and subtype text replacement while preserving a retained projection.

The benchmark additionally checked 64 pairs per fixture (256 total), comparing all projected values, projected entity order, ordered types/subtypes/keywords, base state, cross-zone grants, and source preservation. All fixtures completed without failures or exclusions. This PR is independent of the hidden-world optimization stack and is based directly on upstream `12589ae4`.
