### PR TITLE
Assemble triggered-ability grants without repeated list copies

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
@@ -125,10 +125,21 @@ class TriggerAbilityResolver(
         // gates it, the printed KeywordAbility.Numeric supplies N.
         val renownAbilities = getRenownTriggeredAbilities(entityId, cardDefinitionId, state)
 
-        val allGranted = grantedAbilities + staticGrantedAbilities + attachedGrantedAbilities +
-            selfGrantedAbilities + wardAbilities + flankingAbilities + ringBearerAbilities +
-            suspendAbilities + paradigmAbilities + siegeAbilities + vanishingAbilities +
-            fabricateAbilities + renownAbilities
+        val allGranted = buildList {
+            addAll(grantedAbilities)
+            addAll(staticGrantedAbilities)
+            addAll(attachedGrantedAbilities)
+            addAll(selfGrantedAbilities)
+            addAll(wardAbilities)
+            addAll(flankingAbilities)
+            addAll(ringBearerAbilities)
+            addAll(suspendAbilities)
+            addAll(paradigmAbilities)
+            addAll(siegeAbilities)
+            addAll(vanishingAbilities)
+            addAll(fabricateAbilities)
+            addAll(renownAbilities)
+        }
         val combined = if (allGranted.isNotEmpty()) base + allGranted else base
 
         // Apply text replacement if the entity has one
@@ -329,10 +340,21 @@ class TriggerAbilityResolver(
         // gates it, the printed KeywordAbility.Numeric supplies N.
         val renownAbilities = getRenownTriggeredAbilities(entityId, cardDefinitionId, state)
 
-        val allGranted = grantedAbilities + staticGrantedAbilities + attachedGrantedAbilities +
-            selfGrantedAbilities + wardAbilities + flankingAbilities + ringBearerAbilities +
-            suspendAbilities + paradigmAbilities + siegeAbilities + vanishingAbilities +
-            fabricateAbilities + renownAbilities
+        val allGranted = buildList {
+            addAll(grantedAbilities)
+            addAll(staticGrantedAbilities)
+            addAll(attachedGrantedAbilities)
+            addAll(selfGrantedAbilities)
+            addAll(wardAbilities)
+            addAll(flankingAbilities)
+            addAll(ringBearerAbilities)
+            addAll(suspendAbilities)
+            addAll(paradigmAbilities)
+            addAll(siegeAbilities)
+            addAll(vanishingAbilities)
+            addAll(fabricateAbilities)
+            addAll(renownAbilities)
+        }
         val combined = if (allGranted.isNotEmpty()) base + allGranted else base
 
         val textReplacement = state.getEntity(entityId)?.get<TextReplacementComponent>()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolverTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolverTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.engine.event
+
+import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class TriggerAbilityResolverTest : FunSpec({
+    test("both lookup paths retain grant order, duplicate abilities, and the ungranted base list") {
+        fun ability(name: String) = TriggeredAbility(
+            AbilityId(name), Triggers.Dies.event,
+            effect = LoseLifeEffect(1, EffectTarget.PlayerRef(Player.You)),
+        )
+        val owner = EntityId.of("owner")
+        val targetId = EntityId.of("target")
+        val providerId = EntityId.of("provider")
+        val base = listOf(ability("base"))
+        val temporary = ability("temporary")
+        val static = ability("static")
+        val grant = GrantTriggeredAbility(static, GroupFilter.AllCreatures)
+        val target = CardDefinition.creature("Trigger Target", ManaCost.ZERO, subtypes = emptySet(), power = 1, toughness = 1)
+        val provider = CardDefinition.enchantment("Trigger Provider", ManaCost.ZERO,
+            script = CardScript(staticAbilities = listOf(grant)))
+        val registry = CardRegistry().apply { register(listOf(target, provider)) }
+        val abilities = AbilityRegistry().apply { register(target.name, base) }
+        val resolver = TriggerAbilityResolver(registry, abilities)
+        val zone = ZoneKey(owner, Zone.BATTLEFIELD)
+        val ungranted = GameState(
+            entities = mapOf(targetId to CardEntityFactory.create(target, owner)),
+            zones = mapOf(zone to listOf(targetId)),
+        )
+        (resolver.getTriggeredAbilities(targetId, target.name, ungranted) === base) shouldBe true
+        (resolver.getTriggeredAbilitiesWithProviders(targetId, target.name, ungranted, emptyList()) === base) shouldBe true
+
+        val granted = ungranted.copy(
+            entities = ungranted.entities + (providerId to CardEntityFactory.create(provider, owner)),
+            zones = mapOf(zone to listOf(targetId, providerId)),
+            grantedTriggeredAbilities = List(2) { GrantedTriggeredAbility(targetId, temporary, Duration.Permanent) },
+        )
+        val expected = base + listOf(temporary, temporary, static)
+        resolver.getTriggeredAbilities(targetId, target.name, granted) shouldBe expected
+        resolver.getTriggeredAbilitiesWithProviders(
+            targetId, target.name, granted,
+            listOf(TriggerIndex.GrantProviderEntry(grant, owner, providerId)),
+        ) shouldBe expected
+    }
+})


### PR DESCRIPTION
`TriggerAbilityResolver` combines thirteen sources of granted abilities by repeatedly concatenating lists. Each concatenation copies the accumulated grants, including empty-list allocations when no grants apply. Both ordinary trigger lookup and the lookup using indexed providers take this path.

Collect the already-resolved lists once with `buildList`, in their existing order. Duplicate grants remain duplicate abilities. When no grants apply, assembly retains the existing base list; text replacement still runs afterward. Provider lookup, duration checks, and filtering happen at the same points as before.

### Measured example

The baseline at `12589ae4` and candidate at `22c7d8a` ran side by side in one JVM with coverage disabled. Eight synthetic fixtures exercised regular and indexed lookup across eight target creatures. Battlefield indexes were prebuilt and projection was warm, matching callers that reuse them across lookups.

| Lookup path | Abilities per target | CPU per lookup, before → after | Allocated bytes, before → after |
| --- | --- | ---: | ---: |
| Regular | 0 base, 0 temporary, 0 static | 0.962 → 0.646 µs (−32.8%) | 1,278 → 966 (−24.4%) |
| Indexed providers | 0 base, 0 temporary, 0 static | 0.585 → 0.391 µs (−33.2%) | 936 → 608 (−35.0%) |
| Regular | 1 base, 0 temporary, 0 static | 0.570 → 0.399 µs (−30.0%) | 1,208 → 896 (−25.8%) |
| Indexed providers | 1 base, 0 temporary, 0 static | 0.492 → 0.391 µs (−20.4%) | 880 → 552 (−37.3%) |
| Regular | 1 base, 2 temporary, 1 static | 1.497 → 1.012 µs (−32.4%) | 2,090 → 1,200 (−42.6%) |
| Indexed providers | 1 base, 2 temporary, 1 static | 1.288 → 0.906 µs (−29.7%) | 1,789 → 910 (−49.1%) |
| Regular | 1 base, 8 temporary, 1 static | 1.271 → 0.884 µs (−30.5%) | 2,624 → 1,240 (−52.7%) |
| Indexed providers | 1 base, 8 temporary, 1 static | 0.648 → 0.609 µs (−5.9%) | 2,376 → 936 (−60.6%) |

Each fixture used 10,000 warmup calls per variant, then ten old/new/new/old rounds with 500 calls per batch (10,000 measured calls per variant). CPU and allocation use current-thread JVM counters. Allocation was lower in every round; CPU was lower in every round for seven fixtures and in seven of ten rounds for the indexed base-only fixture. These measurements describe ability lookup with reused indexes and warm projection; they do not measure complete event processing or gameplay speedup.

### Verification

All 33 tests pass across `TriggerAbilityResolverTest`, `TriggerDetectorBatchTriggerTest`, and `EntityMatchesAttachmentScenarioTest`. The new regression checks both lookup paths for base-list identity without grants and exact base → duplicate temporary → static ability order with grants. Existing tests exercise downstream batch triggers and attachment-granted execution.

The benchmark compared complete ordered ability lists for 64 calls per fixture, cycling through the eight targets, and checked source preservation. All eight fixtures completed without failures or exclusions. This PR is based directly on upstream `12589ae4` and is independent of the projection and hidden-world optimization PRs.
