### PR TITLE
Reduce allocation and repeated scans when constructing hidden worlds

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
@@ -70,13 +70,20 @@ class Determinizer internal constructor(
         rng: GameRng,
         fallback: OpponentModel = OpponentModel.IdentityPermutation,
     ): GameState {
+        if (state.turnOrder.isEmpty()) return state
+        // Every player is sampled from this same source position, so analyze its references once.
+        val inFlightPins = when (val pins = inFlightPinAnalysis(state)) {
+            is HiddenSlotRewrite.IdentitySensitiveInFlightPins.Complete -> pins.entityIds
+            // An incomplete traversal cannot justify sampling any hidden identity.
+            is HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete -> return state
+        }
         var sampled = state
         var currentRng = rng
 
         // Even the viewer's own library order is hidden. Teammate hands are visible, but teammate
         // libraries are not. Walk every player and let Visibility decide which cards are hidden.
         for (opponentId in state.turnOrder) {
-            val hidden = hiddenCards(state, opponentId, viewerId)
+            val hidden = hiddenCards(state, opponentId, viewerId, inFlightPins)
             if (hidden.isEmpty()) continue
 
             val definitions = when (val model = models[opponentId] ?: fallback) {
@@ -92,22 +99,28 @@ class Determinizer internal constructor(
             }
 
             if (definitions.size != hidden.size) continue
+            // No caller observes intermediate identities. Copy once for this player and publish
+            // only after all replacements, without mutating an input or previously sampled world.
+            val sampledEntities = sampled.entities.toMutableMap()
             for ((entityId, cardDef) in hidden.zip(definitions)) {
-                val old = sampled.getEntity(entityId) ?: continue
+                val old = sampledEntities[entityId] ?: continue
                 val ownerId = old.get<OwnerComponent>()?.playerId ?: opponentId
-                sampled = HiddenSlotRewrite.rewrite(sampled, entityId, cardDef, ownerId)
+                sampledEntities[entityId] = HiddenSlotRewrite.rewrite(old, cardDef, ownerId)
             }
 
             val libraryKey = ZoneKey(opponentId, Zone.LIBRARY)
             val library = sampled.getZone(libraryKey)
-            val hiddenLibraryIds = hidden.filterTo(mutableSetOf()) { it in library }
-            val (shuffledHidden, next) = currentRng.shuffle(library.filter { it in hiddenLibraryIds })
+            val hiddenIds = hidden.toHashSet()
+            val (shuffledHidden, next) = currentRng.shuffle(library.filter { it in hiddenIds })
             currentRng = next
             val iterator = shuffledHidden.iterator()
             val shuffledLibrary = library.map { id ->
-                if (id in hiddenLibraryIds) iterator.next() else id
+                if (id in hiddenIds) iterator.next() else id
             }
-            sampled = sampled.copy(zones = sampled.zones + (libraryKey to shuffledLibrary))
+            sampled = sampled.copy(
+                entities = sampledEntities,
+                zones = sampled.zones + (libraryKey to shuffledLibrary),
+            )
         }
         return sampled
     }
@@ -116,19 +129,15 @@ class Determinizer internal constructor(
         state: GameState,
         opponentId: EntityId,
         viewerId: EntityId,
+        inFlightPins: Set<EntityId>,
     ): List<EntityId> {
         val handKey = ZoneKey(opponentId, Zone.HAND)
         val libraryKey = ZoneKey(opponentId, Zone.LIBRARY)
         val library = state.getLibrary(opponentId)
         val candidates = library + state.getHand(opponentId)
-        val inFlightPins = when (val pins = inFlightPinAnalysis(state)) {
-            is HiddenSlotRewrite.IdentitySensitiveInFlightPins.Complete -> pins.entityIds
-            // An incomplete traversal cannot justify sampling any hidden identity. HWM rejects the
-            // corresponding all-or-nothing request; sampling instead keeps every candidate slot.
-            is HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete -> return emptyList()
-        }
+        val libraryIds = library.toHashSet()
         return candidates.filter { id ->
-            val zoneKey = if (id in library) libraryKey else handKey
+            val zoneKey = if (id in libraryIds) libraryKey else handKey
             !visibility.isCardIdentityVisibleTo(state, zoneKey, id, viewerId) &&
                 id !in inFlightPins &&
                 isSafeToRewrite(state, id)

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
@@ -3,6 +3,8 @@ package com.wingedsheep.ai.engine.hidden
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.hidden.HiddenSlotRewrite
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
@@ -12,6 +14,7 @@ import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.engine.view.Visibility
 import com.wingedsheep.sdk.model.GameRng
+import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
@@ -21,6 +24,74 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 class DeterminizerInvariantsTest : ScenarioTestBase() {
 
     init {
+        test("sampling retains the pre-batching assignment and library sequence") {
+            val game = scenario().withPlayers().withRngSeed(883L)
+                .withCardInHand(1, "Forest")
+                .withCardInLibrary(1, "Mountain").withCardInLibrary(1, "Hill Giant")
+                .withCardInHand(2, "Mountain").withCardInHand(2, "Hill Giant")
+                .withCardInLibrary(2, "Grizzly Bears").withCardInLibrary(2, "Craw Wurm")
+                .build()
+            val revealed = game.state.getHand(game.player2Id).first()
+            val before = game.state.updateEntity(revealed) { it.with(RevealedToComponent.to(game.player1Id)) }
+            val originalEntities = before.entities.toMap()
+            val originalZones = before.zones.mapValues { it.value.toList() }
+            val models = listOf(
+                emptyMap<EntityId, OpponentModel>(),
+                mapOf(
+                    game.player1Id to OpponentModel.KnownDecklist(
+                        mapOf("Forest" to 1, "Mountain" to 1, "Hill Giant" to 1),
+                    ),
+                    game.player2Id to OpponentModel.KnownDecklist(
+                        mapOf("Mountain" to 1, "Hill Giant" to 1, "Grizzly Bears" to 1, "Craw Wurm" to 1),
+                    ),
+                ),
+            )
+            val sampler = Determinizer(cardRegistry)
+            val signature = buildString {
+                for (model in models) for (viewer in before.turnOrder) for (seed in 1L..16L) {
+                    val world = sampler.sample(before, viewer, model, GameRng.seeded(seed))
+                    world.copy(entities = before.entities, zones = before.zones) shouldBe before
+                    before.entities shouldBe originalEntities
+                    before.zones shouldBe originalZones
+                    world.getEntity(revealed) shouldBe before.getEntity(revealed)
+                    append(viewer.value).append('/').append(seed).append(':')
+                    world.entities.forEach { (id, components) ->
+                        append(id.value).append('=').append(components.get<CardComponent>()?.name).append(';')
+                    }
+                    append(world.zones).append('\n')
+                    val retainedEntities = world.entities.toMap()
+                    sampler.sample(world, viewer, model, GameRng.seeded(seed + 100))
+                    world.entities shouldBe retainedEntities
+                }
+            }
+            // Captured from the per-card-copy implementation at upstream 12589ae4a2.
+            java.security.MessageDigest.getInstance("SHA-256").digest(signature.toByteArray())
+                .joinToString("") { "%02x".format(it) } shouldBe
+                "fe26af39d1fb97c30edbebf726115360a34a390af7d4c15e9c00a80b3ca8620b"
+        }
+
+        test("library membership lookup retains duplicate occurrences and repeated player traversal") {
+            val game = scenario().withPlayers()
+                .withCardInLibrary(2, "Forest")
+                .withCardInLibrary(2, "Mountain")
+                .withCardInLibrary(2, "Hill Giant")
+                .build()
+            val libraryKey = ZoneKey(game.player2Id, Zone.LIBRARY)
+            val library = game.state.getLibrary(game.player2Id)
+            val duplicated = library + library.first()
+            val source = game.state.copy(
+                zones = game.state.zones + (libraryKey to duplicated),
+                turnOrder = game.state.turnOrder + game.player2Id,
+            )
+            val sampler = Determinizer(cardRegistry)
+            for (seed in 1L..16L) {
+                val world = sampler.sample(source, game.player1Id, OpponentModel.IdentityPermutation, GameRng.seeded(seed))
+                world.getLibrary(game.player2Id).shouldContainExactlyInAnyOrder(duplicated)
+                world.entities.keys.toList() shouldBe source.entities.keys.toList()
+                source.getLibrary(game.player2Id) shouldBe duplicated
+            }
+        }
+
         test("sampling preserves structure and everything visible to the viewer") {
             val game = scenario()
                 .withPlayers()
@@ -255,7 +326,9 @@ class DeterminizerInvariantsTest : ScenarioTestBase() {
             val candidateIdentities = candidateIds.associateWith {
                 source.getEntity(it)!!.require<CardComponent>()
             }
+            var analyses = 0
             val determinizer = Determinizer(cardRegistry, Visibility(cardRegistry)) {
+                analyses++
                 HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete("forced for test")
             }
 
@@ -270,6 +343,38 @@ class DeterminizerInvariantsTest : ScenarioTestBase() {
                 sampled.getEntity(entityId)!!.require<CardComponent>() shouldBe identity
             }
             sampled shouldBe source
+            analyses shouldBe 1
+        }
+
+        test("in-flight references are analyzed once for all players in a sample") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInHand(2, "Grizzly Bears")
+                .withCardInLibrary(2, "Hill Giant")
+                .build()
+            var analyses = 0
+            val determinizer = Determinizer(cardRegistry, Visibility(cardRegistry)) { state ->
+                analyses++
+                HiddenSlotRewrite.identitySensitiveInFlightPins(state)
+            }
+            val rng = GameRng.seeded(914L)
+
+            determinizer.sample(game.state, game.player1Id, OpponentModel.IdentityPermutation, rng) shouldBe
+                Determinizer(cardRegistry).sample(game.state, game.player1Id, OpponentModel.IdentityPermutation, rng)
+            analyses shouldBe 1
+        }
+
+        test("a position without players does not analyze in-flight references") {
+            val game = scenario().withPlayers().build()
+            val source = game.state.copy(turnOrder = emptyList())
+            val determinizer = Determinizer(cardRegistry, Visibility(cardRegistry)) {
+                error("There are no players to sample")
+            }
+
+            (determinizer.sample(source, game.player1Id, OpponentModel.IdentityPermutation, GameRng.seeded(915L)) ===
+                source) shouldBe true
         }
 
         test("the viewer does not retain knowledge of their own library order") {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
@@ -125,14 +125,15 @@ object HiddenSlotRewrite {
         container: ComponentContainer,
         currentDefinition: CardDefinition,
         ownerId: EntityId,
-    ): List<String> {
-        val expectedByType = CardEntityFactory.create(currentDefinition, ownerId)
-            .all()
-            .associateBy { it::class.java }
+    ): List<String> = runtimeBlockers(container, CardEntityFactory.create(currentDefinition, ownerId))
+
+    /** Reuse a factory-built expectation while still checking each source container separately. */
+    internal fun runtimeBlockers(container: ComponentContainer, expected: ComponentContainer): List<String> {
         return container.all()
-            .filterNot { it is CardComponent }
-            .filter { component -> expectedByType[component::class.java] != component }
-            .map { component -> component::class.simpleName ?: component::class.java.name }
+            .mapNotNull { component ->
+                if (component is CardComponent || expected.components[component::class.java] == component) null
+                else component::class.simpleName ?: component::class.java.name
+            }
             .sorted()
     }
 
@@ -154,10 +155,22 @@ object HiddenSlotRewrite {
         ownerId: EntityId,
     ): GameState {
         val source = state.getEntity(entityId) ?: return state
-        val rebuilt = CardEntityFactory.create(definition, ownerId)
-        val withController = source.get<ControllerComponent>()
+        return state.withEntity(entityId, rewrite(source, definition, ownerId))
+    }
+
+    /**
+     * The container-only form lets callers batch several rewrites into one entity-map copy.
+     * As with the state form, callers must first clear [runtimeBlockers] for the source slot.
+     */
+    fun rewrite(
+        source: ComponentContainer,
+        definition: CardDefinition,
+        ownerId: EntityId,
+    ): ComponentContainer = rewrite(source, CardEntityFactory.create(definition, ownerId))
+
+    /** Reuse a factory container already built and validated by the materializer. */
+    internal fun rewrite(source: ComponentContainer, rebuilt: ComponentContainer): ComponentContainer =
+        source.get<ControllerComponent>()
             ?.let { rebuilt.with(it) }
             ?: rebuilt.without<ControllerComponent>()
-        return state.withEntity(entityId, withController)
-    }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -5,6 +5,8 @@ import com.wingedsheep.engine.core.InFlightEntityReferences
 import com.wingedsheep.engine.core.InFlightReferenceProjector
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.sdk.core.Zone
@@ -113,7 +115,25 @@ class HiddenWorldMaterializer internal constructor(
                 )
             }
         }
-        var materialized = state
+        if (request.slotAssignments.isEmpty()) {
+            return HiddenWorldMaterializationResult.Materialized(state.copy(rng = request.futureRng))
+        }
+        // Preserve each occurrence, including duplicates within one zone. Validation below still
+        // chooses the first obstruction in assignment order; unrelated malformed slots are ignored.
+        // For one or two assignments the original scan costs less than building an index.
+        val memberships = if (request.slotAssignments.size > 2) {
+            mutableMapOf<EntityId, MutableList<ZoneKey>>().also { index ->
+                for ((zoneKey, ids) in state.zones) {
+                    for (id in ids) {
+                        if (id in request.slotAssignments) index.getOrPut(id) { mutableListOf() }.add(zoneKey)
+                    }
+                }
+            }
+        } else null
+        // Accumulate privately: validation still reads the source, and a refusal publishes nothing.
+        val materializedEntities = state.entities.toMutableMap()
+        // Deck copies share factory defaults, but ownership and per-slot runtime state still differ.
+        val expectedContainers = mutableMapOf<Pair<String, EntityId>, ComponentContainer>()
 
         // Slots are independent, so the order only decides *which* obstruction is reported when a
         // request has several. Sorting makes that report stable across equal requests.
@@ -131,20 +151,28 @@ class HiddenWorldMaterializer internal constructor(
                     listOf("slot is conservatively pinned by in-flight execution"),
                 )
             }
-            val zones = state.zones.filterValues { entityId in it }
-            val occurrences = zones.values.sumOf { zone -> zone.count { it == entityId } }
-            if (occurrences != 1 || zones.keys.singleOrNull()?.zoneType !in SUPPORTED_ZONES) {
+            val zones = if (memberships == null) state.zones.filterValues { entityId in it } else null
+            val indexedZones = memberships?.get(entityId).orEmpty()
+            val occurrences = if (zones != null) zones.values.sumOf { zone -> zone.count { it == entityId } }
+                else indexedZones.size
+            if (occurrences != 1) {
                 return unsupported(
                     UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
                     entityId,
                     listOf(
                         if (occurrences == 0) "entity is not in a zone"
-                        else if (occurrences > 1) "entity occurs in zones $occurrences times"
-                        else "supported slots are HAND/LIBRARY; found ${zones.keys.single().zoneType.name}"
+                        else "entity occurs in zones $occurrences times"
                     ),
                 )
             }
-            val zoneKey = zones.keys.single()
+            val zoneKey = zones?.keys?.single() ?: indexedZones.single()
+            if (zoneKey.zoneType !in SUPPORTED_ZONES) {
+                return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("supported slots are HAND/LIBRARY; found ${zoneKey.zoneType.name}"),
+                )
+            }
 
             val ownerId = container.get<OwnerComponent>()?.playerId
                 ?: return unsupported(
@@ -178,7 +206,10 @@ class HiddenWorldMaterializer internal constructor(
                     entityId,
                     listOf("source definition is not registered: ${currentCard.cardDefinitionId}"),
                 )
-            val blockers = HiddenSlotRewrite.runtimeBlockers(container, currentDefinition, ownerId)
+            val expected = expectedContainers.getOrPut(currentCard.cardDefinitionId to ownerId) {
+                CardEntityFactory.create(currentDefinition, ownerId)
+            }
+            val blockers = HiddenSlotRewrite.runtimeBlockers(container, expected)
             if (blockers.isNotEmpty()) {
                 return unsupported(UnsupportedHiddenWorldKind.RUNTIME_STATE, entityId, blockers)
             }
@@ -189,7 +220,8 @@ class HiddenWorldMaterializer internal constructor(
                     listOf("replacement HAND/LIBRARY identity is a DFC back face: ${replacementDefinition.name}"),
                 )
             }
-            val replacementDefinitionId = CardEntityFactory.create(replacementDefinition, ownerId)
+            val replacementContainer = CardEntityFactory.create(replacementDefinition, ownerId)
+            val replacementDefinitionId = replacementContainer
                 .require<CardComponent>()
                 .cardDefinitionId
             if (cardRegistry.getCard(replacementDefinitionId) != replacementDefinition) {
@@ -199,11 +231,11 @@ class HiddenWorldMaterializer internal constructor(
                     listOf("replacement definition is not registered: $replacementDefinitionId"),
                 )
             }
-            materialized = HiddenSlotRewrite.rewrite(materialized, entityId, replacementDefinition, ownerId)
+            materializedEntities[entityId] = HiddenSlotRewrite.rewrite(container, replacementContainer)
         }
 
         return HiddenWorldMaterializationResult.Materialized(
-            materialized.copy(rng = request.futureRng)
+            state.copy(entities = materializedEntities, rng = request.futureRng)
         )
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewriteTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewriteTest.kt
@@ -1,6 +1,11 @@
 package com.wingedsheep.engine.hidden
 
 import com.wingedsheep.engine.core.ContinuationFrame
+import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.MadnessComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.engine.core.DecisionContext
 import com.wingedsheep.engine.core.TypedEntityReferences
 import com.wingedsheep.engine.core.InFlightReferenceProjector
@@ -18,6 +23,21 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 class HiddenSlotRewriteTest : ScenarioTestBase() {
 
     init {
+        test("runtime blockers retain identity exclusions, decoration values, and sorted names") {
+            val owner = EntityId.of("owner")
+            val definition = cardRegistry.requireCard("Fiery Temper")
+            val expected = CardEntityFactory.create(definition, owner)
+            val renamed = expected.with(expected.require<CardComponent>().copy(name = "Printed alias"))
+            HiddenSlotRewrite.runtimeBlockers(renamed, definition, owner) shouldBe emptyList()
+
+            val changed = renamed
+                .with(RevealedToComponent.to(EntityId.of("viewer")))
+                .with(MadnessComponent(ManaCost.parse("{7}")))
+            HiddenSlotRewrite.runtimeBlockers(changed, definition, owner) shouldBe
+                listOf("MadnessComponent", "RevealedToComponent")
+            expected.require<MadnessComponent>().cost shouldNotBe ManaCost.parse("{7}")
+        }
+
         test("a Mind Rot paused graph pins its discard options but not an unrelated library slot") {
             val game = scenario()
                 .withPlayers()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.hidden
 
+import com.wingedsheep.engine.core.CardEntityFactory
 import com.wingedsheep.engine.core.CardsSelectedResponse
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.ChooseOptionDecision
@@ -14,6 +15,7 @@ import com.wingedsheep.engine.core.SubmitDecision
 import com.wingedsheep.engine.core.PlayLand
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.LastKnownPermanentComponent
@@ -64,6 +66,64 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
 
     init {
         cardRegistry.register(chooseThenShuffle)
+
+        test("zone membership retains multiplicity and sorted refusal order") {
+            val game = scenario().withPlayers()
+                .withCardInLibrary(2, "Forest").withCardInLibrary(2, "Mountain")
+                .withCardInLibrary(2, "Swamp")
+                .build()
+            val ids = game.state.getLibrary(game.player2Id).sortedBy { it.value }
+            val first = ids.first()
+            val later = ids.last()
+            val source = game.state.updateEntity(later) {
+                it.with(RevealedToComponent.to(game.player1Id))
+            }
+            val library = ZoneKey(game.player2Id, Zone.LIBRARY)
+            val hand = ZoneKey(game.player2Id, Zone.HAND)
+            val battlefield = ZoneKey(game.player2Id, Zone.BATTLEFIELD)
+            val withoutFirst = source.zones.mapValues { (_, cards) -> cards.filterNot { it == first } }
+            val cases = listOf(
+                withoutFirst to "entity is not in a zone",
+                (source.zones + (library to (source.zones.getValue(library) + first))) to
+                    "entity occurs in zones 2 times",
+                (source.zones + (hand to listOf(first))) to "entity occurs in zones 2 times",
+                (withoutFirst + (battlefield to listOf(first))) to
+                    "supported slots are HAND/LIBRARY; found BATTLEFIELD",
+            )
+            for ((zones, expectedDetail) in cases) {
+                val malformed = source.copy(zones = zones)
+                val result = materializer.materialize(
+                    malformed,
+                    HiddenWorldMaterializationRequest(
+                        // Insertion order opposes the required sorted failure order. The later
+                        // slot also fails, but its runtime-state refusal must not take precedence.
+                        ids.reversed().associateWith { cardRegistry.requireCard("Island") },
+                        GameRng.seeded(901L),
+                    ),
+                ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+                withClue(expectedDetail) {
+                    result.reason.kind shouldBe UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT
+                    result.reason.entityId shouldBe first
+                    result.reason.details shouldBe listOf(expectedDetail)
+                    materializer.materialize(
+                        malformed,
+                        HiddenWorldMaterializationRequest(
+                            mapOf(first to cardRegistry.requireCard("Island")),
+                            GameRng.seeded(901L),
+                        ),
+                    ) shouldBe result
+                    materializer.materialize(
+                        malformed,
+                        HiddenWorldMaterializationRequest(
+                            linkedMapOf(later to cardRegistry.requireCard("Island"), first to cardRegistry.requireCard("Island")),
+                            GameRng.seeded(901L),
+                        ),
+                    ) shouldBe result
+                    malformed.entities shouldBe source.entities
+                    malformed.rng shouldBe source.rng
+                }
+            }
+        }
 
         test("a Monstrous Emergence hand choice is pinned by the live stack object") {
             val game = scenario()
@@ -123,6 +183,7 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             val assignedIds = listOf(hiddenHandId) + hiddenLibraryIds
             val source = game.state
                 .copy(lastCardDrawnThisTurnByPlayer = mapOf(game.player2Id to hiddenHandId))
+            val sourceEntities = source.entities.toMap()
             val futureRng = GameRng.seeded(202L)
 
             val result = materializer.materialize(
@@ -144,6 +205,10 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             world.zones shouldBe source.zones
             world.lastCardDrawnThisTurnByPlayer shouldBe mapOf(game.player2Id to hiddenHandId)
             cardName(world, hiddenHandId) shouldBe "Fiery Temper"
+            world.getEntity(hiddenHandId)?.get<CardComponent>()?.cardDefinitionId shouldBe
+                CardEntityFactory.create(cardRegistry.requireCard("Fiery Temper"), game.player2Id)
+                    .require<CardComponent>().cardDefinitionId
+            world.getEntity(hiddenHandId)?.get<ControllerComponent>() shouldBe ControllerComponent(game.player2Id)
             cardName(world, hiddenLibraryIds[0]) shouldBe "Mountain"
             cardName(world, hiddenLibraryIds[1]) shouldBe "Island"
             withClue("definition-derived components are rebuilt for the assigned identity") {
@@ -159,7 +224,92 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             }
             withClue("materialization is purely functional") {
                 game.state.getEntity(hiddenHandId)?.get<CardComponent>()?.name shouldBe "Grizzly Bears"
+                source.entities shouldBe sourceEntities
+                world.entities.keys.toList() shouldBe source.entities.keys.toList()
+                val retainedEntities = world.entities.toMap()
+                materializer.materialize(
+                    world,
+                    HiddenWorldMaterializationRequest(
+                        assignedIds.associateWith { cardRegistry.requireCard("Swamp") },
+                        GameRng.seeded(203L),
+                    ),
+                ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>()
+                world.entities shouldBe retainedEntities
             }
+        }
+
+        test("a refusal after a valid slot leaves the entire input world unchanged") {
+            val game = scenario().withPlayers()
+                .withCardInLibrary(2, "Forest").withCardInLibrary(2, "Mountain")
+                .build()
+            val ids = game.state.getLibrary(game.player2Id).sortedBy { it.value }
+            val source = game.state.updateEntity(ids.last()) {
+                it.with(RevealedToComponent.to(game.player1Id))
+            }
+            val originalEntities = source.entities.toMap()
+            val originalRng = source.rng
+            val result = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    ids.associateWith { cardRegistry.requireCard("Island") },
+                    GameRng.seeded(204L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.RUNTIME_STATE
+            result.reason.entityId shouldBe ids.last()
+            source.entities shouldBe originalEntities
+            source.rng shouldBe originalRng
+        }
+
+        test("repeated source definitions retain owner-specific validation and per-slot blockers") {
+            val game = scenario().withPlayers()
+                .withCardInHand(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInHand(2, "Grizzly Bears")
+                .build()
+            val source = game.state
+            val slots = source.turnOrder.flatMap { source.getHand(it) + source.getLibrary(it) }
+            val request = HiddenWorldMaterializationRequest(
+                slots.associateWith { cardRegistry.requireCard("Forest") }, GameRng.seeded(321L),
+            )
+            val world = materializer.materialize(source, request)
+                .shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
+            for (id in slots) {
+                world.getEntity(id)!!.require<CardComponent>().ownerId shouldBe
+                    source.getEntity(id)!!.require<CardComponent>().ownerId
+            }
+
+            val blockedId = (source.getHand(game.player1Id) + source.getLibrary(game.player1Id))
+                .maxBy { it.value }
+            val blocked = source.updateEntity(blockedId) { it.with(RevealedToComponent.to(game.player2Id)) }
+            val originalEntities = blocked.entities.toMap()
+            val result = materializer.materialize(blocked, request)
+                .shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.RUNTIME_STATE
+            result.reason.entityId shouldBe blockedId
+            result.reason.details shouldBe listOf("RevealedToComponent")
+            blocked.entities shouldBe originalEntities
+            blocked.rng shouldBe source.rng
+        }
+
+        test("source validation observes registry changes between materialization requests") {
+            val game = scenario().withPlayers().withCardInHand(2, "Fiery Temper").build()
+            val registry = CardRegistry(cardRegistry)
+            val localMaterializer = HiddenWorldMaterializer(registry)
+            val id = game.state.getHand(game.player2Id).single()
+            val request = HiddenWorldMaterializationRequest(
+                mapOf(id to cardRegistry.requireCard("Forest")), GameRng.seeded(322L),
+            )
+            localMaterializer.materialize(game.state, request)
+                .shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>()
+
+            registry.register(cardRegistry.requireCard("Fiery Temper").copy(keywordAbilities = emptyList()))
+            val result = localMaterializer.materialize(game.state, request)
+                .shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.RUNTIME_STATE
+            result.reason.entityId shouldBe id
+            result.reason.details shouldBe listOf("MadnessComponent")
         }
 
         test("caller-generated assignments are reproducible and do not consume source randomness") {
@@ -417,6 +567,7 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
 
             world shouldBe source.copy(rng = futureRng)
+            (world.entities === source.entities) shouldBe true
         }
 
         test("a paused continuation consumes the caller RNG only when its later shuffle executes") {
@@ -524,6 +675,10 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
 
             result.reason.kind shouldBe UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES
             result.reason.entityId shouldBe null
+            rejectingMaterializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(emptyMap(), GameRng.seeded(619L)),
+            ) shouldBe result
             result.reason.details shouldContain "could not traverse pending decision test: forced"
             cardName(source, handId) shouldBe "Grizzly Bears"
             cardName(source, libraryId) shouldBe "Forest"


### PR DESCRIPTION
Hidden-world construction copies the entire entity map for each rewritten card and repeats source validation and membership scans across many slots. Search sampling pays these costs before any caller can observe the constructed world.

Batch entity replacements and reuse work local to the source position or materialization request:

- Publish one entity-map update per sampled player or materialization request, retaining the empty-request fast path after in-flight completeness validation.
- Reuse validated replacement containers and factory-default source expectations keyed by exact definition ID and owner. Compare against the factory's existing runtime-class index.
- Index zone occurrences for requests with more than two assignments, preserving duplicate occurrences and the direct scan for smaller requests.
- Analyze in-flight pins once per sample and use sets for library membership while keeping ordered lists authoritative for enumeration and shuffling.

Explicit materialization still validates the original state in sorted slot order, preserves controller absence, and returns the same first refusal without publishing a partial world. Sampling retains its RNG sequence and source-state pin semantics. The expected-component index relies on factory-built containers; arbitrary `ComponentContainer.with<T>()` insertions do not universally provide runtime-class keys.

### Measured examples

In a separate earlier MTGallium strict known-deck implementation of the same batching strategy, batching produced **3.45× as many sampled worlds per unit of thread CPU and 69% less allocation** (306.95 → 88.85 µs; 1,025,524 → 316,209 B per world). That was a fixed-state, single-JVM comparison with 1,000 warmups and ten old/new/new/old rounds of 100 calls per batch: 2,000 measured calls per variant, with 64 matched-world equality checks. It illustrates the mechanism; it did not measure this public implementation, the grouped branch, or end-to-end search.

An isolated public materializer comparison (`e7746fcd` → `27e95f23`) measured zone indexing on 104 assignments: 143.412 → 81.400 µs thread CPU and 382,648 → 355,080 B. One/two assignments kept allocation unchanged but timed 2–3% slower; three/four saved CPU while allocating 4–7% more. The benchmark used 1,000 warmups and ten old/new/new/old rounds of 100 calls per batch, with 448 matching full-result comparisons.

The other isolated changes likewise have workload-dependent benefits: larger libraries and repeated source definitions benefit most, while small or distinct-definition requests sometimes regress. Shared pin analysis helps paused positions but has not demonstrated a general ordinary-position sampling gain. Constituent speedups overlap and must not be multiplied into a package estimate.

### Verification

All 35 focused tests pass for this independent group (`12589ae4a22e` → `ca8b9faf25b1`). The [complete combined source at b24f2e1191c7](https://github.com/huxinq/argentum-engine/commit/b24f2e1191c7f4fd83e7c508548346e3a4375495) also passed `just test-rules` (13,375 engine and card-scenario tests) and all 13 `DeterminizerInvariantsTest` tests. The four independent group diffs together reproduce that tested source exactly ([combined diff](https://github.com/huxinq/argentum-engine/compare/12589ae4a22e2abba0bc0274e88e38836d3b92be...b24f2e1191c7f4fd83e7c508548346e3a4375495)). These are locally recorded test results; publishing the source makes the tree comparison independently checkable, but does not provide a public CI reproduction.

Coverage includes both sampling models and viewers across seeds, exact ordering, malformed duplicate zone membership, first-refusal precedence, controller preservation/absence, registry overlays between requests, and source/retained-world immutability.
