### PR TITLE
Avoid temporary characteristic collections during projection

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
@@ -116,22 +116,26 @@ class StateProjector(
                 projectedValues[entityId] = MutableProjectedValues(
                     power = baseStats?.basePower,
                     toughness = baseStats?.baseToughness,
-                    keywords = (cardComponent.baseKeywords.map { it.name } +
-                        cardComponent.baseFlags.map { it.name } +
-                        (container.get<ProtectionComponent>()?.colors?.map { "PROTECTION_FROM_${it.name}" } ?: emptyList()) +
-                        (container.get<ProtectionComponent>()?.subtypes?.map { "PROTECTION_FROM_SUBTYPE_${it.uppercase()}" } ?: emptyList()) +
-            (container.get<ProtectionComponent>()?.supertypes?.map { "PROTECTION_FROM_SUPERTYPE_${it.uppercase()}" } ?: emptyList()) +
-                        (container.get<ProtectionComponent>()?.cardTypes?.map { "PROTECTION_FROM_CARDTYPE_$it" } ?: emptyList()) +
-                        (container.get<HexproofFromComponent>()?.colors?.map { "HEXPROOF_FROM_${it.name}" } ?: emptyList()) +
-                        (container.get<HexproofFromComponent>()?.cardTypes?.map { "HEXPROOF_FROM_CARDTYPE_$it" } ?: emptyList()) +
-                        (container.get<ToxicComponent>()?.let { listOf("TOXIC_${it.amount}") } ?: emptyList()) +
-                        // CR 702.109a: "as long as this permanent's dash cost was paid, it has
-                        // haste" — derived live from the marker every projection, not stored as a
-                        // floating effect (see DashedComponent's doc for why).
-                        (if (container.has<DashedComponent>()) listOf(Keyword.HASTE.name) else emptyList())).toMutableSet(),
-                    colors = cardComponent.colors.map { it.name }.toMutableSet(),
+                    keywords = linkedSetOf<String>().apply {
+                        cardComponent.baseKeywords.forEach { add(it.name) }
+                        cardComponent.baseFlags.forEach { add(it.name) }
+                        container.get<ProtectionComponent>()?.let { protection ->
+                            protection.colors.forEach { add("PROTECTION_FROM_${it.name}") }
+                            protection.subtypes.forEach { add("PROTECTION_FROM_SUBTYPE_${it.uppercase()}") }
+                            protection.supertypes.forEach { add("PROTECTION_FROM_SUPERTYPE_${it.uppercase()}") }
+                            protection.cardTypes.forEach { add("PROTECTION_FROM_CARDTYPE_$it") }
+                        }
+                        container.get<HexproofFromComponent>()?.let { hexproof ->
+                            hexproof.colors.forEach { add("HEXPROOF_FROM_${it.name}") }
+                            hexproof.cardTypes.forEach { add("HEXPROOF_FROM_CARDTYPE_$it") }
+                        }
+                        container.get<ToxicComponent>()?.let { add("TOXIC_${it.amount}") }
+                        // Dash supplies haste from the live marker on every projection.
+                        if (container.has<DashedComponent>()) add(Keyword.HASTE.name)
+                    },
+                    colors = cardComponent.colors.mapTo(linkedSetOf()) { it.name },
                     types = extractTypes(cardComponent),
-                    subtypes = cardComponent.typeLine.subtypes.map { it.value }.toMutableSet(),
+                    subtypes = cardComponent.typeLine.subtypes.mapTo(linkedSetOf()) { it.value },
                     controllerId = container.get<ControllerComponent>()?.playerId,
                     isFaceDown = false
                 )
@@ -394,16 +398,17 @@ class StateProjector(
         // Growth, Aggressive Urge), and lord-style anthems alike.
         applyAffectedPowerAtMostSourceGate(state, projectedValues)
 
-        // Convert to immutable
+        // Transfer the locally owned sets into the final projection. No later step mutates them;
+        // intermediate projections still copy their sets because subsequent layers can change them.
         val finalValues = projectedValues.mapValues { (_, v) ->
             ProjectedValues(
                 power = v.power,
                 toughness = v.toughness,
                 name = v.name,
-                keywords = v.keywords.toSet(),
-                colors = v.colors.toSet(),
-                types = v.types.toSet(),
-                subtypes = v.subtypes.toSet(),
+                keywords = v.keywords,
+                colors = v.colors,
+                types = v.types,
+                subtypes = v.subtypes,
                 controllerId = v.controllerId,
                 isFaceDown = v.isFaceDown,
                 isSuspected = v.isSuspected,
@@ -519,10 +524,10 @@ class StateProjector(
     }
 
     private fun extractTypes(card: CardComponent): MutableSet<String> {
-        val types = mutableSetOf<String>()
-        types.addAll(card.typeLine.supertypes.map { it.name })
-        types.addAll(card.typeLine.cardTypes.map { it.name })
-        types.addAll(card.typeLine.subtypes.map { it.value })
+        val types = linkedSetOf<String>()
+        card.typeLine.supertypes.forEach { types.add(it.name) }
+        card.typeLine.cardTypes.forEach { types.add(it.name) }
+        card.typeLine.subtypes.forEach { types.add(it.value) }
         return types
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedSetInitializationTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedSetInitializationTest.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.engine.mechanics.layers
+
+import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.DashedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.HexproofFromComponent
+import com.wingedsheep.engine.state.components.identity.ProtectionComponent
+import com.wingedsheep.engine.state.components.identity.ToxicComponent
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ProjectedSetInitializationTest : FunSpec({
+    test("projection retains ordered encoded keywords, duplicate collapse, colors, and subtypes") {
+        val owner = EntityId.of("owner")
+        val id = EntityId.of("permanent")
+        val definition = card("Projection Set Witness") {
+            manaCost = "{W}{U}"
+            typeLine = "Legendary Artifact Creature — Bear Warrior"
+            power = 2
+            toughness = 2
+        }
+        val original = CardEntityFactory.create(definition, owner)
+        val container = original.with(original.require<CardComponent>().copy(
+            baseKeywords = linkedSetOf(Keyword.HASTE, Keyword.HEXPROOF),
+            baseFlags = linkedSetOf(AbilityFlag.CANT_BE_BLOCKED),
+            colors = linkedSetOf(Color.BLUE, Color.WHITE),
+        )).with(ProtectionComponent(
+            colors = linkedSetOf(Color.BLUE, Color.RED),
+            subtypes = linkedSetOf("Goblin"),
+            supertypes = linkedSetOf("Legendary"),
+            cardTypes = linkedSetOf("ARTIFACT", "creature"),
+        )).with(HexproofFromComponent(
+            colors = linkedSetOf(Color.WHITE),
+            cardTypes = linkedSetOf("INSTANT", "sorcery"),
+        )).with(ToxicComponent(0)).with(DashedComponent)
+        val source = GameState(
+            entities = mapOf(id to container),
+            zones = mapOf(ZoneKey(owner, Zone.BATTLEFIELD) to listOf(id)),
+        )
+        val projected = StateProjector().project(source)
+        projected.getKeywords(id).toList() shouldBe listOf(
+            "HASTE", "HEXPROOF", "CANT_BE_BLOCKED",
+            "PROTECTION_FROM_BLUE", "PROTECTION_FROM_RED", "PROTECTION_FROM_SUBTYPE_GOBLIN",
+            "PROTECTION_FROM_SUPERTYPE_LEGENDARY", "PROTECTION_FROM_CARDTYPE_ARTIFACT",
+            "PROTECTION_FROM_CARDTYPE_creature", "HEXPROOF_FROM_WHITE",
+            "HEXPROOF_FROM_CARDTYPE_INSTANT", "HEXPROOF_FROM_CARDTYPE_sorcery", "TOXIC_0",
+        )
+        projected.getColors(id).toList() shouldBe listOf("BLUE", "WHITE")
+        projected.getSubtypes(id).toList() shouldBe listOf("Bear", "Warrior")
+        source.getEntity(id) shouldBe container
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedSetOwnershipTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedSetOwnershipTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.mechanics.layers
+
+import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TextReplacement
+import com.wingedsheep.engine.state.components.identity.TextReplacementCategory
+import com.wingedsheep.engine.state.components.identity.TextReplacementComponent
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ProjectedSetOwnershipTest : FunSpec({
+    test("final characteristic sets stay isolated across entities and later projections") {
+        val owner = EntityId.of("owner")
+        val first = EntityId.of("first")
+        val second = EntityId.of("second")
+        val definition = card("Projection Ownership Witness") {
+            manaCost = "{W}{U}"
+            typeLine = "Legendary Artifact Creature — Bear Warrior"
+            power = 2
+            toughness = 2
+        }
+        val factory = CardEntityFactory.create(definition, owner)
+        val card = factory.require<CardComponent>().copy(
+            baseKeywords = linkedSetOf(Keyword.HASTE, Keyword.HEXPROOF),
+            colors = linkedSetOf(Color.BLUE, Color.WHITE),
+        )
+        val container = factory.with(card)
+        val source = GameState(
+            entities = linkedMapOf(first to container, second to container),
+            zones = mapOf(ZoneKey(owner, Zone.BATTLEFIELD) to listOf(first, second)),
+        )
+        val projector = StateProjector()
+        val retained = projector.project(source)
+        val changed = source.withEntity(first, container.with(card.copy(
+            baseKeywords = linkedSetOf(Keyword.FLYING),
+            colors = linkedSetOf(Color.RED),
+        )).with(TextReplacementComponent(listOf(
+            TextReplacement("Bear", "Goblin", TextReplacementCategory.CREATURE_TYPE),
+        ))))
+        val later = projector.project(changed)
+
+        later.getKeywords(first).toList() shouldBe listOf("FLYING")
+        later.getColors(first).toList() shouldBe listOf("RED")
+        later.getTypes(first).toList() shouldBe listOf("LEGENDARY", "ARTIFACT", "CREATURE", "Goblin", "Warrior")
+        later.getSubtypes(first).toList() shouldBe listOf("Goblin", "Warrior")
+        for ((projection, id) in listOf(retained to first, retained to second, later to second)) {
+            projection.getKeywords(id).toList() shouldBe listOf("HASTE", "HEXPROOF")
+            projection.getColors(id).toList() shouldBe listOf("BLUE", "WHITE")
+            projection.getTypes(id).toList() shouldBe listOf("LEGENDARY", "ARTIFACT", "CREATURE", "Bear", "Warrior")
+            projection.getSubtypes(id).toList() shouldBe listOf("Bear", "Warrior")
+        }
+        projector.project(source).getAllProjectedValues() shouldBe retained.getAllProjectedValues()
+        source.getEntity(first) shouldBe container
+        source.getEntity(second) shouldBe container
+        card.baseKeywords.toList() shouldBe listOf(Keyword.HASTE, Keyword.HEXPROOF)
+        card.colors.toList() shouldBe listOf(Color.BLUE, Color.WHITE)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedTypeNamesTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedTypeNamesTest.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.engine.mechanics.layers
+
+import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.TextReplacement
+import com.wingedsheep.engine.state.components.identity.TextReplacementCategory
+import com.wingedsheep.engine.state.components.identity.TextReplacementComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ProjectedTypeNamesTest : FunSpec({
+    test("projected type names preserve ordered supertypes, card types, and replaced subtypes") {
+        val owner = EntityId.of("owner")
+        val id = EntityId.of("permanent")
+        val definition = card("Type Witness") {
+            manaCost = "{0}"
+            typeLine = "Legendary Artifact Creature — Bear Warrior"
+            power = 2
+            toughness = 2
+        }
+        val source = GameState(
+            entities = mapOf(id to CardEntityFactory.create(definition, owner)),
+            zones = mapOf(ZoneKey(owner, Zone.BATTLEFIELD) to listOf(id)),
+        )
+        val projector = StateProjector()
+        val original = projector.project(source)
+        original.getTypes(id).toList() shouldBe listOf("LEGENDARY", "ARTIFACT", "CREATURE", "Bear", "Warrior")
+        original.getSubtypes(id).toList() shouldBe listOf("Bear", "Warrior")
+
+        val changed = source.updateEntity(id) {
+            it.with(TextReplacementComponent(listOf(TextReplacement("Bear", "Goblin", TextReplacementCategory.CREATURE_TYPE))))
+        }
+        val projected = projector.project(changed)
+        projected.getTypes(id).toList() shouldBe listOf("LEGENDARY", "ARTIFACT", "CREATURE", "Goblin", "Warrior")
+        projected.getSubtypes(id).toList() shouldBe listOf("Goblin", "Warrior")
+        original.getTypes(id).toList() shouldBe listOf("LEGENDARY", "ARTIFACT", "CREATURE", "Bear", "Warrior")
+    }
+})


### PR DESCRIPTION
Every fresh state projection builds keyword, color, type, and subtype collections for each permanent. The current path allocates intermediate mapped lists during initialization and copies all four completed sets again at final publication.

Insert characteristic strings directly into ordered mutable sets, then transfer those sets into the final projection after all writes finish. Every entity and projection invocation owns its sets. Intermediate projections retain their copies because subsequent layers still mutate the source values. Type strings still include subtypes, as required by text replacement, and insertion order is preserved.

### Isolated allocation measurements

The constituent changes were measured separately against public `12589ae4`, using explicit fresh `StateProjector.project()` calls over prebuilt synthetic states with coverage disabled:

| Change and measured head | Allocated-byte reduction across its fixtures |
| --- | ---: |
| Collect type names directly (`a5a2b90f`) | About 4.5–4.9% |
| Build initial characteristic sets directly (`8183114d`) | About 17–27% |
| Transfer final sets (`6e828cea`) | 12.3–19.5% |

These are overlapping isolated measurements, not additive reductions or a measurement of this combined branch. Fixtures vary in permanent count and characteristic decoration. CPU was less consistent on small positions. For final transfer, eight fixtures each used 10,000 warmups per variant and ten old/new/new/old rounds of 500 calls per batch; allocation improved in every round. One decorated eight-permanent CPU round was 21.6% slower, while the noisy two-permanent decorated mean improved 27% with a median paired improvement near 16%. The evidence supports allocation reduction during fresh projection, not cached projection reads or an end-to-end gameplay speedup.

### Verification

All 81 focused tests pass for this independent group (`12589ae4a22e` → `3e47a0e32a83`). The [complete combined source at b24f2e1191c7](https://github.com/huxinq/argentum-engine/commit/b24f2e1191c7f4fd83e7c508548346e3a4375495) also passed `just test-rules` (13,375 engine and card-scenario tests) and all 13 `DeterminizerInvariantsTest` tests. The four independent group diffs together reproduce that tested source exactly ([combined diff](https://github.com/huxinq/argentum-engine/compare/12589ae4a22e2abba0bc0274e88e38836d3b92be...b24f2e1191c7f4fd83e7c508548346e3a4375495)). These are locally recorded test results; publishing the source makes the tree comparison independently checkable, but does not provide a public CI reproduction.

The regressions require exact keyword/color/type/subtype order, encoded keyword and flag handling, subtype text replacement in both representations, source preservation, and isolation across entities sharing a source container and across later projections. Layer and controller-projection tests exercise the intermediate snapshots retained by the implementation.
