### PR TITLE
Reduce component-container copying and batch combat cleanup

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatManager.kt
@@ -128,10 +128,8 @@ class CombatManager(
     // =========================================================================
 
     fun endCombat(state: GameState): ExecutionResult {
-        var newState = state
-
-        for ((entityId, _) in state.entities) {
-            newState = newState.updateEntity(entityId) { container ->
+        var newState = if (state.entities.isEmpty()) state else state.copy(
+            entities = state.entities.mapValues { (_, container) ->
                 container
                     .without<AttackingComponent>()
                     .without<BlockingComponent>()
@@ -146,7 +144,7 @@ class CombatManager(
                     .without<AttackedThisCombatComponent>()
                     .without<BlockedThisCombatComponent>()
             }
-        }
+        )
 
         // Expire "until end of combat" effects (CR 511.2: they expire at the end of the combat
         // phase, which per CR 511.3 is once the end of combat step has ended — i.e. here, the same

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/ComponentContainer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/ComponentContainer.kt
@@ -53,10 +53,12 @@ data class ComponentContainer(
     }
 
     /**
-     * Remove a component type (returns new container).
+     * Remove a component type, retaining this container when the type is absent.
      */
     inline fun <reified T : Component> without(): ComponentContainer {
-        return ComponentContainer(components - T::class.java)
+        val key = T::class.java
+        if (!components.containsKey(key)) return this
+        return ComponentContainer(components - key)
     }
 
     /**
@@ -76,15 +78,22 @@ data class ComponentContainer(
          * Create a container with the given components.
          */
         fun of(vararg components: Component): ComponentContainer {
-            return components.fold(EMPTY) { container, component ->
-                container.withComponent(component)
+            if (components.isEmpty()) return EMPTY
+            if (components.size == 1) {
+                val component = components[0]
+                return ComponentContainer(java.util.Collections.singletonMap(component::class.java, component))
             }
+
+            val byType = LinkedHashMap<Class<*>, Component>(components.size)
+            for (component in components) {
+                byType[component::class.java] = component
+            }
+            return ComponentContainer(byType)
         }
     }
 
     /**
      * Internal method to add a component without inline reification.
-     * Used by the of() factory method.
      */
     fun withComponent(component: Component): ComponentContainer {
         val key = component::class.java

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/ComponentContainerSerializationRoundTripTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/ComponentContainerSerializationRoundTripTest.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.hygiene
 
 import com.wingedsheep.engine.core.engineSerializersModule
 import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.Component
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
@@ -53,5 +54,52 @@ class ComponentContainerSerializationRoundTripTest : FunSpec({
             json.encodeToString(ComponentContainer.serializer(), ComponentContainer.EMPTY)
         )
         decoded.isEmpty() shouldBe true
+    }
+
+    test("factory retains empty identity and keys a single component by runtime type") {
+        (ComponentContainer.of() === ComponentContainer.EMPTY) shouldBe true
+        val component: Component = LifeTotalComponent(20)
+        val container = ComponentContainer.of(component)
+        container.get<LifeTotalComponent>() shouldBe component
+        container.get<Component>() shouldBe null
+    }
+
+    test("factory replaces duplicate classes without moving their iteration or serialized position") {
+        val components: Array<Component> = arrayOf(LifeTotalComponent(20), TappedComponent, LifeTotalComponent(37))
+        val container = ComponentContainer.of(*components)
+        val expected = listOf(LifeTotalComponent(37), TappedComponent)
+
+        container.all().toList() shouldBe expected
+        container.get<LifeTotalComponent>() shouldBe LifeTotalComponent(37)
+        container.has<TappedComponent>() shouldBe true
+        val encoded = json.encodeToString(ComponentContainer.serializer(), container)
+        val sequential = ComponentContainer.EMPTY.withComponent(LifeTotalComponent(37)).withComponent(TappedComponent)
+        encoded shouldBe json.encodeToString(ComponentContainer.serializer(), sequential)
+        json.decodeFromString(ComponentContainer.serializer(), encoded).all().toList() shouldBe expected
+
+        components[0] = SummoningSicknessComponent
+        container.with(LifeTotalComponent(1)).without<TappedComponent>()
+        ComponentContainer.of(SummoningSicknessComponent, LifeTotalComponent(2))
+        container.all().toList() shouldBe expected
+    }
+
+    test("removing an absent exact component type retains the container") {
+        val container = ComponentContainer.of(LifeTotalComponent(20), SummoningSicknessComponent)
+        val encoded = json.encodeToString(ComponentContainer.serializer(), container)
+
+        (container.without<TappedComponent>() === container) shouldBe true
+        (container.without<Component>() === container) shouldBe true
+        (ComponentContainer.EMPTY.without<TappedComponent>() === ComponentContainer.EMPTY) shouldBe true
+        json.encodeToString(ComponentContainer.serializer(), container) shouldBe encoded
+    }
+
+    test("removing a present component preserves the source and remaining component order") {
+        val container = ComponentContainer.of(LifeTotalComponent(20), TappedComponent, SummoningSicknessComponent)
+        val removed = container.without<TappedComponent>()
+
+        removed.has<TappedComponent>() shouldBe false
+        removed.all().toList() shouldBe listOf(LifeTotalComponent(20), SummoningSicknessComponent)
+        container.all().toList() shouldBe listOf(LifeTotalComponent(20), TappedComponent, SummoningSicknessComponent)
+        json.decodeFromString(ComponentContainer.serializer(), json.encodeToString(ComponentContainer.serializer(), removed)) shouldBe removed
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/combat/CombatCleanupTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/combat/CombatCleanupTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.mechanics.combat
+
+import com.wingedsheep.engine.mechanics.mana.ManaAbilitySideEffectExecutor
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.combat.AttackedThisCombatComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.player.RestrictedManaEntry
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.ManaExpiry
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class CombatCleanupTest : FunSpec({
+    val registry = CardRegistry()
+    val manager = CombatManager(registry, ManaAbilitySideEffectExecutor(registry) { _, _, _ ->
+        error("Combat cleanup must not execute mana-ability side effects")
+    })
+
+    test("combat cleanup preserves entity order and source while clearing markers and combat mana") {
+        val player = EntityId.of("player")
+        val attacker = EntityId.of("attacker")
+        val ordinary = EntityId.of("ordinary")
+        val combatMana = RestrictedManaEntry(Color.RED, ManaRestriction.AnySpend, expiry = ManaExpiry.END_OF_COMBAT)
+        val turnMana = RestrictedManaEntry(Color.BLUE, ManaRestriction.AnySpend)
+        val pool = ManaPoolComponent(green = 2, restrictedMana = listOf(combatMana, turnMana))
+        val entities = linkedMapOf(
+            attacker to ComponentContainer.of(AttackingComponent(player), LifeTotalComponent(3), AttackedThisCombatComponent),
+            player to ComponentContainer.of(LifeTotalComponent(20), pool),
+            ordinary to ComponentContainer.of(LifeTotalComponent(7)),
+        )
+        val source = GameState(entities = entities, turnOrder = listOf(player))
+        val result = manager.endCombat(source)
+
+        result.events shouldBe emptyList()
+        result.state.entities.keys.toList() shouldBe entities.keys.toList()
+        result.state.getEntity(attacker)!!.all().toList() shouldBe listOf(LifeTotalComponent(3))
+        result.state.getEntity(ordinary) shouldBe entities[ordinary]
+        result.state.getEntity(player)!!.all().toList() shouldBe listOf(
+            LifeTotalComponent(20), pool.copy(restrictedMana = listOf(turnMana))
+        )
+        source.getEntity(attacker)!!.has<AttackingComponent>() shouldBe true
+        source.getEntity(player)!!.get<ManaPoolComponent>() shouldBe pool
+        val retained = result.state.entities.toMap()
+        manager.endCombat(source)
+        result.state.entities shouldBe retained
+    }
+
+    test("empty combat cleanup retains the state") {
+        val state = GameState()
+        (manager.endCombat(state).state === state) shouldBe true
+    }
+})


### PR DESCRIPTION
Constructing a component container copies a growing map for every input. Removing an absent component also creates a new container, and combat cleanup repeats a whole-entity-map copy for every entity while clearing combat markers. Together these create avoidable allocation during card construction and combat transitions.

Build multi-component containers with one ordered runtime-class map, retain containers when an exact component type is absent, and clear combat markers with one entity-map publication. Empty construction retains `EMPTY`; singleton construction uses a singleton map. Duplicate component classes keep their first iteration position and last value. Present removals still preserve source containers, and combat's later duration, counter-modifier, and mana expiry stages retain their existing behavior.

### Measured examples

Isolated container construction (`12589ae4` → `09fb2bfd`) for the card/owner/controller triple fell from 163.5 to 54.0 ns thread CPU and 728 to 264 B per call. Eight distinct components fell from 590.2 to 103.2 ns and 3,128 to 576 B. Each input had 100,000 warmups per variant and ten old/new/new/old rounds of 5,000 calls per batch. Empty calls were about 1.5 ns slower with equal allocation; singleton aggregate gains did not establish a steady-state improvement. Component-value creation and full card construction were excluded.

Isolated batched `endCombat` (`12589ae4` → `f6057679`) on a fixed 32-card-plus-player state fell from 46.859 to 24.304 µs and 195,472 to 134,392 B. That fixture included combat markers and expiring mana; it used 5,000 warmups per variant and ten old/new/new/old rounds of 100 calls per batch. Other duration expiry is covered by tests. Separately, absent-removal fast paths eliminated container allocation for absent types, while present-removal microbenchmarks timed about 2–10% slower.

These are single-JVM measurements of constituent operations. Their percentages overlap and do not quantify the combined branch or gameplay throughput.

### Verification

All 30 focused tests pass for this independent group (`12589ae4a22e` → `10afcbe70e2e`). The [complete combined source at b24f2e1191c7](https://github.com/huxinq/argentum-engine/commit/b24f2e1191c7f4fd83e7c508548346e3a4375495) also passed `just test-rules` (13,375 engine and card-scenario tests) and all 13 `DeterminizerInvariantsTest` tests. The four independent group diffs together reproduce that tested source exactly ([combined diff](https://github.com/huxinq/argentum-engine/compare/12589ae4a22e2abba0bc0274e88e38836d3b92be...b24f2e1191c7f4fd83e7c508548346e3a4375495)). These are locally recorded test results; publishing the source makes the tree comparison independently checkable, but does not provide a public CI reproduction.

Coverage checks runtime-class indexing, duplicate replacement order, serialized order and round trips, input-array independence, absent-removal identity, present-removal isolation, exact combat cleanup, and combat/duration/mana behavior.
