### PR TITLE
Avoid redundant scans and temporary collections in ability lookup

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
@@ -69,7 +69,8 @@ class TriggerAbilityResolver(
             val cardDef = cardRegistry.getCard(cardDefinitionId)
             val classLevel = state.getEntity(entityId)?.get<ClassLevelComponent>()?.currentLevel
             val topLevel = cardDef?.script?.effectiveTriggeredAbilities(classLevel) ?: emptyList()
-            topLevel + getRoomFaceTriggeredAbilities(entityId, cardDef, state)
+            val roomAbilities = getRoomFaceTriggeredAbilities(entityId, cardDef, state)
+            if (roomAbilities.isEmpty()) topLevel else topLevel + roomAbilities
         }
 
         // Merge in any temporarily granted triggered abilities (e.g., from Commando Raid).
@@ -77,13 +78,21 @@ class TriggerAbilityResolver(
         // Mannequin's sacrifice rider lasts only while the mannequin counter is there, and the
         // counter can leave between two state-based-action passes. The one-way latch that stops a
         // re-added counter resurrecting the grant lives in EndedDurationExpiryCheck.
-        val grantedAbilities = state.grantedTriggeredAbilities
-            .filter { it.entityId == entityId && GrantDurationGate.holds(state, it.entityId, it.sourceId, it.duration) }
-            .map { it.ability }
+        val grantedAbilities = buildList {
+            for (grant in state.grantedTriggeredAbilities) {
+                if (grant.entityId == entityId &&
+                    GrantDurationGate.holds(state, grant.entityId, grant.sourceId, grant.duration)
+                ) {
+                    add(grant.ability)
+                }
+            }
+        }
 
         // Merge in triggered abilities granted by static abilities on other permanents
         // (e.g., Hunter Sliver granting provoke to all Slivers)
-        val staticGrantedAbilities = getStaticGrantedTriggeredAbilities(entityId, state)
+        // The index includes every battlefield/soulbond provider this scan can use.
+        val staticGrantedAbilities = if (statics.triggerGrantProviders.isEmpty()) emptyList()
+            else getStaticGrantedTriggeredAbilities(entityId, state)
         val attachedGrantedAbilities = getAttachedGrantedTriggeredAbilities(entityId, state, statics)
         // "This creature has '<triggered ability>' [as long as …]" — a Scope.Self GrantTriggeredAbility
         // on the permanent's own definition, optionally gated by a ConditionalStaticAbility.
@@ -125,10 +134,21 @@ class TriggerAbilityResolver(
         // gates it, the printed KeywordAbility.Numeric supplies N.
         val renownAbilities = getRenownTriggeredAbilities(entityId, cardDefinitionId, state)
 
-        val allGranted = grantedAbilities + staticGrantedAbilities + attachedGrantedAbilities +
-            selfGrantedAbilities + wardAbilities + flankingAbilities + ringBearerAbilities +
-            suspendAbilities + paradigmAbilities + siegeAbilities + vanishingAbilities +
-            fabricateAbilities + renownAbilities
+        val allGranted = buildList {
+            addAll(grantedAbilities)
+            addAll(staticGrantedAbilities)
+            addAll(attachedGrantedAbilities)
+            addAll(selfGrantedAbilities)
+            addAll(wardAbilities)
+            addAll(flankingAbilities)
+            addAll(ringBearerAbilities)
+            addAll(suspendAbilities)
+            addAll(paradigmAbilities)
+            addAll(siegeAbilities)
+            addAll(vanishingAbilities)
+            addAll(fabricateAbilities)
+            addAll(renownAbilities)
+        }
         val combined = if (allGranted.isNotEmpty()) base + allGranted else base
 
         // Apply text replacement if the entity has one
@@ -273,14 +293,21 @@ class TriggerAbilityResolver(
                 val cardDef = cardRegistry.getCard(cardDefinitionId)
                 val classLevel = state.getEntity(entityId)?.get<ClassLevelComponent>()?.currentLevel
                 val topLevel = cardDef?.script?.effectiveTriggeredAbilities(classLevel) ?: emptyList()
-                topLevel + getRoomFaceTriggeredAbilities(entityId, cardDef, state)
+                val roomAbilities = getRoomFaceTriggeredAbilities(entityId, cardDef, state)
+                if (roomAbilities.isEmpty()) topLevel else topLevel + roomAbilities
             }
         }
 
         // Same per-read "for as long as …" gate as the other lookup path above.
-        val grantedAbilities = state.grantedTriggeredAbilities
-            .filter { it.entityId == entityId && GrantDurationGate.holds(state, it.entityId, it.sourceId, it.duration) }
-            .map { it.ability }
+        val grantedAbilities = buildList {
+            for (grant in state.grantedTriggeredAbilities) {
+                if (grant.entityId == entityId &&
+                    GrantDurationGate.holds(state, grant.entityId, grant.sourceId, grant.duration)
+                ) {
+                    add(grant.ability)
+                }
+            }
+        }
 
         val staticGrantedAbilities = if (grantProviders.isNotEmpty()) {
             getStaticGrantedFromProviders(entityId, state, grantProviders)
@@ -329,10 +356,21 @@ class TriggerAbilityResolver(
         // gates it, the printed KeywordAbility.Numeric supplies N.
         val renownAbilities = getRenownTriggeredAbilities(entityId, cardDefinitionId, state)
 
-        val allGranted = grantedAbilities + staticGrantedAbilities + attachedGrantedAbilities +
-            selfGrantedAbilities + wardAbilities + flankingAbilities + ringBearerAbilities +
-            suspendAbilities + paradigmAbilities + siegeAbilities + vanishingAbilities +
-            fabricateAbilities + renownAbilities
+        val allGranted = buildList {
+            addAll(grantedAbilities)
+            addAll(staticGrantedAbilities)
+            addAll(attachedGrantedAbilities)
+            addAll(selfGrantedAbilities)
+            addAll(wardAbilities)
+            addAll(flankingAbilities)
+            addAll(ringBearerAbilities)
+            addAll(suspendAbilities)
+            addAll(paradigmAbilities)
+            addAll(siegeAbilities)
+            addAll(vanishingAbilities)
+            addAll(fabricateAbilities)
+            addAll(renownAbilities)
+        }
         val combined = if (allGranted.isNotEmpty()) base + allGranted else base
 
         val textReplacement = state.getEntity(entityId)?.get<TextReplacementComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -1030,20 +1030,21 @@ class CastPermissionUtils(
         abilityIsManaAbility: Boolean = false
     ): Boolean {
         val projected = state.projectedState
-        for (entityId in state.getBattlefield()) {
+        battlefield@ for (entityId in state.getBattlefield()) {
             val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            // Evaluate the filter from the *granting permanent's* controller's perspective, so a
-            // controller-relative predicate like `opponentControls()` ("lands your opponents
-            // control" on Sharkey) means opponents of the static's controller, not of the land.
-            val granterController = projected.getController(entityId)
-                ?: state.getEntity(entityId)?.get<ControllerComponent>()?.playerId
-                ?: continue
-            val context = PredicateContext(controllerId = granterController, sourceId = entityId)
+            var context: PredicateContext? = null
             for (ability in cardDef.script.staticAbilities) {
                 val prevent = ability as? PreventActivatedAbilities ?: continue
                 // "… can't be activated unless they're mana abilities" — exempt mana abilities.
                 if (prevent.nonManaAbilitiesOnly && abilityIsManaAbility) continue
+                if (context == null) {
+                    // Evaluate from the granting permanent's controller's perspective.
+                    val granterController = projected.getController(entityId)
+                        ?: state.getEntity(entityId)?.get<ControllerComponent>()?.playerId
+                        ?: continue@battlefield
+                    context = PredicateContext(controllerId = granterController, sourceId = entityId)
+                }
                 if (predicateEvaluator.matches(state, projected, sourceId, prevent.filter, context)) {
                     return true
                 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolverTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolverTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.event
+
+import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class TriggerAbilityResolverTest : FunSpec({
+    test("both lookup paths retain grant order, duplicate abilities, and the ungranted base list") {
+        fun ability(name: String) = TriggeredAbility(
+            AbilityId(name), Triggers.Dies.event,
+            effect = LoseLifeEffect(1, EffectTarget.PlayerRef(Player.You)),
+        )
+        val owner = EntityId.of("owner")
+        val targetId = EntityId.of("target")
+        val providerId = EntityId.of("provider")
+        val base = listOf(ability("base"))
+        val temporary = ability("temporary")
+        val static = ability("static")
+        val grant = GrantTriggeredAbility(static, GroupFilter.AllCreatures)
+        val target = CardDefinition.creature("Trigger Target", ManaCost.ZERO, subtypes = emptySet(), power = 1, toughness = 1,
+            script = CardScript(triggeredAbilities = base))
+        val provider = CardDefinition.enchantment("Trigger Provider", ManaCost.ZERO,
+            script = CardScript(staticAbilities = listOf(grant)))
+        val registry = CardRegistry().apply { register(listOf(target, provider)) }
+        val abilities = AbilityRegistry().apply { register(target.name, base) }
+        val resolver = TriggerAbilityResolver(registry, abilities)
+        val zone = ZoneKey(owner, Zone.BATTLEFIELD)
+        val ungranted = GameState(
+            entities = mapOf(targetId to CardEntityFactory.create(target, owner)),
+            zones = mapOf(zone to listOf(targetId)),
+        )
+        (resolver.getTriggeredAbilities(targetId, target.name, ungranted) === base) shouldBe true
+        (resolver.getTriggeredAbilitiesWithProviders(targetId, target.name, ungranted, emptyList()) === base) shouldBe true
+
+        val fallback = TriggerAbilityResolver(registry, AbilityRegistry())
+        (fallback.getTriggeredAbilities(targetId, target.name, ungranted) === base) shouldBe true
+        (fallback.getTriggeredAbilitiesWithProviders(targetId, target.name, ungranted, emptyList()) === base) shouldBe true
+
+        val granted = ungranted.copy(
+            entities = ungranted.entities + (providerId to CardEntityFactory.create(provider, owner)),
+            zones = mapOf(zone to listOf(targetId, providerId)),
+            grantedTriggeredAbilities = listOf(
+                GrantedTriggeredAbility(providerId, ability("unrelated"), Duration.Permanent),
+                GrantedTriggeredAbility(targetId, temporary, Duration.Permanent),
+                GrantedTriggeredAbility(targetId, ability("expired"), Duration.WhileAffectedTapped),
+                GrantedTriggeredAbility(targetId, temporary, Duration.Permanent),
+            ),
+        )
+        val expected = base + listOf(temporary, temporary, static)
+        resolver.getTriggeredAbilities(targetId, target.name, granted) shouldBe expected
+        resolver.getTriggeredAbilitiesWithProviders(
+            targetId, target.name, granted,
+            listOf(TriggerIndex.GrantProviderEntry(grant, owner, providerId)),
+        ) shouldBe expected
+    }
+})


### PR DESCRIPTION
Ability lookup repeatedly copies growing grant lists, scans for static trigger grants even when the current-state index contains no providers, and builds temporary lists for fallback and granted abilities. Activation prevention also constructs predicate contexts before establishing whether a static ability can apply.

Assemble grants once in their existing order, retain the base fallback list when no Room abilities are added, and collect applicable temporary grants in one pass. Skip the static trigger scan only when the shared index proves its provider set empty. Construct activation-prevention contexts after the ability-kind and mana guards.

AbilityRegistry preference, class-level and Room ordering, grant multiplicity, duration gates, and text replacement stay in their existing positions. The provider-present scan retains its current filtering semantics; the indexed-provider and regular paths are not otherwise made identical. The supplied index must describe the current state and registry, as required by its other consumers.

### Isolated measurements

Representative constituent diagnostics used prebuilt synthetic states, shared indexes, warm projection, coverage disabled, and current-thread CPU/allocation counters:

- Ordered grant assembly (`12589ae4` → `22c7d8a`) reduced allocation about 24–61% across eight lookup fixtures.
- Empty-provider scan avoidance (`12589ae4` → `a7a9a745`) reduced CPU about 71% and allocation about 59% for 32 targets without providers. Small-fixture timings changed substantially with warmup. Provider-present gains cannot be attributed to avoiding the scan, because that scan still runs.
- Fallback and temporary-grant lists (`22c7d8a` → `308017de`) reduced allocation about 20–35% across four base/temporary configurations and both lookup paths. All paired rounds favored the candidate, but early JVM compilation inflated some CPU means; the regular empty case's median paired CPU improvement was about 8%, versus its 25% aggregate mean.
- Delaying prevention contexts (`12589ae4` → `fc9330bf`) changed an eight-permanent fixture without applicable prevention from about 153 to 68 ns and 1,024 to 128 B. A small matching-provider fixture had a 1.5% slower CPU mean.

These measurements belong to the named constituent commits and have overlapping costs. They establish no combined percentage, complete trigger-detection saving, or end-to-end gameplay speedup. The two final trigger diagnostics used 100,000 warmups per variant and ten old/new/new/old rounds of 5,000 calls per batch.

### Verification

All 56 focused tests pass for this independent group (`12589ae4a22e` → `914c1563934c`). The [complete combined source at b24f2e1191c7](https://github.com/huxinq/argentum-engine/commit/b24f2e1191c7f4fd83e7c508548346e3a4375495) also passed `just test-rules` (13,375 engine and card-scenario tests) and all 13 `DeterminizerInvariantsTest` tests. The four independent group diffs together reproduce that tested source exactly ([combined diff](https://github.com/huxinq/argentum-engine/compare/12589ae4a22e2abba0bc0274e88e38836d3b92be...b24f2e1191c7f4fd83e7c508548346e3a4375495)). These are locally recorded test results; publishing the source makes the tree comparison independently checkable, but does not provide a public CI reproduction.

Focused coverage checks both lookup paths, registry and fallback list reuse, ordered duplicate grants, unrelated/expired grants, Rooms, battlefield/soulbond providers, and creature-versus-mana activation prevention.
