### PR TITLE
Reuse engine services when creating independent AI players

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.ai.engine.rollout.RolloutCandidateEvaluator
 import com.wingedsheep.ai.engine.rollout.StaticCandidateEvaluator
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
 import com.wingedsheep.engine.legalactions.MeaningfulActionFilter
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
@@ -158,6 +159,30 @@ class AIPlayer(
         return current
     }
 
+    /**
+     * Reuses engine services when a caller needs many independent players for the same registry.
+     * Each [create] starts with fresh strategy memory and decision-resolution state. Keep the
+     * factory within one registry/session; this is not a cross-registry pool or a concurrency API.
+     */
+    class Factory(private val cardRegistry: CardRegistry) {
+        private val processor = ActionProcessor(EngineServices(cardRegistry), computeUndo = false)
+        private val enumerator = LegalActionEnumerator.create(cardRegistry)
+
+        fun create(
+            playerId: EntityId,
+            profile: AiProfile = AiProfile.CURRENT,
+            opponentModels: Map<EntityId, OpponentModel> = emptyMap(),
+            insightSink: AiInsightSink? = null,
+        ): AIPlayer = compose(cardRegistry, playerId, profile, opponentModels, insightSink) {
+            GameSimulator(
+                cardRegistry,
+                processor = processor,
+                enumerator = enumerator,
+                resolveThroughCombatDamage = profile.resolveThroughCombatDamage,
+            )
+        }
+    }
+
     companion object {
         /**
          * Create an AI player with the default evaluation weights.
@@ -186,6 +211,17 @@ class AIPlayer(
              * instead of being discarded. Null (the default) is production — no recording.
              */
             insightSink: AiInsightSink? = null,
+        ): AIPlayer = compose(cardRegistry, playerId, profile, opponentModels, insightSink) {
+            GameSimulator(cardRegistry, resolveThroughCombatDamage = profile.resolveThroughCombatDamage)
+        }
+
+        private fun compose(
+            cardRegistry: CardRegistry,
+            playerId: EntityId,
+            profile: AiProfile,
+            opponentModels: Map<EntityId, OpponentModel>,
+            insightSink: AiInsightSink?,
+            newSimulator: () -> GameSimulator,
         ): AIPlayer {
             val advisorRegistry = CardAdvisorRegistry()
             profile.advisorModules.forEach { it.register(advisorRegistry) }
@@ -194,10 +230,7 @@ class AIPlayer(
             // pre-Phase-6 behaviour — so a profile that doesn't opt in is untouched.
             val intents = if (profile.useCardIntent) IntentCatalog.of(cardRegistry) else IntentCatalog.NONE
 
-            val simulator = GameSimulator(
-                cardRegistry,
-                resolveThroughCombatDamage = profile.resolveThroughCombatDamage,
-            )
+            val simulator = newSimulator()
             // Raw Phase 9 vectors contain CardIntent-derived facts even when the surrounding
             // legacy-based arena profile deliberately keeps Phase 6 timing/targeting behavior off.
             // Give only the evaluator the full catalog so the fitted training schema and runtime

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/AIPlayerFactoryTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/AIPlayerFactoryTest.kt
@@ -1,5 +1,12 @@
 package com.wingedsheep.ai.engine
 
+import com.wingedsheep.ai.engine.advisor.AdvisorDecisionContext
+import com.wingedsheep.ai.engine.advisor.CardAdvisor
+import com.wingedsheep.ai.engine.advisor.CardAdvisorModule
+import com.wingedsheep.ai.engine.advisor.CardAdvisorRegistry
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.NumberChosenResponse
 import com.wingedsheep.engine.core.PassPriority
 import com.wingedsheep.engine.core.SubmitDecision
 import com.wingedsheep.engine.support.GameTestDriver
@@ -9,8 +16,11 @@ import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.matchers.types.shouldNotBeSameInstanceAs
 
 class AIPlayerFactoryTest : FunSpec({
@@ -19,6 +29,10 @@ class AIPlayerFactoryTest : FunSpec({
         initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
         passPriorityUntil(Step.PRECOMBAT_MAIN)
     }
+
+    fun field(value: Any, name: String): Any? = value.javaClass.getDeclaredField(name).apply {
+        isAccessible = true
+    }.get(value)
 
     test("fresh players match standalone choices across profiles and repeated calls") {
         val driver = game()
@@ -44,9 +58,6 @@ class AIPlayerFactoryTest : FunSpec({
         val opponent = factory.create(driver.player2, AiProfile.PRODUCTION)
         // These ownership assertions target the hazard that result equality on a single root
         // misses: reusing an AI carries its loop memory and resolver into another hypothesis.
-        fun field(value: Any, name: String): Any? = value.javaClass.getDeclaredField(name).apply {
-            isAccessible = true
-        }.get(value)
         val firstStrategy = field(first, "strategist")!!
         val secondStrategy = field(second, "strategist")!!
         (field(firstStrategy, "positionsActedFrom") as Collection<*>).isEmpty() shouldBe false
@@ -60,7 +71,7 @@ class AIPlayerFactoryTest : FunSpec({
         field(firstSimulator, "enumerator") shouldBe field(secondSimulator, "enumerator")
     }
 
-    test("fresh players preserve responses and simulation through pending choices") {
+    test("factory simulators retain their own responder callbacks through pending choices") {
         val driver = game()
         val spell = card("Factory Number Choice") {
             manaCost = "{0}"
@@ -74,12 +85,50 @@ class AIPlayerFactoryTest : FunSpec({
         driver.registerCards(listOf(spell))
         val actor = driver.activePlayer!!
         val id = driver.putCardInHand(actor, spell.name)
-        driver.castSpell(actor, id).isSuccess shouldBe true
-        val beforeResolution = driver.state
+        val beforeCast = driver.state
         val factory = AIPlayer.Factory(driver.cardRegistry)
-        // Choosing on the live stack invokes the simulator's nested decision resolver.
-        factory.create(actor, AiProfile.PRODUCTION).chooseAction(beforeResolution) shouldBe
-            AIPlayer.create(driver.cardRegistry, actor, AiProfile.PRODUCTION).chooseAction(beforeResolution)
+        val responses = mutableListOf<Int>()
+        // Distinct advisors make a callback bound to the wrong responder observable.
+        fun profile(number: Int) = AiProfile.PRODUCTION.copy(
+            id = "factory-number-$number",
+            advisorModules = listOf(object : CardAdvisorModule {
+                override fun register(registry: CardAdvisorRegistry) {
+                    registry.register(object : CardAdvisor {
+                        override val cardNames = setOf(spell.name)
+
+                        override fun respondToDecision(context: AdvisorDecisionContext): NumberChosenResponse {
+                            val decision = context.decision.shouldBeInstanceOf<ChooseNumberDecision>()
+                            context.playerId shouldBe actor
+                            responses += number
+                            return NumberChosenResponse(decision.id, number)
+                        }
+                    })
+                }
+            }),
+        )
+
+        val first = factory.create(actor, profile(1))
+        val firstSimulator = field(first, "simulator") as GameSimulator
+        val cast = firstSimulator.getLegalActions(beforeCast, actor).single { it.action is CastSpell }.action
+        fun resolve(simulator: GameSimulator) {
+            // Simulate the cast directly: choosing a sole pass on a live stack skips simulation.
+            val result = simulator.simulate(beforeCast, cast).shouldBeInstanceOf<SimulationResult.Terminal>()
+            result.state.pendingDecision.shouldBeNull()
+            result.state.stack.shouldBeEmpty()
+            result.state.lifeTotal(actor) shouldBe beforeCast.lifeTotal(actor) + 1
+        }
+
+        resolve(firstSimulator)
+        responses shouldBe listOf(1)
+        val second = factory.create(driver.player2, profile(3))
+        val secondSimulator = field(second, "simulator") as GameSimulator
+        resolve(secondSimulator)
+        responses shouldBe listOf(1, 3)
+        resolve(firstSimulator)
+        responses shouldBe listOf(1, 3, 1)
+        driver.state shouldBe beforeCast
+
+        driver.castSpell(actor, id).isSuccess shouldBe true
         driver.bothPass()
         val decision = driver.state.pendingDecision!!
         val state = driver.state

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/AIPlayerFactoryTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/AIPlayerFactoryTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.SubmitDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldNotBeSameInstanceAs
+
+class AIPlayerFactoryTest : FunSpec({
+    fun game() = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("fresh players match standalone choices across profiles and repeated calls") {
+        val driver = game()
+        val state = driver.state
+        val actor = driver.activePlayer!!
+        val factory = AIPlayer.Factory(driver.cardRegistry)
+        for (profile in listOf(AiProfile.CURRENT, AiProfile.PRODUCTION, AiProfile.PRODUCTION_CANDIDATE)) {
+            val expected = AIPlayer.create(driver.cardRegistry, actor, profile).chooseAction(state)
+            repeat(3) {
+                factory.create(actor, profile).chooseAction(state) shouldBe expected
+            }
+        }
+        driver.state shouldBe state
+    }
+
+    test("factory shares services while keeping strategy memory and resolver state per player") {
+        val driver = game()
+        val actor = driver.activePlayer!!
+        val factory = AIPlayer.Factory(driver.cardRegistry)
+        val first = factory.create(actor, AiProfile.PRODUCTION)
+        first.chooseAction(driver.state) shouldNotBe PassPriority(actor)
+        val second = factory.create(actor, AiProfile.PRODUCTION)
+        val opponent = factory.create(driver.player2, AiProfile.PRODUCTION)
+        // These ownership assertions target the hazard that result equality on a single root
+        // misses: reusing an AI carries its loop memory and resolver into another hypothesis.
+        fun field(value: Any, name: String): Any? = value.javaClass.getDeclaredField(name).apply {
+            isAccessible = true
+        }.get(value)
+        val firstStrategy = field(first, "strategist")!!
+        val secondStrategy = field(second, "strategist")!!
+        (field(firstStrategy, "positionsActedFrom") as Collection<*>).isEmpty() shouldBe false
+        (field(secondStrategy, "positionsActedFrom") as Collection<*>).isEmpty() shouldBe true
+        field(first, "responder") shouldNotBeSameInstanceAs field(second, "responder")
+        val firstSimulator = field(first, "simulator")!!
+        val secondSimulator = field(second, "simulator")!!
+        firstSimulator shouldNotBeSameInstanceAs secondSimulator
+        secondSimulator shouldNotBeSameInstanceAs field(opponent, "simulator")
+        field(firstSimulator, "processor") shouldBe field(secondSimulator, "processor")
+        field(firstSimulator, "enumerator") shouldBe field(secondSimulator, "enumerator")
+    }
+
+    test("fresh players preserve responses and simulation through pending choices") {
+        val driver = game()
+        val spell = card("Factory Number Choice") {
+            manaCost = "{0}"
+            typeLine = "Sorcery"
+            spell {
+                effect = Effects.ChooseNumberThen(
+                    then = Effects.GainLife(1), minValue = 1, maxValue = 3,
+                )
+            }
+        }
+        driver.registerCards(listOf(spell))
+        val actor = driver.activePlayer!!
+        val id = driver.putCardInHand(actor, spell.name)
+        driver.castSpell(actor, id).isSuccess shouldBe true
+        val beforeResolution = driver.state
+        val factory = AIPlayer.Factory(driver.cardRegistry)
+        // Choosing on the live stack invokes the simulator's nested decision resolver.
+        factory.create(actor, AiProfile.PRODUCTION).chooseAction(beforeResolution) shouldBe
+            AIPlayer.create(driver.cardRegistry, actor, AiProfile.PRODUCTION).chooseAction(beforeResolution)
+        driver.bothPass()
+        val decision = driver.state.pendingDecision!!
+        val state = driver.state
+        val expected = AIPlayer.create(driver.cardRegistry, decision.playerId, AiProfile.PRODUCTION)
+            .respondToDecision(state, decision)
+        repeat(3) {
+            factory.create(decision.playerId, AiProfile.PRODUCTION).respondToDecision(state, decision) shouldBe expected
+        }
+        driver.submitSuccess(SubmitDecision(decision.playerId, expected))
+    }
+})


### PR DESCRIPTION
Creating an independent AI player currently rebuilds the engine service graph, action processor, and legal-action enumerator. A search client evaluating many hypothetical positions needs fresh strategy memory for each position, but pays this setup cost on every call. Retaining the whole player would carry its loop-prevention memory into the next position.

This adds `AIPlayer.Factory`, which binds those reusable services to one card registry and creates independent players from them:

```kotlin
val factory = AIPlayer.Factory(cardRegistry)
val first = factory.create(actor, AiProfile.PRODUCTION).chooseAction(firstWorld)
val second = factory.create(actor, AiProfile.PRODUCTION).chooseAction(secondWorld)
```

Every `create` builds a fresh `GameSimulator`, `Strategist`, and `DecisionResponder`, including the simulator's recursion guard and responder callback. The existing standalone `AIPlayer.create` and the factory use one profile-composition path. Card-advisor registration keeps its existing semantics, and rollout profiles retain their separate simulation stack.

The factory is intended for sequential use within one registry/session. `GameEnvironment` already shares comparable services across forks; this exposes that construction boundary to clients that need independent AI players. Callers that retain one player can continue using the existing API.

### Measured downstream example

MTGallium's Search Teacher creates an independent Argentum production AI for repeated heuristic decisions. A prototype changed its annotator to retain one lazy factory and create a fresh player for each decision. Comparing that adapter change plus this API against the original path gave:

| Construction plus search selection | Original | Factory | Change |
|---|---:|---:|---:|
| Mean calling-thread CPU per root | 1,565.5 ms | 1,361.0 ms | 13.1% less, **1.15× speedup** |
| Mean elapsed time per root | 1,631.7 ms | 1,414.0 ms | 13.3% less |
| Mean calling-thread allocation per root | 2.513 GB | 2.454 GB | 2.35% less |

The comparison used four synthetic tactical roots, eight particles, 64 simulations, and a 32-decision horizon. Four separate JDK 21 JVMs ran in baseline/factory/factory/baseline order, with two warmups and three measured repetitions per root: 48 measured calls and 32 warmup calls. Both adjacent baseline/factory comparisons favored the factory overall.

The result varies by root: attack, block, and hidden-information fixtures had CPU speedups of 1.217×, 1.141×, and 1.270×; the lethal fixture used 2.2% more CPU. Selection CPU fell 13.3%, while initial construction used about 1.5 ms more CPU. JFR was enabled and the host was contended. These figures measure the combined API-and-caller change on fixed search work, rather than a full-game or ordinary retained-player benefit.

The engine baseline was `12589ae4a22e`; the treatment was `b7bd529fbe9e`, with MTGallium diagnostic source `ce376f8ef6c6` and an explicit adapter overlay. Runtime bundles retained the effective sources, patches, compiled jars, and ordered classpath, with loaded-class origins and input hashes checked around execution. The repository's engine pin stayed unchanged. The retained measurements and manifests were independently audited; raw research artifacts remain outside this PR.

This PR is independent of the earlier hidden-world, projection, component, and ability-lookup optimizations. Those patches were absent from this comparison, so the measurements do not establish their combined speedup.

### Verification

- AI `*Test` suite at `b7bd529fbe9e`: **545 passed, one skipped**, no failures or errors. Command: `just test-class AIPlayerFactoryTest --tests 'com.wingedsheep.ai.*Test'`. Production source is unchanged since this full-suite run and the benchmark.
- `AIPlayerFactoryTest` at `350db12d24c3`: **three passed**. The simulation regression drives a legal cast through two factory-owned simulators whose responders choose distinct numbers, then exercises the first again after creating the second. It requires the response sequence `1, 3, 1`, completed resolution, and an unchanged source state. Existing coverage retains direct-response parity, standalone/factory action parity across three profiles, and fresh strategy, simulator, and responder ownership. Command: `just test-class AIPlayerFactoryTest`.
- All **80 diagnostic calls** matched the complete per-root belief and search results after excluding only evaluator timing. The measured calls completed 3,072 simulations and 50,064 world steps, with all requested particles accepted and no rejected transitions. These counts describe search work, not played games.
