### PR TITLE
Make engine routing IDs deterministic

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/StateProgress.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/StateProgress.kt
@@ -104,6 +104,7 @@ object StateProgress {
      * What is stripped, and why none of it is a game fact:
      * - `entities` — read separately by [objectHash], which drops [IGNORED_COMPONENTS].
      * - `rng`, `nextEntityId`, `timestamp` — advanced by resolving anything at all.
+     * - `nextRoutingId` — allocates decision and continuation references, not game facts.
      * - `priorityPlayerId`, `priorityPassedBy` — whose turn it is to speak, not what is true. This
      *   is what makes an action's own resolution comparable with the position it started from.
      * - `continuationStack` — counted instead; see [digest].
@@ -116,6 +117,7 @@ object StateProgress {
         entities = emptyMap(),
         rng = GameRng(0L),
         nextEntityId = 0L,
+        nextRoutingId = 0L,
         timestamp = 0L,
         priorityPlayerId = null,
         priorityPassedBy = emptySet(),

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/StateProgressTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/StateProgressTest.kt
@@ -39,6 +39,7 @@ class StateProgressTest : FunSpec({
         // inert action look like progress — the exact misreading the guard exists to avoid.
         withClue("rng") { StateProgress.digest(base.copy(rng = GameRng(0x5EED))) shouldBe here }
         withClue("nextEntityId") { StateProgress.digest(base.copy(nextEntityId = 9_999L)) shouldBe here }
+        withClue("nextRoutingId") { StateProgress.digest(base.copy(nextRoutingId = 1L)) shouldBe here }
         withClue("timestamp") { StateProgress.digest(base.copy(timestamp = 9_999L)) shouldBe here }
 
         // Whose turn it is to speak is not what is true of the board. Being blind to it is what

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -413,7 +413,10 @@ Browser-facing decision IDs include a session epoch that rotates on successful u
 validates that epoch before rebinding a response to its engine ID. Undo restores the exact engine
 checkpoint, and replay records only canonical engine actions. Repeated delivery or reconnect to
 the same session preserves an outstanding live ID; a recovered session issues a fresh epoch.
-In-process AI receives engine IDs so its response simulations still address the raw snapshot.
+In-process AI receives engine IDs so its response simulations still address the raw snapshot,
+plus the live epoch captured with that update. Its asynchronous callback returns that epoch;
+the server atomically validates it before execution. An obsolete callback is discarded without
+fallback actions or rejection accounting.
 
 Snapshots written before this counter existed decode with zero and retain their existing UUID or
 clock-based tokens. Historical action logs may still need decision-ID rebinding; replay should use

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -408,6 +408,13 @@ and repeating the same actions reproduces those tokens, including their linked r
 Tokens are opaque to consumers: their spelling is neither a game identifier nor an action's
 semantic identity, and separate games or divergent simulation branches can reuse the same token.
 
+Live request freshness belongs to `GameSession`, separately from engine correlation identity.
+Browser-facing decision IDs include a session epoch that rotates on successful undo; the server
+validates that epoch before rebinding a response to its engine ID. Undo restores the exact engine
+checkpoint, and replay records only canonical engine actions. Repeated delivery or reconnect to
+the same session preserves an outstanding live ID; a recovered session issues a fresh epoch.
+In-process AI receives engine IDs so its response simulations still address the raw snapshot.
+
 Snapshots written before this counter existed decode with zero and retain their existing UUID or
 clock-based tokens. Historical action logs may still need decision-ID rebinding; replay should use
 its recorded engine version. This routing guarantee does not remove other sources of identity

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -398,6 +398,21 @@ what an old input stream re-simulates to. Stored replays therefore pin the card 
 on and carry position checkpoints, with an archived frame stream as the last resort — see
 [data-contracts.md](data-contracts.md) → *Compact replays*.
 
+#### Reproducible routing identity
+
+`GameState.newRoutingId()` allocates game-local correlation tokens for pending decisions,
+continuations, delayed triggers, and combat bands. Its serialized `nextRoutingId` counter is
+independent of entity allocation and gameplay RNG. Every caller must carry the returned state
+forward before allocating another token or executing a nested effect. Restoring the same snapshot
+and repeating the same actions reproduces those tokens, including their linked references.
+Tokens are opaque to consumers: their spelling is neither a game identifier nor an action's
+semantic identity, and separate games or divergent simulation branches can reuse the same token.
+
+Snapshots written before this counter existed decode with zero and retain their existing UUID or
+clock-based tokens. Historical action logs may still need decision-ID rebinding; replay should use
+its recorded engine version. This routing guarantee does not remove other sources of identity
+variation, such as process-global IDs for dynamically constructed abilities.
+
 ### 2.2 Entity-Component-System (ECS)
 
 **Principle:** Every game object is an `EntityId` with behavioral traits attached via components.

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -650,6 +650,15 @@ random or clock-based IDs; reconstruction retains rebinding for those records wh
 the recorded choice payload (entity-id targets/cards). Routing IDs are game-local correlation
 tokens and must not be interpreted as globally unique identifiers or semantic action identity.
 
+The live browser protocol wraps each pending decision ID with a session epoch. Clients continue
+to echo the opaque `pendingDecision.id` in `SubmitDecision`; no new envelope field is needed.
+`GameSession.executeClientAction` rejects a cancelled generation before changing game state,
+undo checkpoints, replay inputs, or message-id bookkeeping, then rebinds a valid response to the
+engine ID for execution and recording. Successful undo rotates the epoch without changing the
+restored engine checkpoint. Full and delta updates share the same token while that prompt is
+outstanding, including after reconnect; a new session instance starts a fresh epoch.
+
+
 #### One store
 
 Every replay — finished or still being recorded — is a row in `game_replays`, written by

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -643,9 +643,12 @@ from a state-threaded counter (never a UUID), `ReplayReconstructor` rebuilds the
 deltas}` stream the viewer consumes. This is kilobytes per game instead of a masked snapshot + a
 per-frame delta + a full unmasked `GameState` per frame.
 
-Decision ids are minted afresh each run (they are not part of the deterministic state), so a
-recorded `SubmitDecision` is re-bound to the freshly created decision's id during reconstruction;
-the choice payload (entity-id targets/cards) is unchanged, so the outcome is identical.
+Decision IDs now come from the serialized `GameState.nextRoutingId` counter, independently of
+entity allocation and gameplay RNG. Repeating the same execution reproduces those IDs, so current
+`SubmitDecision` records already address the reconstructed decision. Historical recordings used
+random or clock-based IDs; reconstruction retains rebinding for those records while preserving
+the recorded choice payload (entity-id targets/cards). Routing IDs are game-local correlation
+tokens and must not be interpreted as globally unique identifiers or semantic action identity.
 
 #### One store
 

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -658,6 +658,15 @@ engine ID for execution and recording. Successful undo rotates the epoch without
 restored engine checkpoint. Full and delta updates share the same token while that prompt is
 outstanding, including after reconnect; a new session instance starts a fresh epoch.
 
+In-process AI updates retain raw decision IDs for engine simulations and carry the same live
+generation separately in `interactionEpoch`. Both full and delta updates capture it under the
+session lock. The AI carries that originating value through thinking and approval delays into
+its callback; `GameSession.executeAiAction` validates it atomically with action execution.
+Missing or obsolete generations are discarded before fallback actions, rejection accounting,
+or broadcasts. Fallback execution rechecks the originating generation, and rejection accounting
+plus any resulting concession share one guarded operation, so undo between recovery steps cannot
+apply them to the replacement branch. Replay continues to record only canonical engine IDs.
+
 
 #### One store
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
@@ -246,7 +246,7 @@ class AiGameManager(
         aiPlayerId: EntityId,
         controller: AiPlayerController,
         gameSession: GameSession?,
-        onActionReady: (EntityId, GameAction) -> Unit = { _, _ -> },
+        onActionReady: (EntityId, GameAction, String?) -> Unit = { _, _, _ -> },
         onMulliganKeep: (EntityId) -> Unit = { _ -> },
         onMulliganTake: (EntityId) -> Unit = { _ -> },
         onBottomCards: (EntityId, List<EntityId>) -> Unit = { _, _ -> },
@@ -275,7 +275,7 @@ class AiGameManager(
         playerName: String,
         controller: AiPlayerController,
         modelOverride: String? = null,
-        onActionReady: (EntityId, GameAction) -> Unit,
+        onActionReady: (EntityId, GameAction, String?) -> Unit,
         onMulliganKeep: (EntityId) -> Unit,
         onMulliganTake: (EntityId) -> Unit,
         onBottomCards: (EntityId, List<EntityId>) -> Unit,
@@ -316,7 +316,7 @@ class AiGameManager(
      * Create an AI opponent and add it to the game session.
      *
      * @param gameSession The game session to add the AI to.
-     * @param onActionReady Callback invoked (async) when the AI wants to submit an action.
+     * @param onActionReady Callback invoked (async) with the action and its snapshot interaction epoch.
      *        This MUST NOT be called while holding stateLock.
      * @param onMulliganKeep Callback for AI keeping hand.
      * @param onMulliganTake Callback for AI taking mulligan.
@@ -326,7 +326,7 @@ class AiGameManager(
     fun createAiOpponent(
         gameSession: GameSession,
         setCode: String? = null,
-        onActionReady: (EntityId, GameAction) -> Unit,
+        onActionReady: (EntityId, GameAction, String?) -> Unit,
         onMulliganKeep: (EntityId) -> Unit,
         onMulliganTake: (EntityId) -> Unit,
         onBottomCards: (EntityId, List<EntityId>) -> Unit,
@@ -392,7 +392,7 @@ class AiGameManager(
         gameSession: GameSession,
         aiPlayerId: EntityId,
         playerName: String,
-        onActionReady: (EntityId, GameAction) -> Unit,
+        onActionReady: (EntityId, GameAction, String?) -> Unit,
         onMulliganKeep: (EntityId) -> Unit,
         onMulliganTake: (EntityId) -> Unit,
         onBottomCards: (EntityId, List<EntityId>) -> Unit
@@ -532,7 +532,7 @@ class AiGameManager(
         gameSession: GameSession,
         aiPlayerId: EntityId,
         deckList: Map<String, Int>?,
-        onActionReady: (EntityId, GameAction) -> Unit,
+        onActionReady: (EntityId, GameAction, String?) -> Unit,
         onMulliganKeep: (EntityId) -> Unit,
         onMulliganTake: (EntityId) -> Unit,
         onBottomCards: (EntityId, List<EntityId>) -> Unit

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiWebSocketSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiWebSocketSession.kt
@@ -47,7 +47,7 @@ class AiWebSocketSession(
      * on every decision, so a change takes effect on the AI's next move.
      */
     @Volatile var thinkingDelayMs: Long = 500,
-    private val onActionReady: (EntityId, GameAction) -> Unit,
+    private val onActionReady: (EntityId, GameAction, String?) -> Unit,
     private val onMulliganKeep: (EntityId) -> Unit,
     private val onMulliganTake: (EntityId) -> Unit,
     private val onBottomCards: (EntityId, List<EntityId>) -> Unit,
@@ -124,7 +124,7 @@ class AiWebSocketSession(
                     message.pendingDecision?.let { it::class.simpleName })
                 lastFullState = message.state
                 accumulateEvents(message.events.map { it.description })
-                handleStateUpdate(message.state, message.legalActions, message.pendingDecision)
+                handleStateUpdate(message.state, message.legalActions, message.pendingDecision, message.interactionEpoch)
             }
 
             is ServerMessage.StateDeltaUpdate -> {
@@ -139,10 +139,10 @@ class AiWebSocketSession(
                     applyDelta(cachedState, message.delta).also { lastFullState = it }
                 } else null
                 if (updatedState != null && (message.legalActions.isNotEmpty() || message.pendingDecision != null)) {
-                    handleStateUpdate(updatedState, message.legalActions, message.pendingDecision)
+                    handleStateUpdate(updatedState, message.legalActions, message.pendingDecision, message.interactionEpoch)
                 } else if (message.legalActions.isNotEmpty() || message.pendingDecision != null) {
                     logger.warn("AI received delta update but has no cached state — falling back to heuristics")
-                    handleActionsOnlyFallback(message.legalActions, message.pendingDecision)
+                    handleActionsOnlyFallback(message.legalActions, message.pendingDecision, message.interactionEpoch)
                 }
             }
 
@@ -266,7 +266,8 @@ class AiWebSocketSession(
     private suspend fun handleStateUpdate(
         state: ClientGameState,
         legalActions: List<LegalActionInfo>,
-        pendingDecision: PendingDecision?
+        pendingDecision: PendingDecision?,
+        interactionEpoch: String?
     ) {
         // If we have legal actions or a pending decision addressed to us, it's our turn.
         // Don't rely on state.priorityPlayerId — it may be stale when using a cached state
@@ -320,7 +321,9 @@ class AiWebSocketSession(
         } else {
             response
         }
-        submitResponse(gated)
+        // Retain the snapshot epoch through thinking and approval delays; reading a newer epoch
+        // here would authorize a response chosen from an obsolete interaction.
+        submitResponse(gated, interactionEpoch)
     }
 
     /**
@@ -329,7 +332,8 @@ class AiWebSocketSession(
      */
     private suspend fun handleActionsOnlyFallback(
         legalActions: List<LegalActionInfo>,
-        pendingDecision: PendingDecision?
+        pendingDecision: PendingDecision?,
+        interactionEpoch: String?
     ) {
         if (legalActions.isEmpty() && pendingDecision == null) return
 
@@ -404,12 +408,12 @@ class AiWebSocketSession(
                     }
                 }
             }
-            submitResponse(autoResponse)
+            submitResponse(autoResponse, interactionEpoch)
         } else if (legalActions.isNotEmpty()) {
             logger.info("AI fallback: passing priority (no state available)")
             val passAction = legalActions.find { it.actionType == "PassPriority" }
             if (passAction != null) {
-                submitResponse(ActionResponse.SubmitAction(passAction.action))
+                submitResponse(ActionResponse.SubmitAction(passAction.action), interactionEpoch)
             }
         }
     }
@@ -492,17 +496,17 @@ class AiWebSocketSession(
         callback(aiPlayerId, selection)
     }
 
-    private fun submitResponse(response: ActionResponse) {
+    private fun submitResponse(response: ActionResponse, interactionEpoch: String?) {
         when (response) {
             is ActionResponse.SubmitAction -> {
-                onActionReady(aiPlayerId, response.action)
+                onActionReady(aiPlayerId, response.action, interactionEpoch)
             }
             is ActionResponse.SubmitDecision -> {
                 val action = SubmitDecision(
                     playerId = response.playerId,
                     response = response.response
                 )
-                onActionReady(aiPlayerId, action)
+                onActionReady(aiPlayerId, action, interactionEpoch)
             }
         }
     }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
@@ -228,8 +228,8 @@ class FreeForAllHandler(
                 gameSession = gameSession,
                 aiPlayerId = playerId,
                 deckList = lobby.getSubmittedDeck(playerId),
-                onActionReady = { aiPlayerId, action ->
-                    gamePlayHandler.handleAiAction(gameSession, aiPlayerId, action)
+                onActionReady = { aiPlayerId, action, interactionEpoch ->
+                    gamePlayHandler.handleAiAction(gameSession, aiPlayerId, action, interactionEpoch)
                 },
                 onMulliganKeep = { aiPlayerId ->
                     gamePlayHandler.handleAiMulliganKeep(gameSession, aiPlayerId)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -185,8 +185,8 @@ class GamePlayHandler(
             aiGameManager.createAiOpponent(
                 gameSession = gameSession,
                 setCode = quickGameSetCode,
-                onActionReady = { aiPlayerId, action ->
-                    handleAiAction(gameSession, aiPlayerId, action)
+                onActionReady = { aiPlayerId, action, interactionEpoch ->
+                    handleAiAction(gameSession, aiPlayerId, action, interactionEpoch)
                 },
                 onMulliganKeep = { aiPlayerId ->
                     handleAiMulliganKeep(gameSession, aiPlayerId)
@@ -400,7 +400,9 @@ class GamePlayHandler(
             gameSession = gameSession,
             aiPlayerId = aiPlayerId,
             deckList = deck,
-            onActionReady = { id, action -> handleAiAction(gameSession, id, action) },
+            onActionReady = { id, action, interactionEpoch ->
+                handleAiAction(gameSession, id, action, interactionEpoch)
+            },
             onMulliganKeep = { id -> handleAiMulliganKeep(gameSession, id) },
             onMulliganTake = { id -> handleAiMulliganTake(gameSession, id) },
             onBottomCards = { id, cardIds -> handleAiBottomCards(gameSession, id, cardIds) }
@@ -1219,7 +1221,9 @@ class GamePlayHandler(
                 gameSession = gameSession,
                 aiPlayerId = aiPlayerId,
                 deckList = deckList,
-                onActionReady = { id, action -> handleAiAction(gameSession, id, action) },
+                onActionReady = { id, action, interactionEpoch ->
+                    handleAiAction(gameSession, id, action, interactionEpoch)
+                },
                 onMulliganKeep = { id -> handleAiMulliganKeep(gameSession, id) },
                 onMulliganTake = { id -> handleAiMulliganTake(gameSession, id) },
                 onBottomCards = { id, cardIds -> handleAiBottomCards(gameSession, id, cardIds) }
@@ -1289,9 +1293,14 @@ class GamePlayHandler(
     // AI opponent callbacks (invoked async from AiWebSocketSession coroutine)
     // =========================================================================
 
-    fun handleAiAction(gameSession: GameSession, aiPlayerId: EntityId, action: com.wingedsheep.engine.core.GameAction) {
+    fun handleAiAction(
+        gameSession: GameSession,
+        aiPlayerId: EntityId,
+        action: com.wingedsheep.engine.core.GameAction,
+        interactionEpoch: String?
+    ) {
         try {
-            val result = gameSession.executeAction(aiPlayerId, action)
+            val result = gameSession.executeAiAction(aiPlayerId, action, interactionEpoch) ?: return
             when (result) {
                 is GameSession.ActionResult.Success -> {
                     logger.debug("AI action executed successfully")
@@ -1313,7 +1322,9 @@ class GamePlayHandler(
                     logger.warn("AI action failed: {} — trying safe fallbacks", result.reason)
                     var recovered = false
                     for (fallback in safeFallbackActions(gameSession, aiPlayerId)) {
-                        when (val fb = gameSession.executeAction(aiPlayerId, fallback)) {
+                        // Undo can occur after the original rejection or between fallback attempts.
+                        val fb = gameSession.executeAiAction(aiPlayerId, fallback, interactionEpoch) ?: return
+                        when (fb) {
                             is GameSession.ActionResult.Success -> {
                                 broadcastStateUpdate(gameSession, fb.events)
                                 if (gameSession.isGameOver()) handleGameOver(gameSession, events = fb.events)
@@ -1335,7 +1346,8 @@ class GamePlayHandler(
                         // it re-chooses the same rejected action, and nothing was applied for the
                         // stall guard to notice — so the seat gets a bounded number of chances and
                         // is then conceded. See [GameStallGuard.onActionRejected].
-                        if (gameSession.noteActionRejected(aiPlayerId)) {
+                        val conceded = gameSession.noteAiActionRejected(aiPlayerId, interactionEpoch) ?: return
+                        if (conceded) {
                             logger.error(
                                 "AI seat {} has had {} actions in a row rejected with no legal " +
                                     "fallback in game {} — conceding the seat rather than " +
@@ -1344,7 +1356,6 @@ class GamePlayHandler(
                                 com.wingedsheep.gameserver.session.GameStallGuard.MAX_CONSECUTIVE_REJECTIONS,
                                 gameSession.sessionId,
                             )
-                            gameSession.playerConcedes(aiPlayerId)
                             broadcastStateUpdate(gameSession, emptyList())
                             if (gameSession.isGameOver()) {
                                 handleGameOver(gameSession, GameOverReason.CONCESSION)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -545,7 +545,7 @@ class GamePlayHandler(
             return
         }
 
-        val result = gameSession.executeAction(playerSession.playerId, message.action, message.messageId)
+        val result = gameSession.executeClientAction(playerSession.playerId, message.action, message.messageId)
         when (result) {
             is GameSession.ActionResult.Success -> {
                 logger.debug("Action executed successfully")
@@ -899,7 +899,10 @@ class GamePlayHandler(
 
         try {
             sessionPlayers.forEach { session ->
-                val update = gameSession.createStateUpdate(session.playerId, allEvents)
+                val update = gameSession.createStateUpdate(
+                    session.playerId, allEvents,
+                    useEngineDecisionIds = session.webSocketSession is AiWebSocketSession,
+                )
                 if (update != null) sender.send(session.webSocketSession, update)
                 else logger.warn("createStateUpdate returned null for player ${session.playerId.value}")
             }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
@@ -758,7 +758,9 @@ class QuickGameLobbyHandler(
             aiGameManager.createAiOpponent(
                 gameSession = gameSession,
                 setCode = aiSetCode,
-                onActionReady = { id, action -> gamePlayHandler.handleAiAction(gameSession, id, action) },
+                onActionReady = { id, action, interactionEpoch ->
+                    gamePlayHandler.handleAiAction(gameSession, id, action, interactionEpoch)
+                },
                 onMulliganKeep = { id -> gamePlayHandler.handleAiMulliganKeep(gameSession, id) },
                 onMulliganTake = { id -> gamePlayHandler.handleAiMulliganTake(gameSession, id) },
                 onBottomCards = { id, cardIds -> gamePlayHandler.handleAiBottomCards(gameSession, id, cardIds) },

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
@@ -862,8 +862,8 @@ class TournamentMatchHandler(
                     gameSession = gameSession,
                     aiPlayerId = ps.playerId,
                     deckList = lobby.getSubmittedDeck(ps.playerId),
-                    onActionReady = { aiPlayerId, action ->
-                        gamePlayHandler.handleAiAction(gameSession, aiPlayerId, action)
+                    onActionReady = { aiPlayerId, action, interactionEpoch ->
+                        gamePlayHandler.handleAiAction(gameSession, aiPlayerId, action, interactionEpoch)
                     },
                     onMulliganKeep = { aiPlayerId ->
                         gamePlayHandler.handleAiMulliganKeep(gameSession, aiPlayerId)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -142,6 +142,8 @@ sealed interface ServerMessage {
         val priorityMode: String? = null,
         /** Monotonically increasing version — clients use this to detect missed messages */
         val stateVersion: Long = 0,
+        /** Live generation accompanying raw engine IDs for asynchronous in-process AI. */
+        val interactionEpoch: String? = null,
     ) : ServerMessage
 
     /**
@@ -167,7 +169,9 @@ sealed interface ServerMessage {
         /** Current priority mode for this player */
         val priorityMode: String? = null,
         /** Monotonically increasing version — clients use this to detect missed messages */
-        val stateVersion: Long = 0
+        val stateVersion: Long = 0,
+        /** Live generation accompanying raw engine IDs for asynchronous in-process AI. */
+        val interactionEpoch: String? = null,
     ) : ServerMessage
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/ReplayReconstructor.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/ReplayReconstructor.kt
@@ -253,10 +253,10 @@ private class ReplayEngine(
     }
 
     /**
-     * Re-bind a recorded action to the current reconstructed state. Decision ids are minted from a
-     * UUID each run, so a recorded [SubmitDecision] carries the *original* run's id; we retarget it
-     * at the id the freshly created pending decision actually has. The choice payload (targets,
-     * cards, numbers — all by deterministic entity id) is untouched, so the outcome is identical.
+     * Re-bind a recorded action to the current reconstructed state. Historical recordings used
+     * random or clock-based decision IDs; current engine routing IDs reproduce from game state.
+     * Keep the fallback for those historical [SubmitDecision] records, retargeting only the
+     * correlation token. The recorded choice payload (targets, cards, numbers) is untouched.
      */
     private fun rebind(action: GameAction, state: GameState): GameAction {
         if (action !is SubmitDecision) return action

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioSessionFactory.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioSessionFactory.kt
@@ -134,7 +134,9 @@ class ScenarioSessionFactory(
                     gameSession = gameSession,
                     aiPlayerId = aiSeatId,
                     playerName = aiSeatName,
-                    onActionReady = { id, action -> gamePlayHandler.handleAiAction(gameSession, id, action) },
+                    onActionReady = { id, action, interactionEpoch ->
+                        gamePlayHandler.handleAiAction(gameSession, id, action, interactionEpoch)
+                    },
                     onMulliganKeep = { id -> gamePlayHandler.handleAiMulliganKeep(gameSession, id) },
                     onMulliganTake = { id -> gamePlayHandler.handleAiMulliganTake(gameSession, id) },
                     onBottomCards = { id, cardIds -> gamePlayHandler.handleAiBottomCards(gameSession, id, cardIds) }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -73,14 +73,14 @@ class GameSession(
     private val stateLock = Any()
 
     /**
-     * Browser response freshness, separate from replayable engine routing. Undo starts a new
+     * Live response freshness, separate from replayable engine routing. Undo starts a new
      * generation even when it restores an identical engine counter. A recovered session gets
      * a fresh epoch too; reconnecting to this instance keeps outstanding responses valid.
      * Read and changed only under [stateLock]. Never stored in engine state or replay inputs.
      */
-    private var liveDecisionEpoch = UUID.randomUUID().toString()
+    private var liveInteractionEpoch = UUID.randomUUID().toString()
 
-    private fun liveDecisionId(engineId: String): String = "$liveDecisionEpoch:$engineId"
+    private fun liveDecisionId(engineId: String): String = "$liveInteractionEpoch:$engineId"
 
     @Volatile
     private var gameState: GameState? = null
@@ -832,8 +832,22 @@ class GameSession(
     }
 
     /**
-     * Execute a trusted engine action (including in-process AI responses).
-     * Browser submissions must go through [executeClientAction].
+     * Apply a delayed AI result only on the live timeline that supplied its snapshot.
+     * Null means obsolete delivery, not an invalid game action: callers must discard it without
+     * fallbacks, rejection accounting, or a broadcast. Validation and execution share the lock.
+     */
+    fun executeAiAction(
+        playerId: EntityId,
+        action: GameAction,
+        interactionEpoch: String?,
+    ): ActionResult? = synchronized(stateLock) {
+        if (interactionEpoch == null || interactionEpoch != liveInteractionEpoch) return null
+        executeAction(playerId, action)
+    }
+
+    /**
+     * Execute an immediate engine action. Browser submissions use [executeClientAction];
+     * asynchronous AI callbacks use [executeAiAction] to validate their originating generation.
      *
      * Routes the action through the engine's ActionProcessor.
      * Synchronized to prevent lost updates when multiple players act simultaneously.
@@ -1024,14 +1038,15 @@ class GameSession(
         lastSentState[playerId] = stateWithLog
         val version = stateVersions.merge(playerId, 1L) { old, inc -> old + inc }!!
 
+        val interactionEpoch = if (useEngineDecisionIds) liveInteractionEpoch else null
         if (previous != null) {
             // Compute delta and send smaller message
             val delta = StateDiffCalculator.computeDelta(previous, stateWithLog)
-            return ServerMessage.StateDeltaUpdate(delta, clientEvents, legalActions, pendingDecision, nextStopPoint, opponentDecisionStatus, stopOverrideInfo, isUndoAvailable(playerId), priorityModeStr, version)
+            return ServerMessage.StateDeltaUpdate(delta, clientEvents, legalActions, pendingDecision, nextStopPoint, opponentDecisionStatus, stopOverrideInfo, isUndoAvailable(playerId), priorityModeStr, version, interactionEpoch)
         }
 
         // First update — send full state
-        return ServerMessage.StateUpdate(stateWithLog, clientEvents, legalActions, pendingDecision, nextStopPoint, opponentDecisionStatus, stopOverrideInfo, isUndoAvailable(playerId), priorityModeStr, version)
+        return ServerMessage.StateUpdate(stateWithLog, clientEvents, legalActions, pendingDecision, nextStopPoint, opponentDecisionStatus, stopOverrideInfo, isUndoAvailable(playerId), priorityModeStr, version, interactionEpoch)
     }
 
     /**
@@ -1228,7 +1243,7 @@ class GameSession(
         }
 
         gameState = checkpoint
-        liveDecisionEpoch = UUID.randomUUID().toString()
+        liveInteractionEpoch = UUID.randomUUID().toString()
         // Roll the replay log back to the actions that produced the restored state, so a later
         // reconstruction replays exactly this history. Yields recorded after the rollback point are
         // dropped too — they were set against actions that no longer exist.
@@ -1517,6 +1532,18 @@ class GameSession(
      */
     fun noteActionRejected(playerId: EntityId): Boolean = synchronized(stateLock) {
         stallGuard.onActionRejected(playerId)
+    }
+
+    /**
+     * Finish AI rejection recovery only on its originating timeline. The rejection count and any
+     * resulting concession are atomic with the epoch check; undo may have occurred since the last
+     * failed fallback. Null tells the caller to discard the obsolete recovery without broadcasting.
+     */
+    fun noteAiActionRejected(playerId: EntityId, interactionEpoch: String?): Boolean? = synchronized(stateLock) {
+        if (interactionEpoch == null || interactionEpoch != liveInteractionEpoch) return null
+        val conceded = noteActionRejected(playerId)
+        if (conceded) playerConcedes(playerId)
+        conceded
     }
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -72,6 +72,16 @@ class GameSession(
     // Lock for synchronizing state modifications to prevent lost updates
     private val stateLock = Any()
 
+    /**
+     * Browser response freshness, separate from replayable engine routing. Undo starts a new
+     * generation even when it restores an identical engine counter. A recovered session gets
+     * a fresh epoch too; reconnecting to this instance keeps outstanding responses valid.
+     * Read and changed only under [stateLock]. Never stored in engine state or replay inputs.
+     */
+    private var liveDecisionEpoch = UUID.randomUUID().toString()
+
+    private fun liveDecisionId(engineId: String): String = "$liveDecisionEpoch:$engineId"
+
     @Volatile
     private var gameState: GameState? = null
         set(value) {
@@ -799,7 +809,31 @@ class GameSession(
     }
 
     /**
-     * Execute a game action.
+     * Execute an action received from a browser. Validate the delivered prompt's generation
+     * before any checkpoint, replay, or idempotency bookkeeping can change, then pass only the
+     * canonical engine response to [executeAction]. Never accept an unwrapped engine ID here.
+     */
+    fun executeClientAction(
+        playerId: EntityId,
+        action: GameAction,
+        messageId: String? = null,
+    ): ActionResult = synchronized(stateLock) {
+        val engineAction = if (action is SubmitDecision) {
+            val pending = gameState?.pendingDecision
+                ?: return ActionResult.Failure("No pending decision")
+            if (action.response.decisionId != liveDecisionId(pending.id)) {
+                return ActionResult.Failure("Decision is no longer current")
+            }
+            action.copy(response = action.response.withDecisionId(pending.id))
+        } else {
+            action
+        }
+        executeAction(playerId, engineAction, messageId)
+    }
+
+    /**
+     * Execute a trusted engine action (including in-process AI responses).
+     * Browser submissions must go through [executeClientAction].
      *
      * Routes the action through the engine's ActionProcessor.
      * Synchronized to prevent lost updates when multiple players act simultaneously.
@@ -923,7 +957,11 @@ class GameSession(
      * Returns either a full [ServerMessage.StateUpdate] (first update or after reconnect)
      * or a [ServerMessage.StateDeltaUpdate] (subsequent updates with only changes).
      */
-    fun createStateUpdate(playerId: EntityId, events: List<GameEvent>): ServerMessage? {
+    fun createStateUpdate(
+        playerId: EntityId,
+        events: List<GameEvent>,
+        useEngineDecisionIds: Boolean = false,
+    ): ServerMessage? = synchronized(stateLock) {
         val state = gameState ?: return null
         val clientState = getClientState(playerId) ?: return null
         val legalActions = getLegalActions(playerId)
@@ -941,7 +979,9 @@ class GameSession(
         // decision to the controller, not the affected player.
         // Enrich with imageUri from card registry since engine doesn't have access to metadata
         val pendingDecision = state.pendingDecision?.takeIf { state.actorFor(it.playerId) == playerId }?.let {
-            decisionEnricher.enrich(it, state, playerId)
+            val enriched = decisionEnricher.enrich(it, state, playerId)
+            // In-process AI simulates against raw engine state; browser clients echo a live ID.
+            if (useEngineDecisionIds) enriched else enriched.withClientRoutingId(liveDecisionId(it.id))
         }
 
         // Calculate next stop point for the Pass button (only if player has priority,
@@ -1188,6 +1228,7 @@ class GameSession(
         }
 
         gameState = checkpoint
+        liveDecisionEpoch = UUID.randomUUID().toString()
         // Roll the replay log back to the actions that produced the restored state, so a later
         // reconstruction replays exactly this history. Yields recorded after the rollback point are
         // dropped too — they were set against actions that no longer exist.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/PendingDecisionRouting.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/PendingDecisionRouting.kt
@@ -1,0 +1,25 @@
+package com.wingedsheep.gameserver.session
+
+import com.wingedsheep.engine.core.*
+
+/** Change only the browser-facing correlation handle; the engine decision remains untouched. */
+internal fun PendingDecision.withClientRoutingId(id: String): PendingDecision = when (this) {
+    is ChooseTargetsDecision -> copy(id = id)
+    is SelectCardsDecision -> copy(id = id)
+    is YesNoDecision -> copy(id = id)
+    is BatchYesNoDecision -> copy(id = id)
+    is ChooseModeDecision -> copy(id = id)
+    is ChooseColorDecision -> copy(id = id)
+    is ChooseNumberDecision -> copy(id = id)
+    is DistributeDecision -> copy(id = id)
+    is OrderObjectsDecision -> copy(id = id)
+    is SplitPilesDecision -> copy(id = id)
+    is ChooseOptionDecision -> copy(id = id)
+    is ChooseReplacementDecision -> copy(id = id)
+    is AssignDamageDecision -> copy(id = id)
+    is SearchLibraryDecision -> copy(id = id)
+    is ReorderLibraryDecision -> copy(id = id)
+    is SelectManaSourcesDecision -> copy(id = id)
+    is BudgetModalDecision -> copy(id = id)
+    is CombatResolutionDecision -> copy(id = id)
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/AiControllerProviderTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/AiControllerProviderTest.kt
@@ -89,7 +89,7 @@ class AiControllerProviderTest : FunSpec({
 
         manager.createAiOpponent(
             gameSession = game,
-            onActionReady = { _, _ -> },
+            onActionReady = { _, _, _ -> },
             onMulliganKeep = { _ -> },
             onMulliganTake = { _ -> },
             onBottomCards = { _, _ -> },
@@ -182,7 +182,7 @@ class AiControllerProviderTest : FunSpec({
             gameSession = game,
             aiPlayerId = aiPlayerId,
             deckList = null,
-            onActionReady = { _, _ -> },
+            onActionReady = { _, _, _ -> },
             onMulliganKeep = { _ -> },
             onMulliganTake = { _ -> },
             onBottomCards = { _, _ -> },

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/AiUndoDecisionFreshnessTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/AiUndoDecisionFreshnessTest.kt
@@ -1,0 +1,312 @@
+package com.wingedsheep.gameserver.session
+
+import com.wingedsheep.ai.ActionResponse
+import com.wingedsheep.ai.AiPlayerController
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.BatchYesNoDecision
+import com.wingedsheep.engine.core.BatchYesNoResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.CancelDecisionResponse
+import com.wingedsheep.engine.core.GameAction
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.SubmitDecision
+import com.wingedsheep.engine.core.engineSerializersModule
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.gameserver.ai.AiWebSocketSession
+import com.wingedsheep.gameserver.handler.GamePlayHandler
+import com.wingedsheep.gameserver.handler.MessageSender
+import com.wingedsheep.gameserver.protocol.ServerMessage
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.springframework.web.socket.TextMessage
+import org.springframework.web.socket.WebSocketSession
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+class AiUndoDecisionFreshnessTest : ScenarioTestBase() {
+    init {
+        test("an actual delayed AI callback cannot answer the replacement Closet batch after undo") {
+            val game = scenario().withPlayers("Human", "AI")
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withCardOnBattlefield(1, "Llanowar Elves")
+                .withCardInHand(1, "Naturalize")
+                .withCardOnBattlefield(2, "Conjurer's Closet")
+                .withCardOnBattlefield(2, "Conjurer's Closet")
+                .withCardOnBattlefield(2, "Conjurer's Closet")
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withActivePlayer(2)
+                .withPriorityPlayer(1)
+                .inPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                .build()
+            val human = game.player1Id
+            val ai = game.player2Id
+            val session = spyk(GameSession(cardRegistry = cardRegistry))
+            val sender = mockk<MessageSender>(relaxed = true)
+            val handler = handler(sender)
+            val oldChoosing = CountDownLatch(1)
+            val newChoosing = CountDownLatch(1)
+            val releaseOld = CountDownLatch(1)
+            val releaseNew = CountDownLatch(1)
+            val oldReturned = CountDownLatch(1)
+            val newReturned = CountDownLatch(1)
+            val callbackFailure = AtomicReference<Throwable?>()
+            val oldEpoch = AtomicReference<String?>()
+            val newEpoch = AtomicReference<String?>()
+            val oldAction = AtomicReference<GameAction?>()
+            val newAction = AtomicReference<GameAction?>()
+            val controller = mockk<AiPlayerController>()
+            every { controller.chooseAction(any(), any(), any(), any()) } answers {
+                val decision = thirdArg<com.wingedsheep.engine.core.PendingDecision>()
+                    .shouldBeInstanceOf<BatchYesNoDecision>()
+                when (decision.count) {
+                    3 -> {
+                        oldChoosing.countDown()
+                        await(releaseOld, "release old controller response")
+                    }
+                    2 -> {
+                        newChoosing.countDown()
+                        await(releaseNew, "release new controller response")
+                    }
+                    else -> error("Unexpected Closet batch size ${decision.count}")
+                }
+                // Distinct payloads identify each callback without relying on its epoch.
+                ActionResponse.SubmitDecision(ai, BatchYesNoResponse(
+                    decision.id, choice = true, applyToAll = decision.count == 3
+                ))
+            }
+            val aiSocket = AiWebSocketSession(
+                aiPlayerId = ai,
+                controller = controller,
+                thinkingDelayMs = 0,
+                onActionReady = { player, action, epoch ->
+                    val response = (action as SubmitDecision).response as BatchYesNoResponse
+                    val old = response.applyToAll
+                    try {
+                        if (old) {
+                            oldEpoch.set(epoch)
+                            oldAction.set(action)
+                        } else {
+                            newEpoch.set(epoch)
+                            newAction.set(action)
+                        }
+                        handler.handleAiAction(session, player, action, epoch)
+                    } catch (failure: Throwable) {
+                        callbackFailure.compareAndSet(null, failure)
+                    } finally {
+                        (if (old) oldReturned else newReturned).countDown()
+                    }
+                },
+                onMulliganKeep = {},
+                onMulliganTake = {},
+                onBottomCards = { _, _ -> }
+            )
+            val humanSocket = mockk<WebSocketSession>(relaxed = true) { every { id } returns "human" }
+            session.injectStateForTesting(game.state, mapOf(
+                human to PlayerSession(humanSocket, human, "Human"),
+                ai to PlayerSession(aiSocket, ai, "AI")
+            ))
+            session.setFullControl(human, true)
+            session.setFullControl(ai, true)
+            val json = Json {
+                serializersModule = engineSerializersModule
+                classDiscriminator = "type"
+                encodeDefaults = true
+            }
+
+            try {
+                val checkpoint = session.getStateForTesting()!!
+                // The undo policy recognizes declared mana abilities in the card script;
+                // intrinsic basic-land mana currently does not establish this checkpoint.
+                val manaSource = game.findPermanent("Llanowar Elves")!!
+                val manaAbility = cardRegistry.getCard("Llanowar Elves")!!.script.activatedAbilities
+                    .single { it.isManaAbility }.id
+                session.executeAction(human, ActivateAbility(human, manaSource, manaAbility))
+                    .shouldBeInstanceOf<GameSession.ActionResult.Success>()
+                session.isUndoAvailable(human) shouldBe true
+                val oldBatch = advanceToBatch(session)
+                oldBatch.count shouldBe 3
+                session.isUndoAvailable(human) shouldBe true
+                val oldUpdate = session.createStateUpdate(ai, emptyList(), useEngineDecisionIds = true)
+                    .shouldBeInstanceOf<ServerMessage.StateUpdate>()
+                oldUpdate.interactionEpoch.shouldNotBeNull()
+                aiSocket.sendMessage(TextMessage(json.encodeToString<ServerMessage>(oldUpdate)))
+                await(oldChoosing, "old AI controller to receive the three-trigger batch")
+
+                session.executeUndo(human).shouldBeInstanceOf<GameSession.ActionResult.Success>()
+                session.getStateForTesting() shouldBe checkpoint
+                val closet = game.findPermanents("Conjurer's Closet").first()
+                val naturalize = game.findCardsInHand(1, "Naturalize").single()
+                session.executeAction(human, CastSpell(human, naturalize, listOf(ChosenTarget.Permanent(closet))))
+                    .shouldBeInstanceOf<GameSession.ActionResult.Success>()
+                val replacementBatch = advanceToBatch(session)
+                replacementBatch.count shouldBe 2
+                replacementBatch.id shouldBe oldBatch.id
+                val newUpdate = session.createStateUpdate(ai, emptyList(), useEngineDecisionIds = true)
+                    .shouldBeInstanceOf<ServerMessage.StateDeltaUpdate>()
+                newUpdate.interactionEpoch.shouldNotBeNull()
+                newUpdate.interactionEpoch shouldNotBe oldUpdate.interactionEpoch
+                aiSocket.sendMessage(TextMessage(json.encodeToString<ServerMessage>(newUpdate)))
+                await(newChoosing, "new AI controller to receive the two-trigger batch")
+
+                val stateBefore = session.getStateForTesting()
+                val actionsBefore = session.getRecordedActions()
+                val checkpointsBefore = session.getReplayCheckpoints()
+                val logsBefore = session.getLogsForPersistence()
+                val undoBefore = session.isUndoAvailable(human)
+                clearMocks(session, sender, answers = false)
+                releaseOld.countDown()
+                await(oldReturned, "obsolete callback to finish through GamePlayHandler")
+                callbackFailure.get() shouldBe null
+                oldEpoch.get() shouldBe oldUpdate.interactionEpoch
+                oldAction.get().shouldBeInstanceOf<SubmitDecision>().response.decisionId shouldBe replacementBatch.id
+                session.getStateForTesting() shouldBe stateBefore
+                session.getRecordedActions() shouldBe actionsBefore
+                session.getReplayCheckpoints() shouldBe checkpointsBefore
+                session.getLogsForPersistence() shouldBe logsBefore
+                session.isUndoAvailable(human) shouldBe undoBefore
+                verify(exactly = 0) { session.executeAction(any(), any(), any()) }
+                verify(exactly = 0) { session.noteActionRejected(any()) }
+                verify(exactly = 0) { session.noteAiActionRejected(any(), any()) }
+                verify(exactly = 0) { sender.send(any(), any()) }
+
+                releaseNew.countDown()
+                await(newReturned, "current callback to finish through GamePlayHandler")
+                callbackFailure.get() shouldBe null
+                newEpoch.get() shouldBe newUpdate.interactionEpoch
+                val accepted = newAction.get().shouldBeInstanceOf<SubmitDecision>()
+                accepted.response.decisionId shouldBe replacementBatch.id
+                session.getRecordedActions() shouldBe actionsBefore + accepted
+                session.getStateForTesting() shouldNotBe stateBefore
+                val replay = actionProcessor.process(stateBefore!!, accepted).result
+                replay.error shouldBe null
+                session.getStateForTesting() shouldBe replay.state
+                verify(exactly = 0) { session.noteActionRejected(any()) }
+                verify(exactly = 0) { session.noteAiActionRejected(any(), any()) }
+            } finally {
+                releaseOld.countDown()
+                releaseNew.countDown()
+                aiSocket.close()
+            }
+        }
+
+        test("undo after a current AI action fails abandons its fallback and rejection bookkeeping") {
+            val game = scenario().withPlayers("Human", "AI")
+                .withCardOnBattlefield(1, "Llanowar Elves")
+                .withCardOnBattlefield(2, "Conjurer's Closet")
+                .withCardOnBattlefield(2, "Conjurer's Closet")
+                .withCardOnBattlefield(2, "Conjurer's Closet")
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withActivePlayer(2)
+                .withPriorityPlayer(1)
+                .inPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                .build()
+            val human = game.player1Id
+            val ai = game.player2Id
+            val session = spyk(GameSession(cardRegistry = cardRegistry))
+            val humanSocket = mockk<WebSocketSession>(relaxed = true) { every { id } returns "human" }
+            val aiSocket = mockk<WebSocketSession>(relaxed = true) { every { id } returns "ai" }
+            session.injectStateForTesting(game.state, mapOf(
+                human to PlayerSession(humanSocket, human, "Human"),
+                ai to PlayerSession(aiSocket, ai, "AI")
+            ))
+            val manaSource = game.findPermanent("Llanowar Elves")!!
+            val manaAbility = cardRegistry.getCard("Llanowar Elves")!!.script.activatedAbilities
+                .single { it.isManaAbility }.id
+            val activate = ActivateAbility(human, manaSource, manaAbility)
+            session.executeAction(human, activate).shouldBeInstanceOf<GameSession.ActionResult.Success>()
+            val original = advanceToBatch(session)
+            session.isUndoAvailable(human) shouldBe true
+            val update = session.createStateUpdate(ai, emptyList(), useEngineDecisionIds = true)
+                .shouldBeInstanceOf<ServerMessage.StateUpdate>()
+            val epoch = update.interactionEpoch.shouldNotBeNull()
+            val invalid = PassPriority(ai) // A priority pass cannot answer the outstanding batch.
+            val sender = mockk<MessageSender>(relaxed = true)
+            val handler = handler(sender)
+            var replacementState: GameState? = null
+            var replacementActions = emptyList<GameAction>()
+            var replacementEpoch: String? = null
+            var interleaved = false
+            every { session.executeAiAction(ai, invalid, epoch) } answers {
+                val result = callOriginal()
+                if (!interleaved) {
+                    interleaved = true
+                    result.shouldBeInstanceOf<GameSession.ActionResult.Failure>()
+                    // Place the undo precisely after the first atomic validation/execution but
+                    // before GamePlayHandler sees Failure and begins its recovery path.
+                    session.executeUndo(human).shouldBeInstanceOf<GameSession.ActionResult.Success>()
+                    session.executeAction(human, activate).shouldBeInstanceOf<GameSession.ActionResult.Success>()
+                    advanceToBatch(session).id shouldBe original.id
+                    replacementState = session.getStateForTesting()
+                    replacementActions = session.getRecordedActions()
+                    replacementEpoch = session.createStateUpdate(ai, emptyList(), useEngineDecisionIds = true)
+                        .shouldBeInstanceOf<ServerMessage.StateDeltaUpdate>().interactionEpoch
+                }
+                result
+            }
+            val logsBefore = session.getLogsForPersistence()
+            val checkpointsBefore = session.getReplayCheckpoints()
+            handler.handleAiAction(session, ai, invalid, epoch)
+            interleaved shouldBe true
+            replacementEpoch.shouldNotBeNull() shouldNotBe epoch
+            session.getStateForTesting() shouldBe replacementState
+            session.getRecordedActions() shouldBe replacementActions
+            session.getReplayCheckpoints() shouldBe checkpointsBefore
+            session.getLogsForPersistence() shouldBe logsBefore
+            session.isUndoAvailable(human) shouldBe true
+            verify(exactly = 0) {
+                session.executeAction(ai, match { it is SubmitDecision && it.response is CancelDecisionResponse }, any())
+            }
+            verify(exactly = 0) { session.noteActionRejected(any()) }
+            verify(exactly = 0) { session.noteAiActionRejected(any(), any()) }
+            verify(exactly = 0) { sender.send(any(), any()) }
+        }
+    }
+
+    private fun advanceToBatch(session: GameSession): BatchYesNoDecision {
+        repeat(12) {
+            val state = session.getStateForTesting()!!
+            state.pendingDecision?.let { return it.shouldBeInstanceOf<BatchYesNoDecision>() }
+            val player = state.priorityPlayerId!!
+            val result = session.executeAction(player, PassPriority(player))
+            check(result !is GameSession.ActionResult.Failure) { "Priority pass failed: $result" }
+        }
+        error("End-step batch was not reached within 12 priority passes")
+    }
+
+    private fun await(latch: CountDownLatch, description: String) {
+        check(latch.await(15, TimeUnit.SECONDS)) { "Timed out waiting for $description" }
+    }
+
+    private fun handler(sender: MessageSender) = GamePlayHandler(
+        sessionRegistry = mockk(relaxed = true),
+        gameRepository = mockk(relaxed = true),
+        lobbyRepository = mockk(relaxed = true),
+        sender = sender,
+        cardRegistry = cardRegistry,
+        printingRegistry = mockk(relaxed = true),
+        tokenArtRegistry = mockk(relaxed = true),
+        deckGenerator = mockk(relaxed = true),
+        gameProperties = mockk(relaxed = true),
+        replayService = mockk(relaxed = true),
+        replayCheckpointFlusher = mockk(relaxed = true),
+        engineVersion = mockk(relaxed = true),
+        aiGameManager = mockk(relaxed = true),
+        matchResultSink = mockk(relaxed = true),
+        rankedResultSink = mockk(relaxed = true),
+        deckProfiler = mockk(relaxed = true)
+    )
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/UndoDecisionFreshnessTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/UndoDecisionFreshnessTest.kt
@@ -1,0 +1,179 @@
+package com.wingedsheep.gameserver.session
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.core.SubmitDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.gameserver.protocol.ServerMessage
+import com.wingedsheep.mtg.sets.definitions.spm.cards.MultiversalPassage
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.web.socket.WebSocketSession
+
+/** Live transport freshness survives undo while engine snapshots keep deterministic routing IDs. */
+class UndoDecisionFreshnessTest : ScenarioTestBase() {
+    init {
+        cardRegistry.register(MultiversalPassage)
+
+        test("a reply retained before undo cannot answer another land's live decision") {
+            val game = scenario().withPlayers()
+                .withCardInHand(1, "Multiversal Passage")
+                .withCardInHand(1, "Multiversal Passage")
+                .build()
+            val initial = game.state
+            val lands = game.findCardsInHand(1, "Multiversal Passage")
+            val player = game.player1Id
+            val session = newSession(game)
+
+            val first = session.executeClientAction(player, PlayLand(player, lands[0]), "land-a")
+                .shouldBeInstanceOf<GameSession.ActionResult.PausedForDecision>()
+            val full = session.createStateUpdate(player, first.events)
+                .shouldBeInstanceOf<ServerMessage.StateUpdate>()
+            val oldPrompt = full.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+            val oldResponse = OptionChosenResponse(oldPrompt.id, oldPrompt.options.indexOf("Island"))
+            oldResponse.optionIndex shouldNotBe -1
+
+            // Resending the same outstanding prompt, including a reconnect's full snapshot,
+            // must keep its token usable; delivery alone does not create a new decision.
+            session.createStateUpdate(player, emptyList())
+                .shouldBeInstanceOf<ServerMessage.StateDeltaUpdate>()
+                .pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>().id shouldBe oldPrompt.id
+            session.clearLastSentState(player)
+            session.createStateUpdate(player, emptyList())
+                .shouldBeInstanceOf<ServerMessage.StateUpdate>()
+                .pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>().id shouldBe oldPrompt.id
+
+            session.isUndoAvailable(player) shouldBe true
+            session.executeUndo(player).shouldBeInstanceOf<GameSession.ActionResult.Success>()
+            session.getStateForTesting() shouldBe initial
+            session.getRecordedActions() shouldBe emptyList()
+
+            val secondAction = PlayLand(player, lands[1])
+            val second = session.executeClientAction(player, secondAction, "land-b")
+                .shouldBeInstanceOf<GameSession.ActionResult.PausedForDecision>()
+            val nextPrompt = session.createStateUpdate(player, second.events)
+                .shouldBeInstanceOf<ServerMessage.StateDeltaUpdate>()
+                .pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+            val beforeRejected = session.getStateForTesting()!!
+            val recordedBefore = session.getRecordedActions()
+            val logsBefore = session.getLogsForPersistence()
+            val checkpointsBefore = session.getReplayCheckpoints()
+            session.isUndoAvailable(player) shouldBe true
+
+            // Undo restores the engine counter: the two different lands intentionally reuse
+            // the same engine handle. The live boundary must distinguish their prompts.
+            first.state.pendingDecision!!.id shouldBe second.state.pendingDecision!!.id
+            val rejected = session.executeClientAction(
+                player, SubmitDecision(player, oldResponse), "choice-retry"
+            )
+            withClue("A delayed response for land A must not select land B's type") {
+                rejected.shouldBeInstanceOf<GameSession.ActionResult.Failure>()
+            }
+            session.getStateForTesting() shouldBe beforeRejected
+            session.getRecordedActions() shouldBe recordedBefore
+            session.getLogsForPersistence() shouldBe logsBefore
+            session.getReplayCheckpoints() shouldBe checkpointsBefore
+            session.isUndoAvailable(player) shouldBe true
+            nextPrompt.id shouldNotBe oldPrompt.id
+
+            // Reuse the rejected request's message ID: rejection must not consume idempotency.
+            val freshResponse = OptionChosenResponse(nextPrompt.id, nextPrompt.options.indexOf("Island"))
+            val accepted = session.executeClientAction(
+                player, SubmitDecision(player, freshResponse), "choice-retry"
+            ).shouldBeInstanceOf<GameSession.ActionResult.PausedForDecision>()
+            accepted.state.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+            accepted.state.projectedState.hasSubtype(lands[1], "Island") shouldBe true
+
+            // The recorded input retains the deterministic engine ID. Reconstructing from
+            // the same checkpoint requires no live token or session epoch.
+            val enginePlay = actionProcessor.process(initial, secondAction).result
+            enginePlay.error shouldBe null
+            enginePlay.state shouldBe beforeRejected
+            enginePlay.events shouldBe second.events
+            val engineResponse = SubmitDecision(
+                player, freshResponse.copy(decisionId = enginePlay.state.pendingDecision!!.id)
+            )
+            session.getRecordedActions() shouldBe listOf(secondAction, engineResponse)
+            val replay = actionProcessor.process(enginePlay.state, engineResponse).result
+            replay.error shouldBe null
+            replay.state shouldBe accepted.state
+            replay.events shouldBe accepted.events
+            actionProcessor.process(enginePlay.state, engineResponse).result shouldBe replay
+        }
+
+        test("session tokens isolate equal engine snapshots and preserve trusted engine-ID consumers") {
+            val game = scenario().withPlayers()
+                .withCardInHand(1, "Multiversal Passage")
+                .build()
+            val player = game.player1Id
+            val land = game.findCardsInHand(1, "Multiversal Passage").single()
+            val firstSession = newSession(game)
+            val secondSession = newSession(game)
+            val action = PlayLand(player, land)
+            val first = firstSession.executeClientAction(player, action)
+                .shouldBeInstanceOf<GameSession.ActionResult.PausedForDecision>()
+            val second = secondSession.executeClientAction(player, action)
+                .shouldBeInstanceOf<GameSession.ActionResult.PausedForDecision>()
+            first.state shouldBe second.state
+            val raw = first.state.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+            second.state.pendingDecision!!.id shouldBe raw.id
+            val firstPrompt = firstSession.createStateUpdate(player, first.events)
+                .shouldBeInstanceOf<ServerMessage.StateUpdate>()
+                .pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+            val secondPrompt = secondSession.createStateUpdate(player, second.events)
+                .shouldBeInstanceOf<ServerMessage.StateUpdate>()
+                .pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+            firstPrompt.id shouldNotBe secondPrompt.id
+            firstPrompt.id shouldNotBe raw.id
+
+            firstSession.executeUndo(game.player2Id)
+                .shouldBeInstanceOf<GameSession.ActionResult.Failure>()
+            firstSession.createStateUpdate(player, emptyList())
+                .shouldBeInstanceOf<ServerMessage.StateDeltaUpdate>()
+                .pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>().id shouldBe firstPrompt.id
+            firstSession.isUndoAvailable(player) shouldBe true
+
+            val rawResponse = SubmitDecision(player, OptionChosenResponse(raw.id, raw.options.indexOf("Island")))
+            firstSession.executeClientAction(player, rawResponse)
+                .shouldBeInstanceOf<GameSession.ActionResult.Failure>()
+            firstSession.getStateForTesting() shouldBe first.state
+            firstSession.getRecordedActions() shouldBe listOf(action)
+
+            val trustedPrompt = firstSession.createStateUpdate(player, emptyList(), useEngineDecisionIds = true)
+                .shouldBeInstanceOf<ServerMessage.StateDeltaUpdate>()
+                .pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+            trustedPrompt.id shouldBe raw.id
+            firstSession.createStateUpdate(player, emptyList())
+                .shouldBeInstanceOf<ServerMessage.StateDeltaUpdate>()
+                .pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>().id shouldBe firstPrompt.id
+
+            val trustedResult = firstSession.executeAction(player, rawResponse)
+                .shouldBeInstanceOf<GameSession.ActionResult.PausedForDecision>()
+            val replay = actionProcessor.process(first.state, rawResponse).result
+            replay.error shouldBe null
+            trustedResult.state shouldBe replay.state
+            trustedResult.events shouldBe replay.events
+            firstSession.getRecordedActions() shouldBe listOf(action, rawResponse)
+        }
+    }
+
+    private fun newSession(game: TestGame): GameSession {
+        val session = GameSession(cardRegistry = cardRegistry)
+        val ws1 = mockk<WebSocketSession>(relaxed = true) { every { id } returns "ws1" }
+        val ws2 = mockk<WebSocketSession>(relaxed = true) { every { id } returns "ws2" }
+        session.injectStateForTesting(
+            game.state,
+            mapOf(
+                game.player1Id to PlayerSession(ws1, game.player1Id, "Player1"),
+                game.player2Id to PlayerSession(ws2, game.player2Id, "Player2")
+            )
+        )
+        return session
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
@@ -653,8 +653,8 @@ sealed interface DecisionResponse {
     /**
      * The same response retargeted at a different pending-decision id. The id is only a routing
      * nonce — the choice payload is unchanged — so this lets a caller that holds a recorded response
-     * re-bind it to a freshly created decision. Used by replay reconstruction, where decision ids
-     * are minted afresh each run (they are not part of the deterministic state).
+     * re-bind it to a reconstructed decision. Current routing IDs reproduce from serialized game
+     * state; replay retains this operation for historical random or clock-based IDs.
      */
     fun withDecisionId(newId: String): DecisionResponse = when (this) {
         is TargetsResponse -> copy(decisionId = newId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -122,8 +122,10 @@ class TriggerProcessor(
                 // after this trigger's target selection is resolved
                 var stateWithContinuations = result.state
                 if (remainingTriggers.isNotEmpty()) {
+                    val (pendingId, pendingState) = stateWithContinuations.newRoutingId()
+                    stateWithContinuations = pendingState
                     val pendingContinuation = PendingTriggersContinuation(
-                        decisionId = "pending-triggers-${java.util.UUID.randomUUID()}",
+                        decisionId = pendingId,
                         remainingTriggers = remainingTriggers
                     )
                     // Push BELOW the TriggeredAbilityContinuation that was just pushed
@@ -249,7 +251,7 @@ class TriggerProcessor(
     ): ExecutionResult {
         val first = run.first()
         val ability = first.ability
-        val decisionId = "batch-may-${java.util.UUID.randomUUID()}"
+        val (decisionId, allocatedState) = state.newRoutingId()
         val decision = BatchYesNoDecision(
             id = decisionId,
             // Same player the BatchKey was built on, so the auto-answer store is keyed identically
@@ -267,11 +269,12 @@ class TriggerProcessor(
 
         // Queue the triggers after the run first (deepest), then the batch frame on top, so the
         // batch resolves before the trailing triggers (APNAP order preserved).
-        var stateWithContinuations = state.withPendingDecision(decision)
+        var stateWithContinuations = allocatedState.withPendingDecision(decision)
         if (remainingTriggers.isNotEmpty()) {
-            stateWithContinuations = stateWithContinuations.pushContinuation(
+            val (pendingId, pendingState) = stateWithContinuations.newRoutingId()
+            stateWithContinuations = pendingState.pushContinuation(
                 PendingTriggersContinuation(
-                    decisionId = "pending-triggers-${java.util.UUID.randomUUID()}",
+                    decisionId = pendingId,
                     remainingTriggers = remainingTriggers
                 )
             )
@@ -1068,7 +1071,7 @@ class TriggerProcessor(
         val optionLabels = offerIndices.map { modal.modes[it].description } +
             (if (doneOffered) listOf(ModalEffectExecutor.DECLINE_MODE_LABEL) else emptyList())
 
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, allocatedState) = state.newRoutingId()
         val pickNumber = selectedModeIndices.size + 1
         val alreadyPicked = if (selectedModeIndices.isEmpty()) "" else {
             "\nAlready picked: ${selectedModeIndices.joinToString("; ") { modal.modes[it].description }}"
@@ -1112,7 +1115,7 @@ class TriggerProcessor(
         )
 
         return ExecutionResult.paused(
-            state.pushContinuation(continuation).withPendingDecision(decision),
+            allocatedState.pushContinuation(continuation).withPendingDecision(decision),
             decision,
             listOf(
                 DecisionRequestedEvent(
@@ -1176,7 +1179,7 @@ class TriggerProcessor(
                 continue
             }
 
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, allocatedState) = state.newRoutingId()
             val pickNumber = ordinal + 1
             val prompt = if (chosenModeIndices.size > 1) {
                 "Choose targets for ${ability.sourceName} — ${mode.description} ($pickNumber of ${chosenModeIndices.size})"
@@ -1213,7 +1216,7 @@ class TriggerProcessor(
             )
 
             return ExecutionResult.paused(
-                state.pushContinuation(continuation).withPendingDecision(decision),
+                allocatedState.pushContinuation(continuation).withPendingDecision(decision),
                 decision,
                 listOf(
                     DecisionRequestedEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DecisionHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DecisionHandler.kt
@@ -4,7 +4,6 @@ import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.model.EntityId
-import java.util.UUID
 
 /**
  * Handles the creation and resolution of player decisions.
@@ -34,8 +33,9 @@ class DecisionHandler {
         legalTargets: Map<Int, List<EntityId>>,
         effectHint: String? = null
     ): ExecutionResult {
+        val (decisionId, allocatedState) = state.newRoutingId()
         val decision = ChooseTargetsDecision(
-            id = generateDecisionId(),
+            id = decisionId,
             playerId = playerId,
             prompt = "Choose targets for $sourceName",
             context = DecisionContext(
@@ -48,7 +48,7 @@ class DecisionHandler {
             legalTargets = legalTargets
         )
 
-        val newState = state.withPendingDecision(decision)
+        val newState = allocatedState.withPendingDecision(decision)
         return ExecutionResult.paused(
             newState,
             decision,
@@ -84,8 +84,9 @@ class DecisionHandler {
          */
         minTotalManaValue: Int? = null
     ): ExecutionResult {
+        val (decisionId, allocatedState) = state.newRoutingId()
         val decision = SelectCardsDecision(
-            id = generateDecisionId(),
+            id = decisionId,
             playerId = playerId,
             prompt = prompt,
             context = DecisionContext(
@@ -101,7 +102,7 @@ class DecisionHandler {
             minTotalManaValue = minTotalManaValue
         )
 
-        val newState = state.withPendingDecision(decision)
+        val newState = allocatedState.withPendingDecision(decision)
         return ExecutionResult.paused(
             newState,
             decision,
@@ -130,8 +131,9 @@ class DecisionHandler {
         phase: DecisionPhase = DecisionPhase.RESOLUTION,
         abilityIdentity: com.wingedsheep.sdk.scripting.AbilityIdentity? = null
     ): ExecutionResult {
+        val (decisionId, allocatedState) = state.newRoutingId()
         val decision = YesNoDecision(
-            id = generateDecisionId(),
+            id = decisionId,
             playerId = playerId,
             prompt = prompt,
             context = DecisionContext(
@@ -144,7 +146,7 @@ class DecisionHandler {
             noText = noText
         )
 
-        val newState = state.withPendingDecision(decision)
+        val newState = allocatedState.withPendingDecision(decision)
         return ExecutionResult.paused(
             newState,
             decision,
@@ -171,8 +173,9 @@ class DecisionHandler {
         minModes: Int = 1,
         maxModes: Int = 1
     ): ExecutionResult {
+        val (decisionId, allocatedState) = state.newRoutingId()
         val decision = ChooseModeDecision(
-            id = generateDecisionId(),
+            id = decisionId,
             playerId = playerId,
             prompt = "Choose ${if (minModes == maxModes) minModes else "$minModes-$maxModes"} mode(s) for $sourceName",
             context = DecisionContext(
@@ -185,7 +188,7 @@ class DecisionHandler {
             maxModes = maxModes
         )
 
-        val newState = state.withPendingDecision(decision)
+        val newState = allocatedState.withPendingDecision(decision)
         return ExecutionResult.paused(
             newState,
             decision,
@@ -212,8 +215,9 @@ class DecisionHandler {
         phase: DecisionPhase = DecisionPhase.RESOLUTION,
         availableColors: Set<Color> = Color.entries.toSet()
     ): ExecutionResult {
+        val (decisionId, allocatedState) = state.newRoutingId()
         val decision = ChooseColorDecision(
-            id = generateDecisionId(),
+            id = decisionId,
             playerId = playerId,
             prompt = prompt,
             context = DecisionContext(
@@ -224,7 +228,7 @@ class DecisionHandler {
             availableColors = availableColors
         )
 
-        val newState = state.withPendingDecision(decision)
+        val newState = allocatedState.withPendingDecision(decision)
         return ExecutionResult.paused(
             newState,
             decision,
@@ -252,8 +256,9 @@ class DecisionHandler {
         targets: List<EntityId>,
         minPerTarget: Int = 0
     ): ExecutionResult {
+        val (decisionId, allocatedState) = state.newRoutingId()
         val decision = DistributeDecision(
-            id = generateDecisionId(),
+            id = decisionId,
             playerId = playerId,
             prompt = prompt,
             context = DecisionContext(
@@ -266,7 +271,7 @@ class DecisionHandler {
             minPerTarget = minPerTarget
         )
 
-        val newState = state.withPendingDecision(decision)
+        val newState = allocatedState.withPendingDecision(decision)
         return ExecutionResult.paused(
             newState,
             decision,
@@ -293,8 +298,9 @@ class DecisionHandler {
         objects: List<EntityId>,
         phase: DecisionPhase = DecisionPhase.RESOLUTION
     ): ExecutionResult {
+        val (decisionId, allocatedState) = state.newRoutingId()
         val decision = OrderObjectsDecision(
-            id = generateDecisionId(),
+            id = decisionId,
             playerId = playerId,
             prompt = prompt,
             context = DecisionContext(
@@ -305,7 +311,7 @@ class DecisionHandler {
             objects = objects
         )
 
-        val newState = state.withPendingDecision(decision)
+        val newState = allocatedState.withPendingDecision(decision)
         return ExecutionResult.paused(
             newState,
             decision,
@@ -332,8 +338,9 @@ class DecisionHandler {
         numberOfPiles: Int = 2,
         pileLabels: List<String> = emptyList()
     ): ExecutionResult {
+        val (decisionId, allocatedState) = state.newRoutingId()
         val decision = SplitPilesDecision(
-            id = generateDecisionId(),
+            id = decisionId,
             playerId = playerId,
             prompt = "Separate cards into $numberOfPiles piles",
             context = DecisionContext(
@@ -346,7 +353,7 @@ class DecisionHandler {
             pileLabels = pileLabels
         )
 
-        val newState = state.withPendingDecision(decision)
+        val newState = allocatedState.withPendingDecision(decision)
         return ExecutionResult.paused(
             newState,
             decision,
@@ -374,8 +381,9 @@ class DecisionHandler {
         maxValue: Int,
         phase: DecisionPhase = DecisionPhase.RESOLUTION
     ): ExecutionResult {
+        val (decisionId, allocatedState) = state.newRoutingId()
         val decision = ChooseNumberDecision(
-            id = generateDecisionId(),
+            id = decisionId,
             playerId = playerId,
             prompt = prompt,
             context = DecisionContext(
@@ -387,7 +395,7 @@ class DecisionHandler {
             maxValue = maxValue
         )
 
-        val newState = state.withPendingDecision(decision)
+        val newState = allocatedState.withPendingDecision(decision)
         return ExecutionResult.paused(
             newState,
             decision,
@@ -402,5 +410,4 @@ class DecisionHandler {
         )
     }
 
-    private fun generateDecisionId(): String = UUID.randomUUID().toString()
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/MulliganHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/MulliganHandler.kt
@@ -8,7 +8,6 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.player.MulliganStateComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
-import java.util.UUID
 
 /**
  * Handles mulligan-related actions during game setup.
@@ -393,9 +392,10 @@ class MulliganHandler(
         val nextLeyline = getNextLeylineChoice(stateWithLeylineScan)
         if (nextLeyline != null) {
             val (playerId, cardId) = nextLeyline
-            val (decision, continuation) = createLeylineDecision(stateWithLeylineScan, playerId, cardId)
+            val (decisionId, allocatedState) = stateWithLeylineScan.newRoutingId()
+            val (decision, continuation) = createLeylineDecision(allocatedState, playerId, cardId, decisionId)
                 ?: return ExecutionResult.success(stateWithLeylineScan, events)
-            val pausedState = stateWithLeylineScan
+            val pausedState = allocatedState
                 .pushContinuation(continuation)
                 .withPendingDecision(decision)
             return ExecutionResult.paused(
@@ -420,13 +420,12 @@ class MulliganHandler(
     /**
      * Build the [YesNoDecision] + [LeylineDecisionContinuation] pair for a specific leyline
      * card in a player's opening hand. The caller is responsible for pushing the continuation
-     * and setting the pending decision on state.
+     * and setting the pending decision on the state returned by [GameState.newRoutingId].
      *
      * Returns null when the card no longer has a [CardComponent] (defensive — shouldn't happen).
      */
-    fun createLeylineDecision(state: GameState, playerId: EntityId, leylineCardId: EntityId): Pair<YesNoDecision, LeylineDecisionContinuation>? {
+    fun createLeylineDecision(state: GameState, playerId: EntityId, leylineCardId: EntityId, decisionId: String): Pair<YesNoDecision, LeylineDecisionContinuation>? {
         val cardName = state.getEntity(leylineCardId)?.get<CardComponent>()?.name ?: return null
-        val decisionId = "leyline-${leylineCardId.value}-${UUID.randomUUID()}"
         val decision = YesNoDecision(
             id = decisionId,
             playerId = playerId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -800,7 +800,7 @@ class ActivateAbilityHandler(
         if (tapXCost != null && action.xValue == null && !alreadyTapping) {
             val tapTargets = costHandler.findUntappedMatchingPermanentsUnified(state, action.playerId, tapXCost.filter)
             val maxX = tapTargets.size
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateAfterRouting) = state.newRoutingId()
             val decision = com.wingedsheep.engine.core.ChooseNumberDecision(
                 id = decisionId,
                 playerId = action.playerId,
@@ -818,7 +818,7 @@ class ActivateAbilityHandler(
                 action = action,
                 tapTargets = tapTargets
             )
-            val pausedState = state
+            val pausedState = stateAfterRouting
                 .withPendingDecision(decision)
                 .pushContinuation(continuation)
             val event = com.wingedsheep.engine.core.DecisionRequestedEvent(
@@ -846,7 +846,7 @@ class ActivateAbilityHandler(
             // "X can't be 0" abilities (Gogo, Master of Mimicry) set a minimum; clamp it to what the
             // player can actually pay so the decision bounds stay valid.
             val minX = ability.minimumXValue.coerceAtMost(maxX)
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateAfterRouting) = state.newRoutingId()
             val decision = com.wingedsheep.engine.core.ChooseNumberDecision(
                 id = decisionId,
                 playerId = action.playerId,
@@ -863,7 +863,7 @@ class ActivateAbilityHandler(
                 decisionId = decisionId,
                 action = action
             )
-            val pausedState = state
+            val pausedState = stateAfterRouting
                 .withPendingDecision(decision)
                 .pushContinuation(continuation)
             val event = com.wingedsheep.engine.core.DecisionRequestedEvent(
@@ -911,7 +911,7 @@ class ActivateAbilityHandler(
             val maxSelections = fixedCount ?: exileXCandidates.size
             val isRealChoice = exileXCandidates.size > minSelections
             if (isRealChoice) {
-                val decisionId = java.util.UUID.randomUUID().toString()
+                val (decisionId, stateAfterRouting) = state.newRoutingId()
                 val prompt = if (fixedCount != null) {
                     "Select $fixedCount card${if (fixedCount > 1) "s" else ""} to exile from " +
                         "graveyard for ${sourceName}"
@@ -938,7 +938,7 @@ class ActivateAbilityHandler(
                     exileCandidates = exileXCandidates,
                     fixedCount = fixedCount
                 )
-                val pausedState = state
+                val pausedState = stateAfterRouting
                     .withPendingDecision(decision)
                     .pushContinuation(continuation)
                 val event = com.wingedsheep.engine.core.DecisionRequestedEvent(
@@ -992,7 +992,7 @@ class ActivateAbilityHandler(
                     exileCandidatesByOwner.flatten()
                 }
             if (exileCandidates.size > exileFromGraveyardCost.count) {
-                val decisionId = java.util.UUID.randomUUID().toString()
+                val (decisionId, stateAfterRouting) = state.newRoutingId()
                 val prompt = "Select ${exileFromGraveyardCost.count} card${if (exileFromGraveyardCost.count > 1) "s" else ""} to exile from graveyard for ${sourceName}"
                 val decision = com.wingedsheep.engine.core.SelectCardsDecision(
                     id = decisionId,
@@ -1013,7 +1013,7 @@ class ActivateAbilityHandler(
                     exileCandidates = exileCandidates,
                     exileCount = exileFromGraveyardCost.count
                 )
-                val pausedState = state
+                val pausedState = stateAfterRouting
                     .withPendingDecision(decision)
                     .pushContinuation(continuation)
                 val event = com.wingedsheep.engine.core.DecisionRequestedEvent(
@@ -1057,7 +1057,7 @@ class ActivateAbilityHandler(
             // case auto-picks. But "with different names" is always a real choice — the player must
             // pick a distinctly-named set even when candidates == count — so always pause for it.
             if (sacrificeCandidates.size > sacrificeCost.count || sacrificeCost.distinctNames) {
-                val decisionId = java.util.UUID.randomUUID().toString()
+                val (decisionId, stateAfterRouting) = state.newRoutingId()
                 val prompt = "Select ${sacrificeCost.count} permanent${if (sacrificeCost.count > 1) "s" else ""} to sacrifice for ${sourceName}"
                 val decision = com.wingedsheep.engine.core.SelectCardsDecision(
                     id = decisionId,
@@ -1079,7 +1079,7 @@ class ActivateAbilityHandler(
                     sacrificeCount = sacrificeCost.count,
                     distinctNames = sacrificeCost.distinctNames
                 )
-                val pausedState = state
+                val pausedState = stateAfterRouting
                     .withPendingDecision(decision)
                     .pushContinuation(continuation)
                 val event = com.wingedsheep.engine.core.DecisionRequestedEvent(
@@ -1118,7 +1118,7 @@ class ActivateAbilityHandler(
             if (candidates.size < minCount) {
                 return ExecutionResult.error(state, "Not enough permanents to $verb for ${sourceName}")
             }
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateAfterRouting) = state.newRoutingId()
             val prompt = "Choose one or more ${variablePermanentsCost.filter.description}s to $verb for ${sourceName}"
             val decision = com.wingedsheep.engine.core.SelectCardsDecision(
                 id = decisionId,
@@ -1139,7 +1139,7 @@ class ActivateAbilityHandler(
                 candidates = candidates,
                 minCount = minCount
             )
-            val pausedState = state.withPendingDecision(decision).pushContinuation(continuation)
+            val pausedState = stateAfterRouting.withPendingDecision(decision).pushContinuation(continuation)
             val event = com.wingedsheep.engine.core.DecisionRequestedEvent(
                 decisionId = decisionId,
                 playerId = action.playerId,
@@ -1191,7 +1191,7 @@ class ActivateAbilityHandler(
                         maxTargets = req.count
                     )
                 }
-                val decisionId = java.util.UUID.randomUUID().toString()
+                val (decisionId, stateAfterRouting) = state.newRoutingId()
                 val prompt = "Choose ${controllerTargetReqsExec.joinToString(" and ") { it.description }} for ${sourceName}"
                 val decision = com.wingedsheep.engine.core.ChooseTargetsDecision(
                     id = decisionId,
@@ -1210,7 +1210,7 @@ class ActivateAbilityHandler(
                     action = action,
                     requirements = controllerTargetReqsExec
                 )
-                val pausedState = state.withPendingDecision(decision).pushContinuation(continuation)
+                val pausedState = stateAfterRouting.withPendingDecision(decision).pushContinuation(continuation)
                 val event = com.wingedsheep.engine.core.DecisionRequestedEvent(
                     decisionId = decisionId,
                     playerId = action.playerId,
@@ -1771,8 +1771,9 @@ class ActivateAbilityHandler(
                     effectResult.state, costPaymentEvents + manaAbilityActivatedEvent
                 )
                 if (deferred.isNotEmpty()) {
+                    val (routingId, stateAfterRouting) = effectResult.state.newRoutingId()
                     val pending = com.wingedsheep.engine.core.PendingTriggersContinuation(
-                        decisionId = "mana-ability-cost-triggers-${java.util.UUID.randomUUID()}",
+                        decisionId = "mana-ability-cost-triggers-$routingId",
                         remainingTriggers = deferred
                     )
                     // Insert at the BOTTOM of the continuation stack so the cost trigger is put on
@@ -1782,7 +1783,7 @@ class ActivateAbilityHandler(
                     // insertion can't jump ahead of unrelated work.
                     val newStack = listOf(pending) + effectResult.state.continuationStack
                     return ExecutionResult.paused(
-                        effectResult.state.copy(continuationStack = newStack),
+                        stateAfterRouting.copy(continuationStack = newStack),
                         effectResult.pendingDecision!!,
                         events + effectResult.events
                     )
@@ -2186,7 +2187,7 @@ class ActivateAbilityHandler(
                 ?.get<com.wingedsheep.engine.state.components.identity.PlayerComponent>()?.name
                 ?: "Player ${opponentId.value}"
         }
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = state.newRoutingId()
         val prompt = "Choose an opponent to choose a target for $sourceName"
         val decision = com.wingedsheep.engine.core.ChooseOptionDecision(
             id = decisionId,
@@ -2207,7 +2208,7 @@ class ActivateAbilityHandler(
             fullRequirements = fullTargetReqs,
             opponentIds = opponentIds
         )
-        val pausedState = state
+        val pausedState = stateAfterRouting
             .withPendingDecision(decision)
             .pushContinuation(continuation)
         val event = com.wingedsheep.engine.core.DecisionRequestedEvent(
@@ -2249,7 +2250,7 @@ class ActivateAbilityHandler(
             )
         }
 
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = state.newRoutingId()
         // The prompt is shown to the opponent who is making the choice, so the "of an opponent's
         // choice" suffix the requirement description carries is redundant noise here — strip it.
         val prompt = "Choose ${opponentReqs.joinToString(" and ") {
@@ -2274,7 +2275,7 @@ class ActivateAbilityHandler(
             fullRequirements = fullTargetReqs,
             deciderId = deciderId
         )
-        val pausedState = state
+        val pausedState = stateAfterRouting
             .withPendingDecision(decision)
             .pushContinuation(continuation)
         val event = com.wingedsheep.engine.core.DecisionRequestedEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CycleCardHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CycleCardHandler.kt
@@ -130,7 +130,7 @@ class CycleCardHandler(
             val fixedMana = cyclingAbility.cost.withXAs(0).cmc
             val maxX = ((manaSolver.getAvailableManaCount(state, action.playerId) - fixedMana) /
                 cyclingAbility.cost.xCount.coerceAtLeast(1)).coerceAtLeast(0)
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateAfterRouting) = state.newRoutingId()
             val decision = com.wingedsheep.engine.core.ChooseNumberDecision(
                 id = decisionId,
                 playerId = action.playerId,
@@ -143,7 +143,7 @@ class CycleCardHandler(
                 minValue = 0,
                 maxValue = maxX
             )
-            val pausedState = state
+            val pausedState = stateAfterRouting
                 .withPendingDecision(decision)
                 .pushContinuation(
                     com.wingedsheep.engine.core.CycleCardChooseXContinuation(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/DeclareBlockersHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/DeclareBlockersHandler.kt
@@ -49,15 +49,16 @@ class DeclareBlockersHandler(
             // after the pause resolves (via checkForMoreContinuations).
             val triggers = triggerDetector.detectTriggers(result.newState, result.events)
             if (triggers.isNotEmpty()) {
+                val (routingId, stateAfterRouting) = result.newState.newRoutingId()
                 val pendingTriggers = PendingTriggersContinuation(
-                    decisionId = "block-triggers-${java.util.UUID.randomUUID()}",
+                    decisionId = "block-triggers-$routingId",
                     remainingTriggers = triggers
                 )
                 // Insert BELOW the top continuation so the pause resolves first, then
                 // checkForMoreContinuations picks up the triggers afterwards.
                 val stack = result.newState.continuationStack
                 val newStack = stack.dropLast(1) + pendingTriggers + stack.last()
-                val stateWithTriggers = result.newState.copy(continuationStack = newStack)
+                val stateWithTriggers = stateAfterRouting.copy(continuationStack = newStack)
                 return ExecutionResult.paused(
                     stateWithTriggers,
                     result.pendingDecision!!,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/SubmitDecisionHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/SubmitDecisionHandler.kt
@@ -127,15 +127,16 @@ class SubmitDecisionHandler(
                 if (sbaResult.isPaused) {
                     var pausedState = sbaResult.state
                     if (preSbaTriggers.isNotEmpty()) {
+                        val (routingId, stateAfterRouting) = pausedState.newRoutingId()
                         val pendingTriggers = PendingTriggersContinuation(
-                            decisionId = "submit-sba-deferred-triggers-${java.util.UUID.randomUUID()}",
+                            decisionId = "submit-sba-deferred-triggers-$routingId",
                             remainingTriggers = preSbaTriggers
                         )
                         val stack = pausedState.continuationStack
                         val newStack = stack.subList(0, preSbaStackSize) +
                             pendingTriggers +
                             stack.subList(preSbaStackSize, stack.size)
-                        pausedState = pausedState.copy(continuationStack = newStack)
+                        pausedState = stateAfterRouting.copy(continuationStack = newStack)
                     }
                     return ExecutionResult.paused(
                         pausedState,
@@ -200,8 +201,9 @@ class SubmitDecisionHandler(
             if (result.isPaused && !result.triggersAlreadyProcessed) {
                 val deferredTriggers = triggerDetector.detectTriggers(result.state, result.events)
                 if (deferredTriggers.isNotEmpty()) {
+                    val (routingId, stateAfterRouting) = result.state.newRoutingId()
                     val pending = PendingTriggersContinuation(
-                        decisionId = "submit-deferred-triggers-${java.util.UUID.randomUUID()}",
+                        decisionId = "submit-deferred-triggers-$routingId",
                         remainingTriggers = deferredTriggers
                     )
                     // Frames untouched by this resume (the identity-equal bottom prefix) are outer
@@ -218,7 +220,7 @@ class SubmitDecisionHandler(
                     val newStack = postStack.subList(0, untouched) + pending +
                         postStack.subList(untouched, postStack.size)
                     return ExecutionResult.paused(
-                        result.state.copy(continuationStack = newStack),
+                        stateAfterRouting.copy(continuationStack = newStack),
                         result.pendingDecision!!,
                         listOf(submittedEvent) + result.events
                     )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/priority/PassPriorityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/priority/PassPriorityHandler.kt
@@ -189,8 +189,9 @@ class PassPriorityHandler(
                 result.events
             )
             if (triggers.isNotEmpty()) {
+                val (routingId, stateAfterRouting) = result.newState.newRoutingId()
                 val pendingTriggers = PendingTriggersContinuation(
-                    decisionId = "resolution-deferred-triggers-${java.util.UUID.randomUUID()}",
+                    decisionId = "resolution-deferred-triggers-$routingId",
                     remainingTriggers = triggers
                 )
                 val stack = result.newState.continuationStack
@@ -198,7 +199,7 @@ class PassPriorityHandler(
                     pendingTriggers +
                     stack.subList(preResolutionStackSize, stack.size)
                 return ExecutionResult.paused(
-                    result.newState.copy(continuationStack = newStack),
+                    stateAfterRouting.copy(continuationStack = newStack),
                     result.pendingDecision!!,
                     result.events
                 )
@@ -239,15 +240,16 @@ class PassPriorityHandler(
         if (sbaResult.isPaused) {
             var pausedState = sbaResult.state
             if (preSbaTriggers.isNotEmpty()) {
+                val (routingId, stateAfterRouting) = pausedState.newRoutingId()
                 val pendingTriggers = PendingTriggersContinuation(
-                    decisionId = "sba-deferred-triggers-${java.util.UUID.randomUUID()}",
+                    decisionId = "sba-deferred-triggers-$routingId",
                     remainingTriggers = preSbaTriggers
                 )
                 val stack = pausedState.continuationStack
                 val newStack = stack.subList(0, preSbaStackSize) +
                     pendingTriggers +
                     stack.subList(preSbaStackSize, stack.size)
-                pausedState = pausedState.copy(continuationStack = newStack)
+                pausedState = stateAfterRouting.copy(continuationStack = newStack)
             }
             return ExecutionResult.paused(
                 pausedState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -4154,7 +4154,7 @@ class CastSpellHandler(
             index to typeToCardIds[type]!!.toList()
         }.toMap()
 
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = currentState.newRoutingId()
         val decision = ChooseOptionDecision(
             id = decisionId,
             playerId = action.playerId,
@@ -4180,7 +4180,7 @@ class CastSpellHandler(
             creatureTypes = sortedTypes
         )
 
-        val pausedState = currentState
+        val pausedState = stateAfterRouting
             .pushContinuation(continuation)
             .withPendingDecision(decision)
 
@@ -4352,7 +4352,7 @@ class CastSpellHandler(
         val optionLabels = offerIndices.map { modalEffect.modes[it].description } +
             (if (doneOffered) listOf("Done") else emptyList())
 
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = state.newRoutingId()
         val pickNumber = selectedModeIndices.size + 1
         val alreadyPicked = if (selectedModeIndices.isNotEmpty()) {
             val labels = selectedModeIndices.map { modalEffect.modes[it].description }
@@ -4389,7 +4389,7 @@ class CastSpellHandler(
             doneOptionOffered = doneOffered
         )
 
-        val pausedState = state
+        val pausedState = stateAfterRouting
             .pushContinuation(continuation)
             .withPendingDecision(decision)
             .withPriority(casterId)
@@ -4497,7 +4497,7 @@ class CastSpellHandler(
             }
 
             val cardName = state.getEntity(action.cardId)?.get<CardComponent>()?.name ?: "spell"
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateAfterRouting) = state.newRoutingId()
             val verb = when (kind) {
                 AdditionalCostSelectionKind.SACRIFICE -> "sacrifice"
                 AdditionalCostSelectionKind.DISCARD -> "discard"
@@ -4531,7 +4531,7 @@ class CastSpellHandler(
                 baseCastAction = action,
                 costKind = kind,
             )
-            val pausedState = state
+            val pausedState = stateAfterRouting
                 .pushContinuation(continuation)
                 .withPendingDecision(decision)
                 .withPriority(action.playerId)
@@ -4675,7 +4675,7 @@ class CastSpellHandler(
                 )
             }
 
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateAfterRouting) = state.newRoutingId()
             val pickNumber = ordinal + 1
             val prompt = "Choose targets for $cardName — ${mode.description} ($pickNumber of ${chosenModeIndices.size})"
             val decision = com.wingedsheep.engine.core.ChooseTargetsDecision(
@@ -4706,7 +4706,7 @@ class CastSpellHandler(
                 currentOrdinal = ordinal
             )
 
-            val pausedState = state
+            val pausedState = stateAfterRouting
                 .pushContinuation(continuation)
                 .withPendingDecision(decision)
                 .withPriority(casterId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ActivateAbilityXCostContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ActivateAbilityXCostContinuationResumer.kt
@@ -107,7 +107,7 @@ class ActivateAbilityXCostContinuationResumer(
         // the frontend renders "Select N/N" with a hard count (this is the assertion the
         // SecludedStarforgeTest UI-flow case pins).
         val sourceName = state.getEntity(action.sourceId)?.get<CardComponent>()?.name
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = state.newRoutingId()
         val prompt = "Select $chosenX permanents to tap for ${sourceName ?: "this ability"}"
         val decision = SelectCardsDecision(
             id = decisionId,
@@ -129,7 +129,7 @@ class ActivateAbilityXCostContinuationResumer(
             chosenX = chosenX,
             tapTargets = continuation.tapTargets
         )
-        val pausedState = state
+        val pausedState = stateAfterRouting
             .withPendingDecision(decision)
             .pushContinuation(nextFrame)
         val event: GameEvent = DecisionRequestedEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ChainSpellContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ChainSpellContinuationResumer.kt
@@ -249,7 +249,7 @@ class ChainSpellContinuationResumer(
             return checkForMore(state, events)
         }
 
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = state.newRoutingId()
 
         val copyCost = effect.copyCost
         val prompt = if (copyCost == null) {
@@ -284,7 +284,7 @@ class ChainSpellContinuationResumer(
             sourceId = sourceId
         )
 
-        val newState = state.withPendingDecision(decision).pushContinuation(copyContinuation)
+        val newState = stateAfterRouting.withPendingDecision(decision).pushContinuation(copyContinuation)
 
         return ExecutionResult.paused(
             newState,
@@ -309,7 +309,7 @@ class ChainSpellContinuationResumer(
         prompt: String,
         useTargetingUI: Boolean
     ): ExecutionResult {
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = state.newRoutingId()
         val decision = SelectCardsDecision(
             id = decisionId,
             playerId = controllerId,
@@ -333,7 +333,7 @@ class ChainSpellContinuationResumer(
             candidateOptions = options
         )
 
-        val newState = state.withPendingDecision(decision).pushContinuation(costContinuation)
+        val newState = stateAfterRouting.withPendingDecision(decision).pushContinuation(costContinuation)
 
         return ExecutionResult.paused(
             newState,
@@ -365,7 +365,7 @@ class ChainSpellContinuationResumer(
             return checkForMore(state, priorEvents)
         }
 
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = state.newRoutingId()
         val decision = SelectCardsDecision(
             id = decisionId,
             playerId = controllerId,
@@ -389,7 +389,7 @@ class ChainSpellContinuationResumer(
             candidateTargets = legalTargets
         )
 
-        val newState = state.withPendingDecision(decision).pushContinuation(targetContinuation)
+        val newState = stateAfterRouting.withPendingDecision(decision).pushContinuation(targetContinuation)
 
         return ExecutionResult.paused(
             newState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
@@ -136,9 +136,9 @@ class CostPaymentContinuationResumer(
         val manaCost = ((cost as? PayCost.Atom)?.atom as? CostAtom.Mana)?.cost ?: return null
         if (ManaPaymentWindow.floatingManaCovers(state, continuation.payerId, manaCost)) return null
 
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = state.newRoutingId()
         val decision = ManaPaymentWindow.buildDecision(
-            state = state,
+            state = stateAfterRouting,
             playerId = continuation.payerId,
             cost = manaCost,
             decisionId = decisionId,
@@ -158,7 +158,7 @@ class CostPaymentContinuationResumer(
             availableSources = decision.availableSources
         )
         return ExecutionResult.paused(
-            state.withPendingDecision(decision).pushContinuation(frame),
+            stateAfterRouting.withPendingDecision(decision).pushContinuation(frame),
             decision,
             listOf(
                 DecisionRequestedEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CreatureTypeChoiceContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CreatureTypeChoiceContinuationResumer.kt
@@ -247,7 +247,7 @@ class CreatureTypeChoiceContinuationResumer(
             val nextPlayer = continuation.remainingPlayers.first()
             val nextRemaining = continuation.remainingPlayers.drop(1)
 
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateAfterRouting) = state.newRoutingId()
             val decision = ChooseOptionDecision(
                 id = decisionId,
                 playerId = nextPlayer,
@@ -267,7 +267,7 @@ class CreatureTypeChoiceContinuationResumer(
                 chosenTypes = updatedChosenTypes
             )
 
-            val stateWithDecision = state.withPendingDecision(decision)
+            val stateWithDecision = stateAfterRouting.withPendingDecision(decision)
             val stateWithContinuation = stateWithDecision.pushContinuation(newContinuation)
 
             return ExecutionResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -12,7 +12,6 @@ import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.Gate
 import com.wingedsheep.sdk.scripting.targets.TargetRequirement
 import com.wingedsheep.sdk.scripting.targets.withCount
-import java.util.UUID
 
 /**
  * Handles core effect and trigger resumption:
@@ -239,7 +238,7 @@ class EffectAndTriggerContinuationResumer(
                 is com.wingedsheep.engine.state.components.stack.ChosenTarget.Spell -> target.spellEntityId
             }
         }
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = state.newRoutingId()
         val decision = DistributeDecision(
             id = decisionId,
             playerId = continuation.controllerId,
@@ -280,7 +279,7 @@ class EffectAndTriggerContinuationResumer(
             interveningIf = continuation.interveningIf
         )
 
-        val newState = state
+        val newState = stateAfterRouting
             .withPendingDecision(decision)
             .pushContinuation(distributionContinuation)
 
@@ -422,9 +421,10 @@ class EffectAndTriggerContinuationResumer(
         val rest = run.drop(1)
         var workingState = state
         if (rest.isNotEmpty()) {
-            workingState = workingState.pushContinuation(
+            val (routingId, stateAfterRouting) = workingState.newRoutingId()
+            workingState = stateAfterRouting.pushContinuation(
                 PendingTriggersContinuation(
-                    decisionId = "batch-may-peel-${java.util.UUID.randomUUID()}",
+                    decisionId = "batch-may-peel-$routingId",
                     remainingTriggers = rest
                 )
             )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/GuessContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/GuessContinuationResumer.kt
@@ -22,7 +22,6 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.effects.CardKind
 import com.wingedsheep.sdk.scripting.effects.Effect
-import java.util.UUID
 
 /**
  * Resumes the two-step opponent-guess flow for
@@ -104,7 +103,7 @@ class GuessContinuationResumer(
             state.getEntity(it)?.get<CardComponent>()?.name
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = state.newRoutingId()
         val decision = ChooseOptionDecision(
             id = decisionId,
             playerId = continuation.guesserId,
@@ -126,7 +125,7 @@ class GuessContinuationResumer(
             effectContext = continuation.effectContext
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateAfterRouting.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(nextContinuation)
 
         return ExecutionResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LeylineContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LeylineContinuationResumer.kt
@@ -165,10 +165,11 @@ class LeylineContinuationResumer(
         val nextLeyline = services.mulliganHandler.getNextLeylineChoice(state)
         if (nextLeyline != null) {
             val (nextPlayerId, nextCardId) = nextLeyline
-            val nextDecision = services.mulliganHandler.createLeylineDecision(state, nextPlayerId, nextCardId)
+            val (decisionId, allocatedState) = state.newRoutingId()
+            val nextDecision = services.mulliganHandler.createLeylineDecision(allocatedState, nextPlayerId, nextCardId, decisionId)
             if (nextDecision != null) {
                 val (decision, nextContinuation) = nextDecision
-                val pausedState = state.pushContinuation(nextContinuation).withPendingDecision(decision)
+                val pausedState = allocatedState.pushContinuation(nextContinuation).withPendingDecision(decision)
                 return ExecutionResult.paused(
                     pausedState,
                     decision,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
@@ -330,7 +330,7 @@ class LibraryAndZoneContinuationResumer(
             }
 
             // Pause for next aura target
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateAfterRouting) = newState.newRoutingId()
             val auraName = nextCardComponent.name
             val requirementInfo = TargetRequirementInfo(
                 index = 0,
@@ -362,7 +362,7 @@ class LibraryAndZoneContinuationResumer(
                 underOwnersControl = continuation.underOwnersControl
             )
 
-            val stateWithDecision = newState.withPendingDecision(decision)
+            val stateWithDecision = stateAfterRouting.withPendingDecision(decision)
             val stateWithContinuation = stateWithDecision.pushContinuation(nextContinuation)
 
             return ExecutionResult(
@@ -864,7 +864,8 @@ class LibraryAndZoneContinuationResumer(
 
         // Grant free-cast permission so the synthesized cast pays nothing.
         val (permId, stateWithGrant) = CastFromCollectionWithoutPayingCostExecutor.grantFreeCast(
-            state = afterBottom,
+            state = (targetPrep as? CastFromCollectionWithoutPayingCostExecutor.TargetPrep.NeedsTargets)?.state
+                ?: afterBottom,
             cardId = continuation.cascadeCardId,
             controllerId = continuation.playerId,
             sourceId = continuation.sourceId,
@@ -1007,7 +1008,8 @@ class LibraryAndZoneContinuationResumer(
         // cast's "whenever you cast a spell (from exile)" triggers are stacked exactly once
         // (Quintorius Kand).
         val (permId, granted) = CastFromCollectionWithoutPayingCostExecutor.grantFreeCast(
-            state = afterBottom,
+            state = (targetPrep as? CastFromCollectionWithoutPayingCostExecutor.TargetPrep.NeedsTargets)?.state
+                ?: afterBottom,
             cardId = discovered,
             controllerId = continuation.playerId,
             sourceId = continuation.sourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
@@ -155,7 +155,7 @@ class ManaPaymentContinuationResumer(
             val solution = manaSolver.solve(state, playerId, partialResult.remainingCost)
             val autoPaySuggestion = solution?.sources?.map { it.entityId } ?: emptyList()
 
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateAfterRouting) = state.newRoutingId()
             val decision = SelectManaSourcesDecision(
                 id = decisionId,
                 playerId = playerId,
@@ -183,7 +183,7 @@ class ManaPaymentContinuationResumer(
                 sourceId = continuation.sourceId
             )
 
-            val stateWithDecision = state.withPendingDecision(decision)
+            val stateWithDecision = stateAfterRouting.withPendingDecision(decision)
             val stateWithContinuation = stateWithDecision.pushContinuation(manaSelectionContinuation)
 
             return ExecutionResult.paused(
@@ -976,7 +976,7 @@ class ManaPaymentContinuationResumer(
         val solution = manaSolver.solve(state, playerId, partialResult.remainingCost)
         val autoPaySuggestion = solution?.sources?.map { it.entityId } ?: emptyList()
 
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = state.newRoutingId()
         val decision = SelectManaSourcesDecision(
             id = decisionId,
             playerId = playerId,
@@ -1003,7 +1003,7 @@ class ManaPaymentContinuationResumer(
             autoPaySuggestion = autoPaySuggestion
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateAfterRouting.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(manaSelectionContinuation)
 
         return ExecutionResult.paused(
@@ -1182,7 +1182,7 @@ class ManaPaymentContinuationResumer(
         val autoPaySuggestion = solution?.sources?.map { it.entityId } ?: emptyList()
 
         // Create mana source selection decision
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = state.newRoutingId()
         val decision = SelectManaSourcesDecision(
             id = decisionId,
             playerId = playerId,
@@ -1206,7 +1206,7 @@ class ManaPaymentContinuationResumer(
             autoPaySuggestion = autoPaySuggestion
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateAfterRouting.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(manaSourceContinuation)
 
         return ExecutionResult.paused(
@@ -1576,7 +1576,7 @@ class ManaPaymentContinuationResumer(
             return ExecutionResult.error(state, "Not enough valid permanents to satisfy $sourceName's tap cost")
         }
 
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = state.newRoutingId()
         val decision = SelectCardsDecision(
             id = decisionId,
             playerId = payingPlayerId,
@@ -1607,7 +1607,7 @@ class ManaPaymentContinuationResumer(
             wardSourceId = wardSourceId
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateAfterRouting.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return ExecutionResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
@@ -633,7 +633,6 @@ class MiscContinuationResumer(
         }
 
         // Prompt for next copy's targets
-        val decisionId = "storm-copy-target-${System.nanoTime()}"
         val legalTargetsMap = mutableMapOf<Int, List<EntityId>>()
         for ((index, requirement) in continuation.spellTargetRequirements.withIndex()) {
             val legalTargets = services.targetFinder.findLegalTargets(
@@ -672,6 +671,8 @@ class MiscContinuationResumer(
             return checkForMore(loopState, loopEvents)
         }
 
+        val (routingId, stateAfterRouting) = currentState.newRoutingId()
+        val decisionId = "storm-copy-target-$routingId"
         val nextContinuation = StormCopyTargetContinuation(
             decisionId = decisionId,
             remainingCopies = remainingAfterThis,
@@ -709,7 +710,7 @@ class MiscContinuationResumer(
             legalTargets = legalTargetsMap
         )
 
-        currentState = currentState.withPendingDecision(decision)
+        currentState = stateAfterRouting.withPendingDecision(decision)
         currentState = currentState.pushContinuation(nextContinuation)
 
         return ExecutionResult.paused(currentState, decision, allEvents)
@@ -1034,7 +1035,7 @@ class MiscContinuationResumer(
                 .dropWhile { it.first != nextType }
                 .drop(1)
 
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateAfterRouting) = newState.newRoutingId()
             val decision = ChooseNumberDecision(
                 id = decisionId,
                 playerId = continuation.controllerId,
@@ -1068,7 +1069,7 @@ class MiscContinuationResumer(
                     prompt = decision.prompt
                 )
             )
-            val pausedState = newState
+            val pausedState = stateAfterRouting
                 .withPendingDecision(decision)
                 .pushContinuation(nextContinuation)
             return ExecutionResult.paused(pausedState, decision, events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -94,7 +94,7 @@ class ModalAndCloneContinuationResumer(
         // More modes still need to be picked — present the next ChooseOptionDecision.
         if (newSelectedIndices.size < continuation.chooseCount && newAvailableIndices.isNotEmpty()) {
             val sourceName = continuation.sourceName ?: "modal spell"
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateAfterRouting) = stateAfterRecord.newRoutingId()
             val prompt = "Choose a mode for $sourceName (${newSelectedIndices.size + 1} of ${continuation.chooseCount})"
             val nextCanDecline = newSelectedIndices.size >= continuation.minChooseCount
             val baseOptions = newAvailableIndices.map { continuation.modes[it].description }
@@ -117,7 +117,7 @@ class ModalAndCloneContinuationResumer(
                 selectedModeIndices = newSelectedIndices,
                 availableIndices = newAvailableIndices
             )
-            val stateWithDecision = stateAfterRecord.withPendingDecision(decision)
+            val stateWithDecision = stateAfterRouting.withPendingDecision(decision)
             val stateWithContinuation = stateWithDecision.pushContinuation(nextContinuation)
             return ExecutionResult.paused(
                 stateWithContinuation,
@@ -1562,7 +1562,7 @@ class ModalAndCloneContinuationResumer(
         val sourceName = continuation.sourceName ?: "modal spell"
 
         val modeDescriptions = modes.map { it.description }
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = state.newRoutingId()
 
         val decision = ChooseOptionDecision(
             id = decisionId,
@@ -1588,7 +1588,7 @@ class ModalAndCloneContinuationResumer(
             outerNamedTargets = continuation.outerNamedTargets
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateAfterRouting.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(modalContinuation)
 
         return ExecutionResult.paused(
@@ -1760,7 +1760,7 @@ internal fun processChosenModeQueue(
     // knows which mode of a Choose-N modal ability they are targeting for. The tail
     // rides on the ModalTargetContinuation; resumeModalTarget re-enters via
     // executeChosenModeWithTail so a nested pause inside this mode still survives.
-    val decisionId = java.util.UUID.randomUUID().toString()
+    val (decisionId, stateAfterRouting) = state.newRoutingId()
     val prompt = "Choose targets for $displayName — ${head.description}"
     val decision = ChooseTargetsDecision(
         id = decisionId,
@@ -1791,7 +1791,7 @@ internal fun processChosenModeQueue(
         outerNamedTargets = outerNamedTargets
     )
 
-    val stateWithContinuation = state.withPendingDecision(decision).pushContinuation(modalTargetContinuation)
+    val stateWithContinuation = stateAfterRouting.withPendingDecision(decision).pushContinuation(modalTargetContinuation)
 
     return ExecutionResult.paused(
         stateWithContinuation,
@@ -1834,9 +1834,10 @@ private fun executeChosenModeWithTail(
     checkForMore: CheckForMore
 ): ExecutionResult {
     val stateForExecution = if (tail.isNotEmpty()) {
-        state.pushContinuation(
+        val (routingId, stateAfterRouting) = state.newRoutingId()
+        stateAfterRouting.pushContinuation(
             ModalChosenModeTailContinuation(
-                decisionId = "modal-chosen-tail-${java.util.UUID.randomUUID()}",
+                decisionId = "modal-chosen-tail-$routingId",
                 controllerId = controllerId,
                 sourceId = sourceId,
                 sourceName = sourceName,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -594,9 +594,9 @@ class SacrificeAndPayContinuationResumer(
         continuation: PayOrSufferContinuation,
         manaCost: ManaCost
     ): ExecutionResult {
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, stateAfterRouting) = state.newRoutingId()
         val decision = ManaPaymentWindow.buildDecision(
-            state = state,
+            state = stateAfterRouting,
             playerId = continuation.playerId,
             cost = manaCost,
             decisionId = decisionId,
@@ -616,7 +616,7 @@ class SacrificeAndPayContinuationResumer(
             availableSources = decision.availableSources
         )
         return ExecutionResult.paused(
-            state.withPendingDecision(decision).pushContinuation(frame),
+            stateAfterRouting.withPendingDecision(decision).pushContinuation(frame),
             decision,
             listOf(
                 DecisionRequestedEvent(
@@ -957,7 +957,7 @@ class SacrificeAndPayContinuationResumer(
                 is CostAtom.PayLife -> {
                     val life = state.lifeTotal(nextPlayerId) // CR 810.9a — team's shared total
                     if (life >= atom.amount) {
-                        val decisionId = java.util.UUID.randomUUID().toString()
+                        val (decisionId, stateAfterRouting) = state.newRoutingId()
                         val prompt = "Pay ${atom.amount} life to prevent ${continuation.sourceName}'s effect?"
                         val decision = YesNoDecision(
                             id = decisionId,
@@ -976,7 +976,7 @@ class SacrificeAndPayContinuationResumer(
                             currentPlayerId = nextPlayerId,
                             remainingPlayers = remainingAfter
                         )
-                        val stateWithContinuation = state.withPendingDecision(decision).pushContinuation(newContinuation)
+                        val stateWithContinuation = stateAfterRouting.withPendingDecision(decision).pushContinuation(newContinuation)
                         return ExecutionResult.paused(
                             stateWithContinuation,
                             decision,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ChooserResolution.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ChooserResolution.kt
@@ -15,7 +15,6 @@ import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.Chooser
 import com.wingedsheep.sdk.scripting.effects.Effect
-import java.util.UUID
 
 /**
  * The single place a [Chooser] becomes a concrete deciding player.
@@ -168,8 +167,8 @@ object ChooserResolution {
         context: EffectContext,
         prompt: String
     ): EffectResult {
-        val decisionId = UUID.randomUUID().toString()
-        val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
+        val sourceName = context.sourceId?.let { stateWithRoutingId.getEntity(it)?.get<CardComponent>()?.name }
         val decision = ChooseOptionDecision(
             id = decisionId,
             playerId = context.controllerId,
@@ -179,7 +178,7 @@ object ChooserResolution {
                 sourceName = sourceName,
                 phase = DecisionPhase.RESOLUTION
             ),
-            options = opponents.map { playerName(state, it) }
+            options = opponents.map { playerName(stateWithRoutingId, it) }
         )
         val continuation = ChooseOpponentDeciderContinuation(
             decisionId = decisionId,
@@ -190,7 +189,7 @@ object ChooserResolution {
             baseContext = context
         )
         return EffectResult.paused(
-            state.withPendingDecision(decision).pushContinuation(continuation),
+            stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation),
             decision,
             listOf(
                 DecisionRequestedEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/chain/ChainCopyExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/chain/ChainCopyExecutor.kt
@@ -18,7 +18,6 @@ import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.ChainCopyEffect
 import com.wingedsheep.sdk.scripting.effects.CopyRecipient
 import com.wingedsheep.sdk.scripting.effects.Effect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -44,13 +43,14 @@ class ChainCopyExecutor(
             ?: return EffectResult.success(state)
 
         // Step 2: Pre-push after-action continuation (sits below any inner continuations)
+        val (afterActionId, stateWithRoutingId) = state.newRoutingId()
         val afterActionContinuation = ChainCopyAfterActionContinuation(
-            decisionId = "chain-after-action-${UUID.randomUUID()}",
+            decisionId = "chain-after-action-$afterActionId",
             effect = effect,
             recipientPlayerId = recipientPlayerId,
             sourceId = context.sourceId
         )
-        val stateWithContinuation = state.pushContinuation(afterActionContinuation)
+        val stateWithContinuation = stateWithRoutingId.pushContinuation(afterActionContinuation)
 
         // Step 3: Execute the inner action via the registry
         val actionResult = effectExecutor(stateWithContinuation, effect.action, context)
@@ -135,9 +135,9 @@ class ChainCopyExecutor(
         }
 
         // Build the yes/no decision
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val sourceName = context.sourceId?.let { sourceId ->
-            state.getEntity(sourceId)?.get<CardComponent>()?.name
+            stateWithRoutingId.getEntity(sourceId)?.get<CardComponent>()?.name
         } ?: effect.spellName
 
         val copyCost = effect.copyCost
@@ -173,7 +173,7 @@ class ChainCopyExecutor(
             sourceId = context.sourceId
         )
 
-        val newState = state.withPendingDecision(decision).pushContinuation(continuation)
+        val newState = stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation)
 
         return EffectResult.paused(
             newState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/OpponentGuessesTopCardKindExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/OpponentGuessesTopCardKindExecutor.kt
@@ -12,7 +12,6 @@ import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.OpponentGuessesTopCardKindEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -58,7 +57,7 @@ class OpponentGuessesTopCardKindExecutor : EffectExecutor<OpponentGuessesTopCard
 
         val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseOptionDecision(
             id = decisionId,
             playerId = chooserId,
@@ -80,7 +79,7 @@ class OpponentGuessesTopCardKindExecutor : EffectExecutor<OpponentGuessesTopCard
             effectContext = context
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/PlayerGuessesConditionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/PlayerGuessesConditionExecutor.kt
@@ -12,7 +12,6 @@ import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.PlayerGuessesConditionEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -56,7 +55,7 @@ class PlayerGuessesConditionExecutor : EffectExecutor<PlayerGuessesConditionEffe
             ?.let { effect.prompt.replace("{name}", it) }
             ?: effect.prompt
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = YesNoDecision(
             id = decisionId,
             playerId = guesserId,
@@ -79,7 +78,7 @@ class PlayerGuessesConditionExecutor : EffectExecutor<PlayerGuessesConditionEffe
         )
 
         return EffectResult.paused(
-            state.withPendingDecision(decision).pushContinuation(continuation),
+            stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation),
             decision,
             listOf(
                 DecisionRequestedEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/PreventAndReactShield.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/PreventAndReactShield.kt
@@ -13,7 +13,6 @@ import com.wingedsheep.sdk.scripting.EventPattern
 import com.wingedsheep.sdk.scripting.TriggerSpec
 import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
 import com.wingedsheep.sdk.scripting.effects.Effect
-import java.util.UUID
 
 /** Installs a one-shot source shield and its linked "when damage is prevented this way" trigger. */
 internal fun GameState.installPreventAndReactShield(
@@ -34,9 +33,9 @@ internal fun GameState.installPreventAndReactShield(
     val sourceName = effectSourceName
         ?: stateWithSource.getEntity(reactionSourceId)?.get<CardComponent>()?.name
         ?: "Source"
-    val delayedTriggerId = UUID.randomUUID().toString()
+    val (delayedTriggerId, stateWithRoutingId) = stateWithSource.newRoutingId()
 
-    var result = stateWithSource
+    var result = stateWithRoutingId
     onPrevented?.let { reaction ->
         result = result.addDelayedTrigger(
             DelayedTriggeredAbility(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/PreventDamageExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/PreventDamageExecutor.kt
@@ -23,7 +23,6 @@ import com.wingedsheep.sdk.scripting.effects.PreventDamageEffect
 import com.wingedsheep.sdk.scripting.effects.PreventionDirection
 import com.wingedsheep.sdk.scripting.effects.PreventionScope
 import com.wingedsheep.sdk.scripting.effects.PreventionSourceFilter
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -106,10 +105,10 @@ class PreventDamageExecutor(
 
         if (sourceIds.isEmpty()) return EffectResult.success(state)
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decisionContext = DecisionContext(
             sourceId = context.sourceId,
-            sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
+            sourceName = context.sourceId?.let { stateWithRoutingId.getEntity(it)?.get<CardComponent>()?.name }
         )
 
         val decision = SelectCardsDecision(
@@ -130,11 +129,11 @@ class PreventDamageExecutor(
                 decisionId = decisionId,
                 controllerId = controllerId,
                 sourceId = context.sourceId,
-                sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name },
+                sourceName = context.sourceId?.let { stateWithRoutingId.getEntity(it)?.get<CardComponent>()?.name },
                 onPrevented = effect.onPrevented,
                 preventDamage = effect.preventDamage
             )
-            val newState = state.withPendingDecision(decision).pushContinuation(continuation)
+            val newState = stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation)
             return EffectResult.paused(newState, decision)
         } else {
             // Prevention-only path: prevent N damage (or all, when amount is null) from chosen source
@@ -150,10 +149,10 @@ class PreventDamageExecutor(
                 controllerId
             } else {
                 context.resolveTarget(effect.target)
-                    ?: return EffectResult.error(state, "Could not resolve target for PreventDamageEffect with ChosenSource")
+                    ?: return EffectResult.error(stateWithRoutingId, "Could not resolve target for PreventDamageEffect with ChosenSource")
             }
-            val amount = effect.amount?.let { amountEvaluator.evaluate(state, it, context) }
-            if (amount != null && amount <= 0) return EffectResult.success(state)
+            val amount = effect.amount?.let { amountEvaluator.evaluate(stateWithRoutingId, it, context) }
+            if (amount != null && amount <= 0) return EffectResult.success(stateWithRoutingId)
 
             val continuation = PreventDamageFromChosenSourceContinuation(
                 decisionId = decisionId,
@@ -163,11 +162,11 @@ class PreventDamageExecutor(
                 amount = amount,
                 gainLifeFromColors = effect.gainLifeFromColors.map { it.name }.toSet(),
                 sourceId = context.sourceId,
-                sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name },
+                sourceName = context.sourceId?.let { stateWithRoutingId.getEntity(it)?.get<CardComponent>()?.name },
                 nextInstanceOnly = effect.nextInstanceOnly,
                 halvePreventedDamage = effect.halvePreventedDamage
             )
-            val newState = state.withPendingDecision(decision).pushContinuation(continuation)
+            val newState = stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation)
             return EffectResult.paused(newState, decision)
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/BeholdEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/BeholdEffectExecutor.kt
@@ -12,7 +12,6 @@ import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.BeholdEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -70,7 +69,7 @@ class BeholdEffectExecutor(
         val sourceName = context.sourceId
             ?.let { state.getEntity(it)?.get<CardComponent>()?.name }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = SelectCardsDecision(
             id = decisionId,
             playerId = beholder,
@@ -94,7 +93,7 @@ class BeholdEffectExecutor(
             effectContext = context,
         )
 
-        val paused = state
+        val paused = stateWithRoutingId
             .pushContinuation(continuation)
             .withPendingDecision(decision)
         return EffectResult.paused(paused, decision)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/BudgetModalEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/BudgetModalEffectExecutor.kt
@@ -7,7 +7,6 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.BudgetModalEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -34,7 +33,7 @@ class BudgetModalEffectExecutor(
             state.getEntity(sourceId)?.get<CardComponent>()?.name
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = BudgetModalDecision(
             id = decisionId,
             playerId = playerId,
@@ -60,7 +59,7 @@ class BudgetModalEffectExecutor(
             selectedModeIndices = emptyList(),
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ChooseActionEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ChooseActionEffectExecutor.kt
@@ -15,7 +15,6 @@ import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.EffectChoice
 import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -64,7 +63,7 @@ class ChooseActionEffectExecutor(
             state.getEntity(sourceId)?.get<CardComponent>()?.name
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseOptionDecision(
             id = decisionId,
             playerId = choosingPlayerId,
@@ -89,7 +88,7 @@ class ChooseActionEffectExecutor(
             triggeringEntityId = context.triggeringEntityId
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -36,7 +36,6 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TriggerSpec
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -142,8 +141,9 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
             else -> null
         }
 
+        val (delayedTriggerId, stateWithRoutingId) = state.newRoutingId()
         val delayedTrigger = DelayedTriggeredAbility(
-            id = UUID.randomUUID().toString(),
+            id = delayedTriggerId,
             effect = resolvedEffect,
             fireAtStep = effect.step,
             sourceId = sourceId,
@@ -161,7 +161,7 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
             fireOnPlayerId = fireOnPlayerId
         )
 
-        return EffectResult.success(state.addDelayedTrigger(delayedTrigger))
+        return EffectResult.success(stateWithRoutingId.addDelayedTrigger(delayedTrigger))
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -47,7 +47,6 @@ import com.wingedsheep.sdk.scripting.effects.SelectionMode
 import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -243,7 +242,7 @@ class GatedEffectExecutor(
         // player confirms a number, not a formula.
         val payLabel = (gate as? Gate.MayPay)?.let { computedCostLabel(state, it.cost, context) }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = YesNoDecision(
             id = decisionId,
             playerId = playerId,
@@ -266,7 +265,7 @@ class GatedEffectExecutor(
             effectContext = context
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(
@@ -300,7 +299,7 @@ class GatedEffectExecutor(
             state.getEntity(sourceId)?.get<CardComponent>()?.name
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = YesNoDecision(
             id = decisionId,
             playerId = playerId,
@@ -319,7 +318,7 @@ class GatedEffectExecutor(
             effectContext = context
         )
 
-        val stateWithContinuation = state.withPendingDecision(decision).pushContinuation(continuation)
+        val stateWithContinuation = stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation)
 
         return EffectResult.paused(
             stateWithContinuation,
@@ -384,7 +383,7 @@ class GatedEffectExecutor(
             WaterbendPermanentChoice(it.entityId, it.name, it.isCreature)
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val declineText = otherwise?.description?.replaceFirstChar { it.lowercase() }
         val decision = SelectManaSourcesDecision(
             id = decisionId,
@@ -415,7 +414,7 @@ class GatedEffectExecutor(
             otherwise = otherwise
         )
 
-        val stateWithContinuation = state.withPendingDecision(decision).pushContinuation(continuation)
+        val stateWithContinuation = stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation)
 
         return EffectResult.paused(
             stateWithContinuation,
@@ -513,7 +512,7 @@ class GatedEffectExecutor(
             state.getEntity(sourceId)?.get<CardComponent>()?.name
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseNumberDecision(
             id = decisionId,
             playerId = playerId,
@@ -532,7 +531,7 @@ class GatedEffectExecutor(
             effectContext = context
         )
 
-        val stateWithContinuation = state.withPendingDecision(decision).pushContinuation(continuation)
+        val stateWithContinuation = stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation)
 
         return EffectResult.paused(
             stateWithContinuation,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/MayRevealCardFromHandEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/MayRevealCardFromHandEffectExecutor.kt
@@ -15,7 +15,6 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.MayRevealCardFromHandEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -67,7 +66,7 @@ class MayRevealCardFromHandEffectExecutor(
         val sourceName = context.sourceId
             ?.let { state.getEntity(it)?.get<CardComponent>()?.name }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = SelectCardsDecision(
             id = decisionId,
             playerId = revealer,
@@ -91,7 +90,7 @@ class MayRevealCardFromHandEffectExecutor(
             effectContext = context,
         )
 
-        val paused = state
+        val paused = stateWithRoutingId
             .pushContinuation(continuation)
             .withPendingDecision(decision)
         return EffectResult.paused(paused, decision)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ModalEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ModalEffectExecutor.kt
@@ -12,7 +12,6 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.ModalEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -132,7 +131,7 @@ class ModalEffectExecutor(
         val basePrompt = "Choose a mode for ${sourceName ?: "modal spell"}"
         val prompt = if (effectiveChooseCount > 1) "$basePrompt (1 of $effectiveChooseCount)" else basePrompt
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseOptionDecision(
             id = decisionId,
             playerId = playerId,
@@ -168,7 +167,7 @@ class ModalEffectExecutor(
             recordChosenModesThisTurn = effect.excludeModesChosenThisTurn
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(
@@ -352,9 +351,10 @@ internal fun processPreTargetedEffectQueue(
     // Pre-push the tail continuation so that if the effect pauses, our frame sits
     // beneath the inner decision's frames and auto-resumes when they finish.
     val stateForExecution = if (tail.isNotEmpty()) {
-        state.pushContinuation(
+        val (continuationId, stateWithRoutingId) = state.newRoutingId()
+        stateWithRoutingId.pushContinuation(
             ModalPreChosenContinuation(
-                decisionId = "modal-pre-chosen-${UUID.randomUUID()}",
+                decisionId = "modal-pre-chosen-$continuationId",
                 controllerId = ctx.controllerId,
                 sourceId = ctx.sourceId,
                 sourceName = ctx.sourceName,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
@@ -27,7 +27,6 @@ import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
 import com.wingedsheep.sdk.scripting.effects.SelectionMode
 import com.wingedsheep.sdk.scripting.targets.TargetRequirement
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -98,7 +97,7 @@ class ReflexiveTriggerEffectExecutor(
             state.getEntity(sourceId)?.get<CardComponent>()?.name
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = YesNoDecision(
             id = decisionId,
             playerId = playerId,
@@ -122,7 +121,7 @@ class ReflexiveTriggerEffectExecutor(
             effectContext = context
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/damage/DividedDamageExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/damage/DividedDamageExecutor.kt
@@ -14,7 +14,6 @@ import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils.toEntityId
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -120,7 +119,7 @@ class DividedDamageExecutor(
             state.getEntity(sourceId)?.get<CardComponent>()?.name
         } ?: "Effect"
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = DistributeDecision(
             id = decisionId,
             playerId = context.controllerId,
@@ -143,7 +142,7 @@ class DividedDamageExecutor(
             targets = targets
         )
 
-        val newState = state
+        val newState = stateWithRoutingId
             .withPendingDecision(decision)
             .pushContinuation(continuation)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/damage/OptionalDamageRedirect.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/damage/OptionalDamageRedirect.kt
@@ -13,7 +13,6 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.Effect
-import java.util.UUID
 
 /**
  * The "**you may**" half of an optional damage-redirection shield (Blood of the Martyr:
@@ -171,8 +170,9 @@ object OptionalDamageRedirect {
             pruned.getEntity(redirectToId)?.get<CardComponent>()?.name ?: "the redirection target"
         }
 
+        val (decisionId, stateWithRoutingId) = pruned.newRoutingId()
         val decision = YesNoDecision(
-            id = UUID.randomUUID().toString(),
+            id = decisionId,
             playerId = shield.controllerId,
             prompt = "$sourceName would deal ${instance.amount} damage to $recipientName — " +
                 "have that damage dealt to $redirectName instead?",
@@ -184,7 +184,7 @@ object OptionalDamageRedirect {
             yesText = "Redirect it",
             noText = "Let it through"
         )
-        return Check.Ask(pruned.withPendingDecision(decision), decision, key)
+        return Check.Ask(stateWithRoutingId.withPendingDecision(decision), decision, key)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CastAnyNumberFromCollectionWithoutPayingCostExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CastAnyNumberFromCollectionWithoutPayingCostExecutor.kt
@@ -16,7 +16,6 @@ import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.CastAnyNumberFromCollectionWithoutPayingCostEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -59,10 +58,10 @@ class CastAnyNumberFromCollectionWithoutPayingCostExecutor :
 
         val controllerId = context.controllerId
         val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
 
         val cardInfo = candidates.associateWith { cardId ->
-            val cardComponent = state.getEntity(cardId)?.get<CardComponent>()
+            val cardComponent = stateWithRoutingId.getEntity(cardId)?.get<CardComponent>()
             SearchCardInfo(
                 name = cardComponent?.name ?: "Unknown",
                 manaCost = cardComponent?.manaCost?.toString() ?: "",
@@ -108,7 +107,7 @@ class CastAnyNumberFromCollectionWithoutPayingCostExecutor :
             maxCasts = effect.maxCasts,
         )
 
-        val pausedState = state
+        val pausedState = stateWithRoutingId
             .pushContinuation(continuation)
             .withPendingDecision(decision)
             .withPriority(controllerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CastFromCollectionWithoutPayingCostExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CastFromCollectionWithoutPayingCostExecutor.kt
@@ -25,7 +25,6 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.AfterResolveDestination
 import com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect
 import com.wingedsheep.sdk.scripting.effects.ModalEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -107,7 +106,7 @@ class CastFromCollectionWithoutPayingCostExecutor(
         // the copy"); only the free-cast path stamps PlayWithoutPayingCostComponent. Both grant a
         // MayPlayPermission so the card is castable from its current (e.g. exile) zone.
         val (permId, newState) = grantFreeCast(
-            state = state,
+            state = (prep as? TargetPrep.NeedsTargets)?.state ?: state,
             cardId = cardId,
             controllerId = controllerId,
             sourceId = context.sourceId,
@@ -187,6 +186,7 @@ class CastFromCollectionWithoutPayingCostExecutor(
 
         /** Pause with [decision] and push [continuation]; the resumer performs the cast with the picks. */
         data class NeedsTargets(
+            val state: GameState,
             val decision: ChooseTargetsDecision,
             val continuation: CastFromCollectionTargetsContinuation,
             val event: DecisionRequestedEvent,
@@ -320,7 +320,7 @@ class CastFromCollectionWithoutPayingCostExecutor(
             // Name the face being cast — a transformed cast prompts for "Deluge of the Dead",
             // not for the front face the player exiled.
             val cardName = (if (castTransformed) cardDef?.name else null) ?: cardComponent?.name ?: "spell"
-            val decisionId = UUID.randomUUID().toString()
+            val (decisionId, stateWithRoutingId) = state.newRoutingId()
             val decision = ChooseTargetsDecision(
                 id = decisionId,
                 playerId = casterId,
@@ -346,7 +346,7 @@ class CastFromCollectionWithoutPayingCostExecutor(
                 decisionType = "CHOOSE_TARGETS",
                 prompt = decision.prompt,
             )
-            return TargetPrep.NeedsTargets(decision, continuation, event)
+            return TargetPrep.NeedsTargets(stateWithRoutingId, decision, continuation, event)
         }
 
         /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChooseCreatureTypePipelineExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChooseCreatureTypePipelineExecutor.kt
@@ -7,7 +7,6 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.effects.ChooseCreatureTypeEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -31,7 +30,7 @@ class ChooseCreatureTypePipelineExecutor : EffectExecutor<ChooseCreatureTypeEffe
         val allCreatureTypes = Subtype.ALL_CREATURE_TYPES
         val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseOptionDecision(
             id = decisionId,
             playerId = controllerId,
@@ -53,7 +52,7 @@ class ChooseCreatureTypePipelineExecutor : EffectExecutor<ChooseCreatureTypeEffe
             options = allCreatureTypes
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChooseOptionPipelineExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChooseOptionPipelineExecutor.kt
@@ -9,7 +9,6 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.effects.ChooseOptionEffect
 import com.wingedsheep.sdk.scripting.effects.OptionType
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -56,7 +55,7 @@ class ChooseOptionPipelineExecutor(
             OptionType.CARD_NAME -> "Name a card"
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseOptionDecision(
             id = decisionId,
             playerId = controllerId,
@@ -78,7 +77,7 @@ class ChooseOptionPipelineExecutor(
             options = options
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChoosePileExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChoosePileExecutor.kt
@@ -7,7 +7,6 @@ import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.ChoosePileEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -59,7 +58,7 @@ class ChoosePileExecutor : EffectExecutor<ChoosePileEffect> {
             )
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseOptionDecision(
             id = decisionId,
             playerId = deciderId,
@@ -90,7 +89,7 @@ class ChoosePileExecutor : EffectExecutor<ChoosePileEffect> {
             storedCollections = context.pipeline.storedCollections
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
@@ -30,7 +30,6 @@ import com.wingedsheep.engine.state.components.stack.captureEntitySnapshots
 import com.wingedsheep.sdk.scripting.effects.MoveType
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.effects.ZonePlacement
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -403,9 +402,9 @@ class MoveCollectionExecutor(
             )
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val sourceName = context.sourceId?.let { sourceId ->
-            state.getEntity(sourceId)?.get<CardComponent>()?.name
+            stateWithRoutingId.getEntity(sourceId)?.get<CardComponent>()?.name
         }
 
         val isOwnLibrary = destPlayerId == context.controllerId
@@ -440,7 +439,7 @@ class MoveCollectionExecutor(
             placement = placement
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(
@@ -575,7 +574,7 @@ class MoveCollectionExecutor(
             )
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val auraName = cardComponent.name
         val requirementInfo = TargetRequirementInfo(
             index = 0,
@@ -607,7 +606,7 @@ class MoveCollectionExecutor(
             underOwnersControl = underOwnersControl
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/NoteCreatureTypePipelineExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/NoteCreatureTypePipelineExecutor.kt
@@ -8,7 +8,6 @@ import com.wingedsheep.engine.state.components.battlefield.NotedCreatureTypesCom
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.effects.NoteCreatureTypeEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -52,7 +51,7 @@ class NoteCreatureTypePipelineExecutor : EffectExecutor<NoteCreatureTypeEffect> 
         val prompt = effect.prompt
             ?: if (effect.secret) "Secretly choose a creature type" else "Note a creature type"
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseOptionDecision(
             id = decisionId,
             playerId = controllerId,
@@ -75,7 +74,7 @@ class NoteCreatureTypePipelineExecutor : EffectExecutor<NoteCreatureTypeEffect> 
             secret = effect.secret
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/PutOnTopOrBottomOfLibraryExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/PutOnTopOrBottomOfLibraryExecutor.kt
@@ -7,7 +7,6 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.sdk.scripting.effects.PutOnLibraryPositionOfChoiceEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -51,7 +50,7 @@ class PutOnTopOrBottomOfLibraryExecutor : EffectExecutor<PutOnLibraryPositionOfC
         val promptPhrase = positions.joinToString(" or ") {
             it.label.replaceFirstChar { c -> c.lowercase() }
         }
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseOptionDecision(
             id = decisionId,
             playerId = ownerId,
@@ -74,7 +73,7 @@ class PutOnTopOrBottomOfLibraryExecutor : EffectExecutor<PutOnLibraryPositionOfC
             positions = positions
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
@@ -22,7 +22,6 @@ import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.SelectionMode
 import com.wingedsheep.sdk.scripting.effects.SelectionRestriction
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -417,15 +416,15 @@ class SelectFromCollectionExecutor(
         conditionalMinimums: List<ConditionalSelectionMinimum> = emptyList()
     ): EffectResult {
         val playerId = decidingPlayerId ?: context.controllerId
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val sourceName = context.sourceId?.let { sourceId ->
-            state.getEntity(sourceId)?.get<CardComponent>()?.name
+            stateWithRoutingId.getEntity(sourceId)?.get<CardComponent>()?.name
         }
 
         // Build card info for hidden-zone cards (library cards are normally hidden)
         val allDisplayCards = cards + nonSelectableCards
         val cardInfoMap = allDisplayCards.associateWith { cardId ->
-            val container = state.getEntity(cardId)
+            val container = stateWithRoutingId.getEntity(cardId)
             val cardComponent = container?.get<CardComponent>()
             SearchCardInfo(
                 name = cardComponent?.name ?: "Unknown",
@@ -500,7 +499,7 @@ class SelectFromCollectionExecutor(
             restrictions = effect.restrictions
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectTargetPipelineExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectTargetPipelineExecutor.kt
@@ -8,7 +8,6 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -77,9 +76,9 @@ class SelectTargetPipelineExecutor(
         effect: SelectTargetEffect,
         legalTargets: List<EntityId>
     ): EffectResult {
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val controllerId = context.controllerId
-        val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
+        val sourceName = context.sourceId?.let { stateWithRoutingId.getEntity(it)?.get<CardComponent>()?.name }
 
         require(effect.requirement.count == 1) {
             "SelectTargetEffect offers one target slot, but ${effect.requirement.description} asks " +
@@ -114,7 +113,7 @@ class SelectTargetPipelineExecutor(
             storedCollections = context.pipeline.storedCollections
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/linkedexile/ReturnOneFromLinkedExileExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/linkedexile/ReturnOneFromLinkedExileExecutor.kt
@@ -10,7 +10,6 @@ import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.ReturnOneFromLinkedExileEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -73,10 +72,10 @@ class ReturnOneFromLinkedExileExecutor : EffectExecutor<ReturnOneFromLinkedExile
         }
 
         // Multiple eligible cards — create a decision
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
 
         val cardInfoMap = playerCards.associateWith { cardId ->
-            val container = state.getEntity(cardId)
+            val container = stateWithRoutingId.getEntity(cardId)
             val cardComponent = container?.get<CardComponent>()
             SearchCardInfo(
                 name = cardComponent?.name ?: "Unknown",
@@ -111,7 +110,7 @@ class ReturnOneFromLinkedExileExecutor : EffectExecutor<ReturnOneFromLinkedExile
             eligibleCards = playerCards
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/ExploreEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/ExploreEffectExecutor.kt
@@ -22,7 +22,6 @@ import com.wingedsheep.sdk.scripting.effects.ExploreEffect
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
 import com.wingedsheep.sdk.scripting.effects.ZonePlacement
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -129,7 +128,7 @@ class ExploreEffectExecutor(
 
             val (stateAfterCounter, counterEvents) = addPlusOneCounter(stateWithRevealed, exploringCreatureId, context)
 
-            val decisionId = UUID.randomUUID().toString()
+            val (decisionId, stateWithRoutingId) = stateAfterCounter.newRoutingId()
             val decision = YesNoDecision(
                 id = decisionId,
                 playerId = explorerId,
@@ -172,7 +171,7 @@ class ExploreEffectExecutor(
                 effectContext = context
             )
 
-            val stateWithContinuation = stateAfterCounter
+            val stateWithContinuation = stateWithRoutingId
                 .withPendingDecision(decision)
                 .pushContinuation(continuation)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddCountersUpToExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddCountersUpToExecutor.kt
@@ -12,7 +12,6 @@ import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.AddCountersUpToEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -52,7 +51,7 @@ class AddCountersUpToExecutor(
         val targetName = state.getEntity(targetId)?.get<CardComponent>()?.name ?: ""
         val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseNumberDecision(
             id = decisionId,
             playerId = context.controllerId,
@@ -74,7 +73,7 @@ class AddCountersUpToExecutor(
             sourceId = context.sourceId
         )
 
-        val newState = state
+        val newState = stateWithRoutingId
             .withPendingDecision(decision)
             .pushContinuation(continuation)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/DistributeCountersAmongFilteredExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/DistributeCountersAmongFilteredExecutor.kt
@@ -12,7 +12,6 @@ import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.DistributeCountersAmongFilteredEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -52,7 +51,7 @@ class DistributeCountersAmongFilteredExecutor : EffectExecutor<DistributeCounter
         val sourceId = context.sourceId ?: context.controllerId
         val sourceName = state.getEntity(sourceId)?.get<CardComponent>()?.name ?: "Spell"
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = DistributeDecision(
             id = decisionId,
             playerId = context.controllerId,
@@ -78,7 +77,7 @@ class DistributeCountersAmongFilteredExecutor : EffectExecutor<DistributeCounter
             removeFromSource = false
         )
 
-        val newState = state
+        val newState = stateWithRoutingId
             .withPendingDecision(decision)
             .pushContinuation(continuation)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/DistributeCountersFromSelfExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/DistributeCountersFromSelfExecutor.kt
@@ -12,7 +12,6 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.DistributeCountersFromSelfEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -62,7 +61,7 @@ class DistributeCountersFromSelfExecutor : EffectExecutor<DistributeCountersFrom
 
         val sourceName = sourceEntity.get<CardComponent>()?.name ?: "Creature"
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = DistributeDecision(
             id = decisionId,
             playerId = context.controllerId,
@@ -85,7 +84,7 @@ class DistributeCountersFromSelfExecutor : EffectExecutor<DistributeCountersFrom
             counterType = effect.counterType
         )
 
-        val newState = state
+        val newState = stateWithRoutingId
             .withPendingDecision(decision)
             .pushContinuation(continuation)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/MoveChosenCountersToTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/MoveChosenCountersToTargetExecutor.kt
@@ -12,7 +12,6 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.MoveChosenCountersToTargetEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -57,7 +56,7 @@ class MoveChosenCountersToTargetExecutor : EffectExecutor<MoveChosenCountersToTa
         val (firstType, firstMax) = present.first()
         val remaining = present.drop(1)
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseNumberDecision(
             id = decisionId,
             playerId = context.controllerId,
@@ -85,7 +84,7 @@ class MoveChosenCountersToTargetExecutor : EffectExecutor<MoveChosenCountersToTa
             anyMovedSoFar = false
         )
 
-        val newState = state
+        val newState = stateWithRoutingId
             .withPendingDecision(decision)
             .pushContinuation(continuation)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/PayCountersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/PayCountersExecutor.kt
@@ -14,7 +14,6 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.PayCountersEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -48,7 +47,7 @@ class PayCountersExecutor : EffectExecutor<PayCountersEffect> {
 
         val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseNumberDecision(
             id = decisionId,
             playerId = playerId,
@@ -70,7 +69,7 @@ class PayCountersExecutor : EffectExecutor<PayCountersEffect> {
             sourceId = context.sourceId
         )
 
-        val newState = state
+        val newState = stateWithRoutingId
             .withPendingDecision(decision)
             .pushContinuation(continuation)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/ProliferateExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/ProliferateExecutor.kt
@@ -18,7 +18,6 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.ProliferateEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -87,7 +86,7 @@ class ProliferateExecutor : EffectExecutor<ProliferateEffect> {
             ?.let { state.getEntity(it)?.get<CardComponent>()?.name }
             ?: "Proliferate"
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = SelectCardsDecision(
             id = decisionId,
             playerId = context.controllerId,
@@ -109,7 +108,7 @@ class ProliferateExecutor : EffectExecutor<ProliferateEffect> {
             eligibleEntities = eligible
         )
 
-        val newState = state
+        val newState = stateWithRoutingId
             .withPendingDecision(decision)
             .pushContinuation(continuation)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/RemoveAnyNumberOfCountersFlow.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/RemoveAnyNumberOfCountersFlow.kt
@@ -10,7 +10,6 @@ import com.wingedsheep.engine.core.RemoveAnyNumberOfCountersContinuation
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.sdk.model.EntityId
-import java.util.UUID
 
 /**
  * The prompt-per-counter-kind walk behind
@@ -101,7 +100,8 @@ object RemoveAnyNumberOfCountersFlow {
                 continue
             }
 
-            val decisionId = UUID.randomUUID().toString()
+            val (decisionId, stateWithRoutingId) = currentState.newRoutingId()
+            currentState = stateWithRoutingId
             val decision = ChooseNumberDecision(
                 id = decisionId,
                 playerId = controllerId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/protection/GrantProtectionFromChosenCardTypeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/protection/GrantProtectionFromChosenCardTypeExecutor.kt
@@ -11,7 +11,6 @@ import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.GrantProtectionFromChosenCardTypeEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -45,7 +44,7 @@ class GrantProtectionFromChosenCardTypeExecutor :
         val cardTypes = GrantProtectionFromChosenCardTypeEffect.PROTECTABLE_CARD_TYPES
         val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseOptionDecision(
             id = decisionId,
             playerId = context.controllerId,
@@ -68,7 +67,7 @@ class GrantProtectionFromChosenCardTypeExecutor :
             duration = effect.duration
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/room/RoomDoorResolution.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/room/RoomDoorResolution.kt
@@ -17,7 +17,6 @@ import com.wingedsheep.engine.state.components.identity.RoomComponent
 import com.wingedsheep.engine.state.components.identity.RoomFace
 import com.wingedsheep.engine.state.components.identity.RoomFaceId
 import com.wingedsheep.sdk.model.EntityId
-import java.util.UUID
 
 /**
  * Shared resolution logic for the resolution-time "lock a door" / "unlock a door" effects
@@ -86,7 +85,7 @@ object RoomDoorResolution {
         controllerId: EntityId,
         lock: Boolean,
     ): EffectResult {
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val verb = if (lock) "lock" else "unlock"
         val decision = ChooseOptionDecision(
             id = decisionId,
@@ -106,7 +105,7 @@ object RoomDoorResolution {
             candidateFaceIds = candidates.map { it.id },
             lock = lock,
         )
-        val newState = state.withPendingDecision(decision).pushContinuation(continuation)
+        val newState = stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation)
         return EffectResult.paused(
             newState,
             decision,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/BecomeCreatureTypeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/BecomeCreatureTypeExecutor.kt
@@ -7,7 +7,6 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.effects.BecomeCreatureTypeEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -56,7 +55,7 @@ class BecomeCreatureTypeExecutor : EffectExecutor<BecomeCreatureTypeEffect> {
             .firstOrNull { it.value in allCreatureTypes }
             ?.value
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseOptionDecision(
             id = decisionId,
             playerId = context.controllerId,
@@ -80,7 +79,7 @@ class BecomeCreatureTypeExecutor : EffectExecutor<BecomeCreatureTypeEffect> {
             duration = effect.duration
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ChangeCreatureTypeTextExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ChangeCreatureTypeTextExecutor.kt
@@ -9,7 +9,6 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.effects.ChangeCreatureTypeTextEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -79,7 +78,7 @@ class ChangeCreatureTypeTextExecutor(
         val excludedNote = if (effect.excludedTypes.isNotEmpty())
             " (can't be ${effect.excludedTypes.joinToString(" or ")})" else ""
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseReplacementDecision(
             id = decisionId,
             playerId = context.controllerId,
@@ -107,7 +106,7 @@ class ChangeCreatureTypeTextExecutor(
             duration = Duration.Permanent
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ChangeWordInTextExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ChangeWordInTextExecutor.kt
@@ -10,7 +10,6 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.ChangeWordInTextEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -142,7 +141,7 @@ class ChangeWordInTextExecutor(
         // Pre-select the first on-card word so the common single-relevant case is one click.
         val defaultFromIndex = fromOptions.indexOfFirst { it in relevant }.takeIf { it >= 0 }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseReplacementDecision(
             id = decisionId,
             playerId = context.controllerId,
@@ -172,7 +171,7 @@ class ChangeWordInTextExecutor(
             duration = effect.duration
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AmassExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AmassExecutor.kt
@@ -16,7 +16,6 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.AmassEffect
 import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -93,7 +92,7 @@ class AmassExecutor(
         val sourceName = context.sourceId
             ?.let { state.getEntity(it)?.get<CardComponent>()?.name }
             ?: "Amass"
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = SelectCardsDecision(
             id = decisionId,
             playerId = controllerId,
@@ -116,7 +115,7 @@ class AmassExecutor(
             sourceId = context.sourceId,
             candidates = armies
         )
-        val newState = state.withPendingDecision(decision).pushContinuation(continuation)
+        val newState = stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation)
         return EffectResult.paused(
             newState,
             decision,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
@@ -16,7 +16,6 @@ import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.references.Player
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -203,7 +202,7 @@ class AnyPlayerMayPayExecutor(
         playerOrder: List<EntityId>,
         currentIndex: Int
     ): EffectResult {
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val prompt = "Pay ${cost.amount} life to prevent $sourceName's effect?"
 
         val decision = YesNoDecision(
@@ -230,7 +229,7 @@ class AnyPlayerMayPayExecutor(
             filter = com.wingedsheep.sdk.scripting.GameObjectFilter.Any
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CollectEvidenceChosenAmountExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CollectEvidenceChosenAmountExecutor.kt
@@ -13,7 +13,6 @@ import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.CollectEvidenceChosenAmountEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -69,7 +68,7 @@ class CollectEvidenceChosenAmountExecutor : EffectExecutor<CollectEvidenceChosen
             )
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseNumberDecision(
             id = decisionId,
             playerId = playerId,
@@ -91,7 +90,7 @@ class CollectEvidenceChosenAmountExecutor : EffectExecutor<CollectEvidenceChosen
         )
 
         return EffectResult.paused(
-            state.withPendingDecision(decision).pushContinuation(continuation),
+            stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation),
             decision,
             listOf(
                 DecisionRequestedEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/EachPlayerChoosesCreatureTypeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/EachPlayerChoosesCreatureTypeExecutor.kt
@@ -7,7 +7,6 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.effects.EachPlayerChoosesCreatureTypeEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -37,7 +36,7 @@ class EachPlayerChoosesCreatureTypeExecutor : EffectExecutor<EachPlayerChoosesCr
         val firstPlayer = playerOrder.first()
         val remainingPlayers = playerOrder.drop(1)
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseOptionDecision(
             id = decisionId,
             playerId = firstPlayer,
@@ -62,7 +61,7 @@ class EachPlayerChoosesCreatureTypeExecutor : EffectExecutor<EachPlayerChoosesCr
             storeAs = effect.storeAs
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayAnyAmountOfLifeAsEntersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayAnyAmountOfLifeAsEntersExecutor.kt
@@ -14,7 +14,6 @@ import com.wingedsheep.engine.state.components.battlefield.EnteredWithValueCompo
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.PayAnyAmountOfLifeAsEntersEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -52,7 +51,7 @@ class PayAnyAmountOfLifeAsEntersExecutor(
         }
 
         val permanentName = state.getEntity(permanentId)?.get<CardComponent>()?.name ?: "it"
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseNumberDecision(
             id = decisionId,
             playerId = context.controllerId,
@@ -66,7 +65,7 @@ class PayAnyAmountOfLifeAsEntersExecutor(
             maxValue = max
         )
 
-        val newState = state
+        val newState = stateWithRoutingId
             .withPendingDecision(decision)
             .pushContinuation(
                 PayAnyAmountOfLifeAsEntersContinuation(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
@@ -24,7 +24,6 @@ import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
 import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
 import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -228,7 +227,7 @@ class PayOrSufferExecutor(
         }
 
         // Create a yes/no decision
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val prompt = "Discard ${if (cost.count == 1) "a card" else "${cost.count} cards"} at random to keep $sourceName?"
 
         val decision = YesNoDecision(
@@ -263,7 +262,7 @@ class PayOrSufferExecutor(
             iterationEntityId = context.pipeline.iterationTarget
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(
@@ -612,7 +611,7 @@ class PayOrSufferExecutor(
             return executeSufferEffect(state, effect.suffer, context)
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val cards = if (cost.count == 1) "card" else "cards"
         val decision = YesNoDecision(
             id = decisionId,
@@ -647,7 +646,7 @@ class PayOrSufferExecutor(
         )
 
         return EffectResult.paused(
-            state.withPendingDecision(decision).pushContinuation(continuation),
+            stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation),
             decision,
             listOf()
         )
@@ -672,7 +671,7 @@ class PayOrSufferExecutor(
         }
 
         // Create a yes/no decision
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val prompt = "Pay ${cost.amount} life to avoid ${describeConsequence(effect, sourceName)}?"
 
         val decision = YesNoDecision(
@@ -707,7 +706,7 @@ class PayOrSufferExecutor(
             iterationEntityId = context.pipeline.iterationTarget
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(
@@ -804,7 +803,7 @@ class PayOrSufferExecutor(
         }
 
         // Create a yes/no decision
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val consequence = describeConsequence(effect, sourceName)
         val prompt = "Pay ${cost.cost} or $consequence?"
 
@@ -840,7 +839,7 @@ class PayOrSufferExecutor(
             manaCost = cost.cost
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(
@@ -889,7 +888,7 @@ class PayOrSufferExecutor(
             return executeSufferEffect(state, effect.suffer, context)
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val prompt = "Choose one:"
 
         val decision = ChooseOptionDecision(
@@ -924,7 +923,7 @@ class PayOrSufferExecutor(
             storedCollections = context.pipeline.storedCollections
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/TheRingTemptsYouExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/TheRingTemptsYouExecutor.kt
@@ -15,7 +15,6 @@ import com.wingedsheep.engine.state.components.identity.RingBearerComponent
 import com.wingedsheep.engine.state.components.player.TheRingComponent
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.TheRingTemptsYouEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -68,7 +67,8 @@ class TheRingTemptsYouExecutor : EffectExecutor<TheRingTemptsYouEffect> {
             )
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = newState.newRoutingId()
+        newState = stateWithRoutingId
         val decision = SelectCardsDecision(
             id = decisionId,
             playerId = temptedId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyEachTargetSpellExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyEachTargetSpellExecutor.kt
@@ -137,7 +137,8 @@ class CopyEachTargetSpellExecutor(
                 }
 
                 val spellName = cardComponent?.name ?: "spell"
-                val decisionId = "copy-each-spell-target-${System.nanoTime()}"
+                val (routingId, stateWithRoutingId) = currentState.newRoutingId()
+                val decisionId = "copy-each-spell-target-$routingId"
                 val continuation = CopyEachSpellContinuation(
                     decisionId = decisionId,
                     remainingSpellIds = queue,
@@ -161,7 +162,7 @@ class CopyEachTargetSpellExecutor(
                     legalTargets = legalTargetsMap
                 )
 
-                val paused = currentState.withPendingDecision(decision).pushContinuation(continuation)
+                val paused = stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation)
                 return ExecutionResult.paused(paused, decision, allEvents)
             }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyTargetSpellExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyTargetSpellExecutor.kt
@@ -237,12 +237,13 @@ class CopyTargetSpellExecutor(
         copyCount: Int = 1,
         stackResolver: StackResolver = StackResolver(cardRegistry = cardRegistry)
     ): EffectResult {
-        val decisionId = "copy-spell-target-${System.nanoTime()}"
+        val (routingId, stateWithRoutingId) = state.newRoutingId()
+        val decisionId = "copy-spell-target-$routingId"
 
         val legalTargetsMap = mutableMapOf<Int, List<EntityId>>()
         for ((index, requirement) in targetRequirements.withIndex()) {
             val legalTargets = targetFinder.findLegalTargets(
-                state, requirement, context.controllerId, context.sourceId
+                stateWithRoutingId, requirement, context.controllerId, context.sourceId
             )
             legalTargetsMap[index] = legalTargets
         }
@@ -254,7 +255,7 @@ class CopyTargetSpellExecutor(
         if (hasNoLegalTargets) {
             return EffectResult.from(
                 putInheritedCopies(
-                    state, stackResolver, spellEntityId, context.controllerId, copyCount,
+                    stateWithRoutingId, stackResolver, spellEntityId, context.controllerId, copyCount,
                     keywordsForCopy, removeLegendary, tokenRiders = null
                 )
             )
@@ -300,7 +301,7 @@ class CopyTargetSpellExecutor(
             legalTargets = legalTargetsMap
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(stateWithContinuation, decision)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyTargetSpellOrAbilityExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyTargetSpellOrAbilityExecutor.kt
@@ -174,7 +174,8 @@ class CopyTargetSpellOrAbilityExecutor(
                 val copyLabel = if (totalCopies > 1)
                     "copy $copyNumber of $totalCopies of $sourceName's ability"
                 else "copy of $sourceName's ability"
-                val decisionId = "copy-ability-target-${System.nanoTime()}"
+                val (routingId, stateWithRoutingId) = currentState.newRoutingId()
+                val decisionId = "copy-ability-target-$routingId"
                 val decision = ChooseTargetsDecision(
                     id = decisionId,
                     playerId = controllerId,
@@ -198,7 +199,7 @@ class CopyTargetSpellOrAbilityExecutor(
                     remainingCopies = copiesLeft,
                     totalCopies = totalCopies
                 )
-                val paused = currentState
+                val paused = stateWithRoutingId
                     .withPendingDecision(decision)
                     .pushContinuation(continuation)
                 return ExecutionResult.paused(paused, decision, allEvents)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyTargetTriggeredAbilityExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/CopyTargetTriggeredAbilityExecutor.kt
@@ -81,8 +81,9 @@ class CopyTargetTriggeredAbilityExecutor(
             return EffectResult.success(state)
         }
 
-        val decisionId = "copy-triggered-ability-target-${System.nanoTime()}"
-        val sourceName = state.getEntity(abilityEntityId)
+        val (routingId, stateWithRoutingId) = state.newRoutingId()
+        val decisionId = "copy-triggered-ability-target-$routingId"
+        val sourceName = stateWithRoutingId.getEntity(abilityEntityId)
             ?.get<TriggeredAbilityOnStackComponent>()?.sourceName ?: "ability"
 
         val continuation = CopyTriggeredAbilityTargetContinuation(
@@ -109,7 +110,7 @@ class CopyTargetTriggeredAbilityExecutor(
             legalTargets = legalTargetsMap
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult.paused(stateWithContinuation, decision)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/StormCopyEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/StormCopyEffectExecutor.kt
@@ -154,7 +154,8 @@ class StormCopyEffectExecutor(
                 continue
             }
 
-            val decisionId = "storm-copy-target-${System.nanoTime()}"
+            val (routingId, stateWithRoutingId) = currentState.newRoutingId()
+            val decisionId = "storm-copy-target-$routingId"
             val continuation = StormCopyTargetContinuation(
                 decisionId = decisionId,
                 remainingCopies = copiesLeft,
@@ -189,7 +190,7 @@ class StormCopyEffectExecutor(
                 legalTargets = legalTargetsMap
             )
 
-            val stateWithDecision = currentState.withPendingDecision(decision)
+            val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
             val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
             return EffectResult.paused(stateWithContinuation, decision, allEvents)
@@ -267,7 +268,8 @@ class StormCopyEffectExecutor(
                         continue
                     }
 
-                    val decisionId = "storm-copy-modal-target-${System.nanoTime()}"
+                    val (routingId, stateWithRoutingId) = currentState.newRoutingId()
+                    val decisionId = "storm-copy-modal-target-$routingId"
                     val copyNumber = totalCopies - copiesLeft + 1
                     val copyLabel = if (totalCopies > 1) "copy $copyNumber of $totalCopies of $spellName"
                         else "copy of $spellName"
@@ -306,7 +308,7 @@ class StormCopyEffectExecutor(
                         removeLegendary = removeLegendary
                     )
 
-                    val pausedState = currentState
+                    val pausedState = stateWithRoutingId
                         .withPendingDecision(decision)
                         .pushContinuation(continuation)
                     return ExecutionResult.paused(pausedState, decision, allEvents)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/WardCounterEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/WardCounterEffectExecutor.kt
@@ -272,7 +272,7 @@ class WardCounterEffectExecutor(
         ): EffectResult {
             val label = WardCost.PlayerCounters(counterType, amount).clause
                 .replaceFirstChar { it.uppercase() }
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateWithRoutingId) = state.newRoutingId()
             val decision = YesNoDecision(
                 id = decisionId,
                 playerId = payingPlayerId,
@@ -297,7 +297,7 @@ class WardCounterEffectExecutor(
                 wardSourceId = wardSourceId
             )
 
-            val stateWithContinuation = state.withPendingDecision(decision).pushContinuation(continuation)
+            val stateWithContinuation = stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation)
 
             return EffectResult.paused(
                 stateWithContinuation,
@@ -347,7 +347,7 @@ class WardCounterEffectExecutor(
 
             val labels = payable.map { it.clause.replaceFirstChar { ch -> ch.uppercase() } } +
                 "Counter spell"
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateWithRoutingId) = state.newRoutingId()
             val decision = ChooseOptionDecision(
                 id = decisionId,
                 playerId = payingPlayerId,
@@ -372,7 +372,7 @@ class WardCounterEffectExecutor(
                 wardSourceId = wardSourceId
             )
 
-            val stateWithContinuation = state.withPendingDecision(decision).pushContinuation(continuation)
+            val stateWithContinuation = stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation)
 
             return EffectResult.paused(
                 stateWithContinuation,
@@ -616,7 +616,7 @@ class WardCounterEffectExecutor(
                 if (count == 1) "a card" else "$count cards"
             }
             val randomSuffix = if (random) " at random" else ""
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateWithRoutingId) = state.newRoutingId()
             val decision = YesNoDecision(
                 id = decisionId,
                 playerId = payingPlayerId,
@@ -642,7 +642,7 @@ class WardCounterEffectExecutor(
                 wardSourceId = wardSourceId
             )
 
-            val stateWithDecision = state.withPendingDecision(decision)
+            val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
             val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
             return EffectResult.paused(
@@ -714,7 +714,7 @@ class WardCounterEffectExecutor(
                 WaterbendPermanentChoice(it.entityId, it.name, it.isCreature)
             }
 
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateWithRoutingId) = state.newRoutingId()
             val payPrompt = if (waterbend) {
                 "Pay $manaCost for ward (tap artifacts/creatures to help) or your spell will be countered"
             } else {
@@ -749,7 +749,7 @@ class WardCounterEffectExecutor(
                 waterbend = waterbend
             )
 
-            val stateWithDecision = state.withPendingDecision(decision)
+            val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
             val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
             return EffectResult.paused(
@@ -786,7 +786,7 @@ class WardCounterEffectExecutor(
                 return counterSpellOrAbility(state, cardRegistry, spellEntityId)
             }
 
-            val decisionId = java.util.UUID.randomUUID().toString()
+            val (decisionId, stateWithRoutingId) = state.newRoutingId()
             val decision = YesNoDecision(
                 id = decisionId,
                 playerId = payingPlayerId,
@@ -810,7 +810,7 @@ class WardCounterEffectExecutor(
                 wardSourceId = wardSourceId
             )
 
-            val stateWithDecision = state.withPendingDecision(decision)
+            val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
             val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
             return EffectResult.paused(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/AuraTokenHostChooser.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/AuraTokenHostChooser.kt
@@ -13,7 +13,6 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.CreateTokenCopyOfTargetEffect
-import java.util.UUID
 
 /**
  * Raises the "what does this Aura token enchant?" choice (CR 303.4h).
@@ -55,14 +54,14 @@ internal object AuraTokenHostChooser {
             return EffectResult.success(state)
         }
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseTargetsDecision(
             id = decisionId,
             playerId = controllerId,
             prompt = "Choose what the $auraName token enchants",
             context = DecisionContext(
                 sourceId = context.sourceId,
-                sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name },
+                sourceName = context.sourceId?.let { stateWithRoutingId.getEntity(it)?.get<CardComponent>()?.name },
                 phase = DecisionPhase.RESOLUTION,
             ),
             targetRequirements = listOf(
@@ -87,7 +86,7 @@ internal object AuraTokenHostChooser {
         )
 
         return EffectResult(
-            state = state.withPendingDecision(decision).pushContinuation(continuation),
+            state = stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation),
             events = emptyList(),
             pendingDecision = decision,
         )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
@@ -25,7 +25,6 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.CreateTokenCopyOfSourceEffect
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -154,9 +153,11 @@ class CreateTokenCopyOfSourceExecutor(
                 val remaining = cappedCount - (index + 1)
                 var pausedState = newState
                 if (remaining > 0) {
-                    pausedState = pausedState.pushContinuation(
+                    val (continuationId, stateWithRoutingId) = newState.newRoutingId()
+                    newState = stateWithRoutingId
+                    pausedState = stateWithRoutingId.pushContinuation(
                         com.wingedsheep.engine.core.CreateTokenCopyRemainingContinuation(
-                            decisionId = "create-token-copy-remaining-${UUID.randomUUID()}",
+                            decisionId = "create-token-copy-remaining-$continuationId",
                             effect = effect,
                             context = context,
                             controllerId = controllerId,
@@ -210,9 +211,10 @@ class CreateTokenCopyOfSourceExecutor(
             // (Stormsplitter: "exile it at the beginning of the next end step").
             val exileStep = effect.exileAtStep
             if (exileStep != null) {
-                newState = newState.addDelayedTrigger(
+                val (delayedTriggerId, stateWithRoutingId) = newState.newRoutingId()
+                newState = stateWithRoutingId.addDelayedTrigger(
                     DelayedTriggeredAbility(
-                        id = UUID.randomUUID().toString(),
+                        id = delayedTriggerId,
                         effect = MoveToZoneEffect(EffectTarget.SpecificEntity(tokenId), Zone.EXILE),
                         fireAtStep = exileStep,
                         sourceId = sourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -37,7 +37,6 @@ import com.wingedsheep.sdk.scripting.effects.GatedEffect
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
 import com.wingedsheep.sdk.scripting.effects.SacrificeTargetEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -330,9 +329,11 @@ class CreateTokenCopyOfTargetExecutor(
                 if (remaining > 0) {
                     // The rest of the batch resumes below the choice's continuation once this token's
                     // choice (and every granted-riot instance) has fully resolved.
-                    pausedState = pausedState.pushContinuation(
+                    val (continuationId, stateWithRoutingId) = newState.newRoutingId()
+                    newState = stateWithRoutingId
+                    pausedState = stateWithRoutingId.pushContinuation(
                         com.wingedsheep.engine.core.CreateTokenCopyRemainingContinuation(
-                            decisionId = "create-token-copy-remaining-${UUID.randomUUID()}",
+                            decisionId = "create-token-copy-remaining-$continuationId",
                             effect = effect,
                             context = context,
                             controllerId = controllerId,
@@ -397,8 +398,10 @@ class CreateTokenCopyOfTargetExecutor(
             val sourceId = context.sourceId ?: controllerId
             val sourceName = state.getEntity(sourceId)?.get<CardComponent>()?.name ?: "Unknown"
             for (tokenId in createdTokens) {
+                val (delayedTriggerId, stateWithRoutingId) = newState.newRoutingId()
+                newState = stateWithRoutingId
                 val delayedTrigger = DelayedTriggeredAbility(
-                    id = UUID.randomUUID().toString(),
+                    id = delayedTriggerId,
                     effect = SacrificeTargetEffect(EffectTarget.SpecificEntity(tokenId)),
                     fireAtStep = sacrificeStep,
                     sourceId = sourceId,
@@ -434,8 +437,10 @@ class CreateTokenCopyOfTargetExecutor(
                 } else {
                     exileEffect
                 }
+                val (delayedTriggerId, stateWithRoutingId) = newState.newRoutingId()
+                newState = stateWithRoutingId
                 val delayedTrigger = DelayedTriggeredAbility(
-                    id = UUID.randomUUID().toString(),
+                    id = delayedTriggerId,
                     effect = delayedEffect,
                     fireAtStep = exileStep,
                     sourceId = sourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
@@ -43,7 +43,6 @@ import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
 import com.wingedsheep.sdk.scripting.effects.SacrificeTargetEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -299,8 +298,10 @@ class CreateTokenExecutor(
                 state.getEntity(id)?.get<CardComponent>()?.name ?: "Unknown"
             }
             for (tokenId in createdTokens) {
+                val (delayedTriggerId, stateWithRoutingId) = newState.newRoutingId()
+                newState = stateWithRoutingId
                 val delayedTrigger = DelayedTriggeredAbility(
-                    id = UUID.randomUUID().toString(),
+                    id = delayedTriggerId,
                     effect = MoveToZoneEffect(EffectTarget.SpecificEntity(tokenId), Zone.EXILE),
                     fireAtStep = exileStep,
                     sourceId = sourceId,
@@ -321,8 +322,10 @@ class CreateTokenExecutor(
                 state.getEntity(id)?.get<CardComponent>()?.name ?: "Unknown"
             }
             for (tokenId in createdTokens) {
+                val (delayedTriggerId, stateWithRoutingId) = newState.newRoutingId()
+                newState = stateWithRoutingId
                 val delayedTrigger = DelayedTriggeredAbility(
-                    id = UUID.randomUUID().toString(),
+                    id = delayedTriggerId,
                     effect = SacrificeTargetEffect(EffectTarget.SpecificEntity(tokenId)),
                     fireAtStep = sacrificeStep,
                     sourceId = sourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
@@ -37,7 +37,6 @@ import com.wingedsheep.sdk.scripting.ModifyTokenCount
 import com.wingedsheep.sdk.scripting.ReplaceTokenCreationWithAttachedCopy
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.events.ControllerFilter
-import java.util.UUID
 
 /**
  * Checks for token creation replacement effects (e.g., Mirrormind Crown)
@@ -307,7 +306,8 @@ object TokenCreationReplacementHelper {
                 var newState = state.withEntity(entityId, container.with(TokenReplacementOfferedThisTurnComponent))
 
                 if (re.optional) {
-                    val decisionId = UUID.randomUUID().toString()
+                    val (decisionId, stateWithRoutingId) = newState.newRoutingId()
+                    newState = stateWithRoutingId
                     val prompt = "Use $cardName? Create ${if (tokenCount == 1) "a token that's a copy" else "$tokenCount tokens that are copies"} of ${attachedCard.name} instead?"
 
                     val decision = YesNoDecision(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
@@ -28,7 +28,6 @@ import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
 import com.wingedsheep.sdk.scripting.effects.ZonePlacement
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -258,14 +257,14 @@ class MoveToZoneEffectExecutor(
         }
 
         val cardName = cardComponent.name
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val decision = ChooseTargetsDecision(
             id = decisionId,
             playerId = controllerId,
             prompt = "Choose what $cardName attaches to",
             context = DecisionContext(
                 sourceId = context.sourceId,
-                sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name },
+                sourceName = context.sourceId?.let { stateWithRoutingId.getEntity(it)?.get<CardComponent>()?.name },
                 phase = DecisionPhase.RESOLUTION
             ),
             targetRequirements = listOf(
@@ -283,7 +282,7 @@ class MoveToZoneEffectExecutor(
             cardId = cardId,
             controllerId = controllerId
         )
-        val newState = state.withPendingDecision(decision).pushContinuation(continuation)
+        val newState = stateWithRoutingId.withPendingDecision(decision).pushContinuation(continuation)
         return EffectResult(state = newState, events = emptyList(), pendingDecision = decision)
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/PutOntoBattlefieldAttachedToChosenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/PutOntoBattlefieldAttachedToChosenExecutor.kt
@@ -19,7 +19,6 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.effects.PutOntoBattlefieldAttachedToChosenEffect
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.TargetObject
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -122,7 +121,7 @@ class PutOntoBattlefieldAttachedToChosenExecutor(
         }
 
         // Pause for the controller to choose a host.
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, stateWithRoutingId) = state.newRoutingId()
         val cardName = cardComponent.name
         val requirementInfo = TargetRequirementInfo(
             index = 0,
@@ -136,7 +135,7 @@ class PutOntoBattlefieldAttachedToChosenExecutor(
             prompt = "Choose what $cardName attaches to",
             context = DecisionContext(
                 sourceId = context.sourceId,
-                sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name },
+                sourceName = context.sourceId?.let { stateWithRoutingId.getEntity(it)?.get<CardComponent>()?.name },
                 phase = DecisionPhase.RESOLUTION
             ),
             targetRequirements = listOf(requirementInfo),
@@ -149,7 +148,7 @@ class PutOntoBattlefieldAttachedToChosenExecutor(
             controllerId = controllerId
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = stateWithRoutingId.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return EffectResult(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -192,15 +192,16 @@ internal class AttackPhaseManager(
         taxEvents: List<com.wingedsheep.engine.core.GameEvent>,
         bands: List<Set<EntityId>> = emptyList()
     ): ExecutionResult {
+        var newState = state
         // Assign each band a shared id, then map every banded attacker to it (CR 702.22).
         val bandIdByAttacker: Map<EntityId, String> = buildMap {
             for (band in bands) {
-                val bandId = java.util.UUID.randomUUID().toString()
+                val (bandId, bandState) = newState.newRoutingId()
+                newState = bandState
                 for (attackerId in band) put(attackerId, bandId)
             }
         }
 
-        var newState = state
         val tapEvents = mutableListOf<TappedEvent>()
         for ((attackerId, defenderId) in attackers) {
             val hasVigilance = projected.hasKeyword(attackerId, Keyword.VIGILANCE)
@@ -311,7 +312,7 @@ internal class AttackPhaseManager(
         val solution = manaSolver.solve(state, attackingPlayer, manaCost)
         val autoPaySuggestion = solution?.sources?.map { it.entityId } ?: emptyList()
 
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, allocatedState) = state.newRoutingId()
         val attackerNames = attackers.keys.mapNotNull { state.getEntity(it)?.get<CardComponent>()?.name }
         val attackerListing = when (attackerNames.size) {
             0 -> "your attackers"
@@ -342,7 +343,7 @@ internal class AttackPhaseManager(
             bands = bands,
         )
         return ExecutionResult.paused(
-            state.withPendingDecision(decision).pushContinuation(continuation),
+            allocatedState.withPendingDecision(decision).pushContinuation(continuation),
             decision,
         )
     }
@@ -366,7 +367,7 @@ internal class AttackPhaseManager(
             state, attackingPlayer, payingAttacker, requirement
         )
         val attackerName = state.getEntity(payingAttacker)?.get<CardComponent>()?.name ?: "your attacker"
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, allocatedState) = state.newRoutingId()
         val decision = com.wingedsheep.engine.core.SelectCardsDecision(
             id = decisionId,
             playerId = attackingPlayer,
@@ -392,7 +393,7 @@ internal class AttackPhaseManager(
             bands = bands,
         )
         return ExecutionResult.paused(
-            state.withPendingDecision(decision).pushContinuation(continuation),
+            allocatedState.withPendingDecision(decision).pushContinuation(continuation),
             decision,
         )
     }
@@ -420,7 +421,7 @@ internal class AttackPhaseManager(
             state, attackingPlayer, payingAttacker, requirement
         )
         val attackerName = state.getEntity(payingAttacker)?.get<CardComponent>()?.name ?: "your attacker"
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, allocatedState) = state.newRoutingId()
         val decision = com.wingedsheep.engine.core.SelectCardsDecision(
             id = decisionId,
             playerId = attackingPlayer,
@@ -444,7 +445,7 @@ internal class AttackPhaseManager(
             bands = bands,
         )
         return ExecutionResult.paused(
-            state.withPendingDecision(decision).pushContinuation(continuation),
+            allocatedState.withPendingDecision(decision).pushContinuation(continuation),
             decision,
             carryEvents,
         )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
@@ -39,7 +39,6 @@ import com.wingedsheep.sdk.scripting.CantBlockUnlessCoBlocker
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.filters.unified.Scope
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
-import java.util.UUID
 
 /**
  * Handles the declare blockers step of combat.
@@ -1139,7 +1138,7 @@ internal class BlockPhaseManager(
         val solution = manaSolver.solve(state, blockingPlayer, manaCost)
         val autoPaySuggestion = solution?.sources?.map { it.entityId } ?: emptyList()
 
-        val decisionId = java.util.UUID.randomUUID().toString()
+        val (decisionId, allocatedState) = state.newRoutingId()
         val decision = com.wingedsheep.engine.core.SelectManaSourcesDecision(
             id = decisionId,
             playerId = blockingPlayer,
@@ -1163,7 +1162,7 @@ internal class BlockPhaseManager(
             autoPaySuggestion = autoPaySuggestion,
         )
         return ExecutionResult.paused(
-            state.withPendingDecision(decision).pushContinuation(continuation),
+            allocatedState.withPendingDecision(decision).pushContinuation(continuation),
             decision,
         )
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -37,7 +37,6 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AssignCombatDamageAsUnblocked
 import com.wingedsheep.sdk.scripting.DivideCombatDamageFreely
 import com.wingedsheep.sdk.scripting.effects.RedirectScope
-import java.util.UUID
 
 /**
  * Handles combat damage using a three-phase pipeline:
@@ -112,7 +111,7 @@ internal class CombatDamageManager(
             if (attackerPower <= 0) continue
 
             val attackingPlayer = projected.getController(attackerId) ?: continue
-            val decisionId = UUID.randomUUID().toString()
+            val (decisionId, allocatedState) = state.newRoutingId()
 
             val decision = YesNoDecision(
                 id = decisionId,
@@ -134,7 +133,7 @@ internal class CombatDamageManager(
                 firstStrike = firstStrike
             )
 
-            val pausedState = state
+            val pausedState = allocatedState
                 .withPendingDecision(decision)
                 .pushContinuation(continuation)
 
@@ -199,7 +198,7 @@ internal class CombatDamageManager(
 
             if (targets.size <= 1) continue
 
-            val decisionId = UUID.randomUUID().toString()
+            val (decisionId, allocatedState) = state.newRoutingId()
             val attackingPlayer = projected.getController(attackerId) ?: continue
 
             val decision = DistributeDecision(
@@ -223,7 +222,7 @@ internal class CombatDamageManager(
                 firstStrike = firstStrike
             )
 
-            val pausedState = state
+            val pausedState = allocatedState
                 .withPendingDecision(decision)
                 .pushContinuation(continuation)
 
@@ -620,7 +619,7 @@ internal class CombatDamageManager(
             .filterNot { it in attackerChoosers }
         val choosers = attackerChoosers + blockerChoosers
 
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, allocatedState) = state.newRoutingId()
         // Names here are the real card names; per-viewer face-down masking is applied downstream at
         // delivery time (DecisionEnricher), since this one decision graph is shown to both choosers.
         val prompt = if (candidates.size == 1) {
@@ -651,7 +650,7 @@ internal class CombatDamageManager(
             decisionShape = decision,
         )
         return ExecutionResult.paused(
-            state.withPendingDecision(decision).pushContinuation(continuation),
+            allocatedState.withPendingDecision(decision).pushContinuation(continuation),
             decision,
         )
     }
@@ -673,7 +672,7 @@ internal class CombatDamageManager(
         val updatedEdges = previous.edges.map { edge ->
             latestAmounts[edge.id]?.let { edge.copy(amount = it) } ?: edge
         }
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, allocatedState) = state.newRoutingId()
         val newDecision = previous.copy(
             id = decisionId,
             playerId = nextChooser,
@@ -687,7 +686,7 @@ internal class CombatDamageManager(
             decisionShape = newDecision,
         )
         return ExecutionResult.paused(
-            state.withPendingDecision(newDecision).pushContinuation(continuation),
+            allocatedState.withPendingDecision(newDecision).pushContinuation(continuation),
             newDecision,
         )
     }
@@ -1645,7 +1644,7 @@ internal class CombatDamageManager(
                 val shieldAmount = mod.remainingAmount
                 if (shieldAmount >= totalDamage) continue
 
-                val decisionId = UUID.randomUUID().toString()
+                val (decisionId, allocatedState) = state.newRoutingId()
 
                 val decision = DistributeDecision(
                     id = decisionId,
@@ -1671,7 +1670,7 @@ internal class CombatDamageManager(
                     firstStrike = firstStrike
                 )
 
-                val pausedState = state
+                val pausedState = allocatedState
                     .withPendingDecision(decision)
                     .pushContinuation(continuation)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -39,7 +39,6 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.DistributedCounterRemoval
 import com.wingedsheep.sdk.scripting.costs.PayCost
-import java.util.UUID
 
 /**
  * Single, shared engine service that owns paying every [PayCost] variant.
@@ -288,7 +287,7 @@ class CostPaymentService(private val services: EngineServices) {
         // and the trailing "Don't pay" option means decline.
         val affordable = cost.options.filter { canAfford(state, payerId, it, sourceId) }
         val labels = affordable.map { it.description.replaceFirstChar { ch -> ch.uppercase() } } + "Don't pay"
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, allocatedState) = state.newRoutingId()
         val decision = ChooseOptionDecision(
             id = decisionId,
             playerId = payerId,
@@ -298,7 +297,7 @@ class CostPaymentService(private val services: EngineServices) {
         )
         // Store the reduced (affordable-only) Choice so the resumer can map the option index directly.
         val reduced = PayCost.Choice(affordable)
-        val stateWithContinuation = state.withPendingDecision(decision)
+        val stateWithContinuation = allocatedState.withPendingDecision(decision)
             .pushContinuation(continuation(decisionId, payerId, sourceId, sourceName, reduced, ctx))
         return PaymentResult.Pending(
             stateWithContinuation,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1703,9 +1703,10 @@ class StackResolver(
             val sacrificeStep = copyRiders?.sacrificeAtStep
             if (sacrificeStep != null) {
                 val sourceName = newState.getEntity(spellId)?.get<CardComponent>()?.name ?: "Unknown"
-                newState = newState.addDelayedTrigger(
+                val (triggerId, allocatedState) = newState.newRoutingId()
+                newState = allocatedState.addDelayedTrigger(
                     DelayedTriggeredAbility(
-                        id = java.util.UUID.randomUUID().toString(),
+                        id = triggerId,
                         effect = com.wingedsheep.sdk.scripting.effects.SacrificeTargetEffect(
                             com.wingedsheep.sdk.scripting.targets.EffectTarget.SpecificEntity(spellId)
                         ),
@@ -1941,8 +1942,9 @@ class StackResolver(
             val entryTimestamp = newState.getEntity(spellId)
                 ?.get<com.wingedsheep.engine.state.components.battlefield.BattlefieldEntryTimestampComponent>()
                 ?.timestamp
+            val (triggerId, allocatedState) = newState.newRoutingId()
             val delayedTrigger = DelayedTriggeredAbility(
-                id = java.util.UUID.randomUUID().toString(),
+                id = triggerId,
                 effect = WarpExileEffect(
                     target = EffectTarget.SpecificEntity(spellId),
                     enteredBattlefieldTimestamp = entryTimestamp
@@ -1952,7 +1954,7 @@ class StackResolver(
                 sourceName = cardComponent?.name ?: "Unknown",
                 controllerId = controllerId
             )
-            newState = newState.addDelayedTrigger(delayedTrigger)
+            newState = allocatedState.addDelayedTrigger(delayedTrigger)
         }
 
         // Dash (CR 702.109a): create delayed trigger to return this permanent to its owner's
@@ -1961,8 +1963,9 @@ class StackResolver(
             val entryTimestamp = newState.getEntity(spellId)
                 ?.get<com.wingedsheep.engine.state.components.battlefield.BattlefieldEntryTimestampComponent>()
                 ?.timestamp
+            val (triggerId, allocatedState) = newState.newRoutingId()
             val delayedTrigger = DelayedTriggeredAbility(
-                id = java.util.UUID.randomUUID().toString(),
+                id = triggerId,
                 effect = MoveTrackedBattlefieldObjectEffect(
                     target = EffectTarget.SpecificEntity(spellId),
                     destination = Zone.HAND,
@@ -1973,7 +1976,7 @@ class StackResolver(
                 sourceName = cardComponent?.name ?: "Unknown",
                 controllerId = controllerId
             )
-            newState = newState.addDelayedTrigger(delayedTrigger)
+            newState = allocatedState.addDelayedTrigger(delayedTrigger)
         }
 
         // Prepared (Secrets of Strixhaven): a preparation creature whose face carries the PREPARED
@@ -2022,31 +2025,34 @@ class StackResolver(
         exiledCardId: EntityId,
         casterId: EntityId,
         sourceName: String
-    ): GameState = state.addDelayedTrigger(
-        com.wingedsheep.engine.event.DelayedTriggeredAbility(
-            id = java.util.UUID.randomUUID().toString(),
-            effect = com.wingedsheep.sdk.scripting.effects.MayEffect(
-                com.wingedsheep.sdk.scripting.effects.CompositeEffect(
-                    listOf(
-                        com.wingedsheep.sdk.scripting.effects.GatherCardsEffect(
-                            source = com.wingedsheep.sdk.scripting.effects.CardSource.Self,
-                            storeAs = "rebound_recast",
-                        ),
-                        com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect(
-                            from = "rebound_recast",
-                        ),
-                    )
+    ): GameState {
+        val (triggerId, allocatedState) = state.newRoutingId()
+        return allocatedState.addDelayedTrigger(
+            com.wingedsheep.engine.event.DelayedTriggeredAbility(
+                id = triggerId,
+                effect = com.wingedsheep.sdk.scripting.effects.MayEffect(
+                    com.wingedsheep.sdk.scripting.effects.CompositeEffect(
+                        listOf(
+                            com.wingedsheep.sdk.scripting.effects.GatherCardsEffect(
+                                source = com.wingedsheep.sdk.scripting.effects.CardSource.Self,
+                                storeAs = "rebound_recast",
+                            ),
+                            com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect(
+                                from = "rebound_recast",
+                            ),
+                        )
+                    ),
+                    descriptionOverride = "cast this card from exile without paying its mana cost",
                 ),
-                descriptionOverride = "cast this card from exile without paying its mana cost",
-            ),
-            fireAtStep = com.wingedsheep.sdk.core.Step.UPKEEP,
-            fireOnPlayerId = casterId,
-            notBeforeTurn = state.turnNumber + 1,
-            sourceId = exiledCardId,
-            sourceName = sourceName,
-            controllerId = casterId,
+                fireAtStep = com.wingedsheep.sdk.core.Step.UPKEEP,
+                fireOnPlayerId = casterId,
+                notBeforeTurn = state.turnNumber + 1,
+                sourceId = exiledCardId,
+                sourceName = sourceName,
+                controllerId = casterId,
+            )
         )
-    )
+    }
 
     /**
      * Resolve a non-permanent spell - execute effects, put in graveyard.
@@ -2170,9 +2176,10 @@ class StackResolver(
             // pauses for a decision of its own — the frame sits beneath the inner decision's frames
             // and auto-resumes once they finish (CR 702.47b: main spell first, then the spliced text).
             val stateForMainEffect = if (spliceEntries.isNotEmpty()) {
-                newState.pushContinuation(
+                val (tailId, allocatedState) = newState.newRoutingId()
+                allocatedState.pushContinuation(
                     SpliceTailContinuation(
-                        decisionId = "splice-tail-${java.util.UUID.randomUUID()}",
+                        decisionId = tailId,
                         controllerId = spellComponent.casterId,
                         sourceId = spellId,
                         sourceName = cardComponent?.name,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/replacement/ReplacementEffectProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/replacement/ReplacementEffectProcessor.kt
@@ -313,7 +313,7 @@ class ReplacementEffectProcessor {
         context: EffectContext?
     ): ProcessorResult.Paused {
         val playerId = event.affectedPlayerId
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, allocatedState) = state.newRoutingId()
 
         val decision = ChooseOptionDecision(
             id = decisionId,
@@ -336,7 +336,7 @@ class ReplacementEffectProcessor {
             context = context
         )
 
-        val stateWithDecision = state.withPendingDecision(decision)
+        val stateWithDecision = allocatedState.withPendingDecision(decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(continuation)
 
         return ProcessorResult.Paused(stateWithContinuation, decision)
@@ -358,14 +358,14 @@ class ReplacementEffectProcessor {
         alreadyApplied: Set<ReplacementEffectIdentity>,
         context: EffectContext?
     ): ProcessorResult {
-        val decisionId = UUID.randomUUID().toString()
+        val (decisionId, allocatedState) = state.newRoutingId()
         val promptResult = event.createOptionalPrompt(
             decisionId, gathered, state.copy(activeReplacementChain = alreadyApplied), context
         )
             ?: // Event doesn't support optional prompts — treat as mandatory
             return applySingle(state, gathered, event, alreadyApplied)
 
-        val stateWithDecision = state.withPendingDecision(promptResult.decision)
+        val stateWithDecision = allocatedState.withPendingDecision(promptResult.decision)
         val stateWithContinuation = stateWithDecision.pushContinuation(promptResult.continuation)
 
         return ProcessorResult.Paused(stateWithContinuation, promptResult.decision)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -358,6 +358,14 @@ data class GameState(
     val nextEntityId: Long = 0L,
 
     /**
+     * Game-local correlation IDs for decisions, continuations, delayed triggers, and combat bands.
+     * Independent of entity allocation and gameplay RNG; persisted so restore and replay resume
+     * the same sequence. Older snapshots omit this field and start the new sequence at zero;
+     * their existing UUID routing IDs remain valid and cannot collide with the `r` namespace.
+     */
+    val nextRoutingId: Long = 0L,
+
+    /**
      * Per-player persistent "yield" preferences keyed by [com.wingedsheep.sdk.scripting.AbilityIdentity]
      * (MTGO right-click yields — see `backlog/stack-collapse-and-batch-decisions.md` §C). Lives on
      * [GameState] (not the server session) so it survives serialization, replays deterministically,
@@ -1121,6 +1129,16 @@ data class GameState(
      */
     fun newEntity(): Pair<EntityId, GameState> =
         EntityId("e$nextEntityId") to copy(nextEntityId = nextEntityId + 1)
+
+    /**
+     * Allocate an opaque, game-local routing token and carry the returned state forward.
+     * Equal snapshots allocate equal tokens; distinct allocations along one timeline are unique.
+     * These tokens are neither globally unique game IDs nor semantic action identities.
+     */
+    fun newRoutingId(): Pair<String, GameState> {
+        check(nextRoutingId >= 0 && nextRoutingId < Long.MAX_VALUE) { "Routing ID counter exhausted" }
+        return "r$nextRoutingId" to copy(nextRoutingId = nextRoutingId + 1)
+    }
 
     /**
      * Set the priority player (returns new state).

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/RoutingIdentityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/RoutingIdentityTest.kt
@@ -1,0 +1,225 @@
+package com.wingedsheep.engine.core
+
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.EffectHandler
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.GameRng
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+
+/** Routing handles must reproduce without spending gameplay entropy or entity identity. */
+class RoutingIdentityTest : ScenarioTestBase() {
+    private val json = Json {
+        serializersModule = engineSerializersModule
+        allowStructuredMapKeys = true
+        encodeDefaults = true
+    }
+
+    init {
+        test("routing allocation is independent of gameplay randomness and entity allocation") {
+            val initial = GameState(rng = GameRng.seeded(42))
+            val (first, allocated) = initial.newRoutingId()
+            first shouldBe "r0"
+            val (second, twiceAllocated) = allocated.newRoutingId()
+            second shouldBe "r1"
+            initial.nextRoutingId shouldBe 0L
+            twiceAllocated.nextRoutingId shouldBe 2L
+            twiceAllocated.rng shouldBe initial.rng
+            twiceAllocated.nextEntityId shouldBe initial.nextEntityId
+            twiceAllocated.nextRandom { nextBoolean() }.first shouldBe
+                initial.nextRandom { nextBoolean() }.first
+            twiceAllocated.newEntity().first shouldBe initial.newEntity().first
+
+            val advanced = initial.nextRandom { nextBoolean() }.second.newEntity().second
+            advanced.newRoutingId().first shouldBe first
+            advanced.newRoutingId().second.nextRoutingId shouldBe 1L
+        }
+
+        test("routing allocation fails before the counter can overflow or reuse handles") {
+            val last = GameState(nextRoutingId = Long.MAX_VALUE - 1)
+            val (id, exhausted) = last.newRoutingId()
+            id shouldBe "r${Long.MAX_VALUE - 1}"
+            exhausted.nextRoutingId shouldBe Long.MAX_VALUE
+            shouldThrow<IllegalStateException> { exhausted.newRoutingId() }
+            shouldThrow<IllegalStateException> { GameState(nextRoutingId = -1).newRoutingId() }
+        }
+
+        test("serialized routing allocation resumes at the saved counter") {
+            val state = GameState(rng = GameRng.seeded(17)).newRoutingId().second.newRoutingId().second
+            val restored = json.decodeFromString<GameState>(json.encodeToString(state))
+            restored shouldBe state
+            restored.newRoutingId() shouldBe state.newRoutingId()
+            restored.newRoutingId().first shouldBe "r2"
+
+        }
+
+        test("a legacy pending UUID decision resumes before allocating the first new routing handle") {
+            val game = scenario().withPlayers().build()
+            val paused = EffectHandler(cardRegistry = cardRegistry).execute(
+                game.state,
+                MayEffect(MayEffect(Effects.GainLife(2))),
+                EffectContext(sourceId = null, controllerId = game.player1Id)
+            )
+            paused.error shouldBe null
+            val oldId = "73b0b4a6-5d8a-4f36-9870-6c63852a1927"
+            val oldDecision = paused.state.pendingDecision.shouldBeInstanceOf<YesNoDecision>().copy(id = oldId)
+            val oldContinuation = paused.state.continuationStack.single()
+                .shouldBeInstanceOf<GatedEffectContinuation>().copy(decisionId = oldId)
+            val legacyState = paused.state.copy(
+                pendingDecision = oldDecision,
+                continuationStack = listOf(oldContinuation)
+            )
+            val legacy = JsonObject(
+                json.parseToJsonElement(json.encodeToString(legacyState)).jsonObject - "nextRoutingId"
+            )
+            val restoredLegacy = json.decodeFromString<GameState>(legacy.toString())
+            restoredLegacy.nextRoutingId shouldBe 0L
+            restoredLegacy.pendingDecision shouldBe oldDecision
+            restoredLegacy.continuationStack shouldBe listOf(oldContinuation)
+            val oldResponse = SubmitDecision(game.player1Id, YesNoResponse(oldId, true))
+            val resumed = actionProcessor.process(restoredLegacy, oldResponse).result
+            resumed.error shouldBe null
+            val newDecision = resumed.state.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+            newDecision.id shouldBe "r0"
+            newDecision.id shouldNotBe oldId
+            resumed.state.nextRoutingId shouldBe 1L
+            resumed.state.rng shouldBe legacyState.rng
+            resumed.state.nextEntityId shouldBe legacyState.nextEntityId
+            val stale = actionProcessor.process(resumed.state, oldResponse).result
+            stale.error.shouldNotBeNull()
+            stale.state shouldBe resumed.state
+            stale.events.shouldBeEmpty()
+            val completed = actionProcessor.process(
+                resumed.state, SubmitDecision(game.player1Id, YesNoResponse(newDecision.id, true))
+            ).result
+            completed.error shouldBe null
+            completed.state.pendingDecision shouldBe null
+            completed.state.lifeTotal(game.player1Id) shouldBe 22
+        }
+
+        test("real consecutive decisions replay with recorded responses and reject a stale response") {
+            val game = scenario().withPlayers().build()
+            val initial = game.state
+            val handler = EffectHandler(cardRegistry = cardRegistry)
+            val effect = CompositeEffect(listOf(
+                MayEffect(Effects.GainLife(1)),
+                MayEffect(Effects.GainLife(2))
+            ))
+            val context = EffectContext(sourceId = null, controllerId = game.player1Id)
+            val first = handler.execute(initial, effect, context)
+            val replayFirst = handler.execute(initial, effect, context)
+            first.error shouldBe null
+            val decision = first.state.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+            first.state shouldBe replayFirst.state
+            first.events shouldBe replayFirst.events
+            first.state.rng shouldBe initial.rng
+            first.state.nextEntityId shouldBe initial.nextEntityId
+
+            val recorded = SubmitDecision(game.player1Id, YesNoResponse(decision.id, true))
+            val recordedJson = json.encodeToString(recorded)
+            val resumed = actionProcessor.process(first.state, recorded).result
+            val restored = json.decodeFromString<GameState>(json.encodeToString(replayFirst.state))
+            val replayResumed = actionProcessor.process(
+                restored, json.decodeFromString<SubmitDecision>(recordedJson)
+            ).result
+            resumed.error shouldBe null
+            resumed.state shouldBe replayResumed.state
+            resumed.events shouldBe replayResumed.events
+            resumed.state.lifeTotal(game.player1Id) shouldBe 21
+            val nextDecision = resumed.state.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+            nextDecision.id shouldNotBe decision.id
+
+            val stale = actionProcessor.process(resumed.state, recorded).result
+            stale.error.shouldNotBeNull()
+            stale.state shouldBe resumed.state
+            stale.events.shouldBeEmpty()
+
+            val nextResponse = SubmitDecision(game.player1Id, YesNoResponse(nextDecision.id, true))
+            val completed = actionProcessor.process(resumed.state, nextResponse).result
+            val replayCompleted = actionProcessor.process(replayResumed.state, nextResponse).result
+            completed.error shouldBe null
+            completed.state.pendingDecision shouldBe null
+            completed.state.lifeTotal(game.player1Id) shouldBe 23
+            completed.state shouldBe replayCompleted.state
+            completed.events shouldBe replayCompleted.events
+        }
+
+        test("multiple delayed triggers retain distinct reproducible handles and watched references") {
+            val game = scenario().withPlayers().withCardOnBattlefield(1, "Grizzly Bears").build()
+            val source = game.findPermanent("Grizzly Bears")!!
+            val context = EffectContext(
+                sourceId = source,
+                controllerId = game.player1Id,
+                targets = listOf(ChosenTarget.Permanent(source))
+            )
+            val delayed = CreateDelayedTriggerEffect(
+                step = Step.END,
+                effect = Effects.GainLife(1),
+                watchedTarget = EffectTarget.ContextTarget(0)
+            )
+            val handler = EffectHandler(cardRegistry = cardRegistry)
+            val effect = CompositeEffect(listOf(delayed, delayed))
+            val created = handler.execute(game.state, effect, context)
+            val replay = handler.execute(game.state, effect, context)
+            created.error shouldBe null
+            created.state shouldBe replay.state
+            created.events shouldBe replay.events
+            val triggers = created.state.delayedTriggers
+            triggers.size shouldBe 2
+            triggers.map { it.id }.toSet().size shouldBe 2
+            triggers.map { it.watchedEntityId } shouldBe listOf(source, source)
+            triggers.map { it.sourceId } shouldBe listOf(source, source)
+            created.state.nextRoutingId shouldBe game.state.nextRoutingId + 2
+            created.state.nextEntityId shouldBe game.state.nextEntityId
+            created.state.rng shouldBe game.state.rng
+            json.decodeFromString<GameState>(json.encodeToString(created.state)) shouldBe created.state
+        }
+
+        test("multiple attacking bands receive distinct reproducible handles shared by their members") {
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Banding Scout")
+                .withCardOnBattlefield(1, "Banding Scout")
+                .withCardOnBattlefield(1, "Centaur Courser")
+                .withCardOnBattlefield(1, "Centaur Courser")
+                .build()
+            val scouts = game.findPermanents("Banding Scout")
+            val coursers = game.findPermanents("Centaur Courser")
+            val initial = game.state.copy(phase = Phase.COMBAT, step = Step.DECLARE_ATTACKERS)
+            val action = DeclareAttackers(
+                game.player1Id,
+                (scouts + coursers).associateWith { game.player2Id },
+                bands = listOf(setOf(scouts[0], coursers[0]), setOf(scouts[1], coursers[1]))
+            )
+            val declared = actionProcessor.process(initial, action).result
+            val replay = actionProcessor.process(initial, action).result
+            declared.error shouldBe null
+            declared.state shouldBe replay.state
+            declared.events shouldBe replay.events
+            val bandIds = scouts.map { declared.state.getEntity(it)!!.get<AttackingComponent>()!!.bandId }
+            bandIds.forEach { it.shouldNotBeNull() }
+            bandIds[0] shouldNotBe bandIds[1]
+            coursers.map { declared.state.getEntity(it)!!.get<AttackingComponent>()!!.bandId } shouldBe bandIds
+            declared.state.nextRoutingId shouldBe initial.nextRoutingId + 2
+            declared.state.rng shouldBe initial.rng
+            declared.state.nextEntityId shouldBe initial.nextEntityId
+        }
+    }
+}


### PR DESCRIPTION
Re-executing the same game state can produce a different decision ID, so a recorded `SubmitDecision` no longer addresses the reconstructed prompt. Delayed triggers and combat bands also receive fresh UUIDs, while some spell-copy prompts use wall-clock time. These tokens make equivalent executions differ even when the rules state and choices are the same.

`GameState.newRoutingId()` now allocates correlation tokens from a serialized counter. The engine carries the advanced state through decisions, continuations, delayed triggers, and combat bands, including helper paths that previously returned only a prompt. Allocation is independent of gameplay RNG and entity IDs, so creating a routing token does not consume a shuffle draw or renumber game objects. The AI's cycle digest excludes this bookkeeping counter.

Live browser responses carry a session epoch in the delivered decision ID. Successful undo rotates that epoch, so an answer retained for one Multiversal Passage cannot select the land type of another copy played after undo, even though both engine prompts use the same deterministic ID. The server validates freshness before modifying state or bookkeeping, then records the canonical engine response. Repeated delivery and reconnect preserve outstanding tokens. In-process AI keeps raw engine IDs for its response simulations and carries the originating live epoch separately through full/delta updates, thinking delays, approval gates, and callbacks. The server checks that epoch atomically before accepting a response. Fallback actions recheck it, and rejection counting plus any resulting concession share one guarded operation, so an obsolete callback cannot disrupt the replacement branch through recovery.

Equal snapshots and action sequences reproduce routing IDs and their linked references. IDs remain game-local: separate games or divergent simulation branches can reuse a token. Older snapshots default the absent counter to zero and retain existing UUID decisions; historical replay rebinding remains available. Process-global IDs for dynamically constructed abilities are a separate source of variation, so this change does not establish universal byte-identical replay.

### Verification

- `just test-class AiUndoDecisionFreshnessTest --no-daemon`: both regressions passed. A real asynchronous controller holds a three-Closet batch response across human undo and Naturalize, then releases it against a two-Closet batch with the same raw ID. The obsolete callback leaves state, replay, logs, undo, rejection bookkeeping, and broadcasts unchanged; a callback from the new generation succeeds and matches canonical engine replay. A second case forces undo between an AI failure and fallback recovery. Both fail with the live epoch guard disabled: the old callback changes the replacement state, and obsolete recovery removes its undo checkpoint.
- `just test-class UndoDecisionFreshnessTest --no-daemon`: both session regressions passed. The two-Passage reproducer failed at the previous head by accepting the stale answer; it now verifies rejection without state, replay, log, undo, or idempotency changes, fresh-response success, and exact engine replay. It also covers session isolation, failed undo, raw-ID rejection from browsers, and AI-compatible delivery.
- `just --command scripts/gradle-locked :game-server:test --no-daemon`: 538 passed; 13 existing skips (nine Docker-dependent migration cases and four opt-in benchmark/replay-fuzzer cases).
- `just test-class RoutingIdentityTest`: seven regressions cover allocation independence and exhaustion, serialization, legacy UUID response acceptance, exact repeated decision execution, stale-response rejection, delayed-trigger references, and combat-band membership.
- `just test-rules`: 13,523 engine and card-scenario tests passed.
- `just test-class StateProgressTest --tests LoopingActionAiTest`: passed.
- `just --command scripts/gradle-locked :ai:test --tests '*Test'`: 549 passed; the existing opt-in arena budget-scaling experiment remained disabled. Benchmarks were excluded.
- Source scan: no UUID or clock-based routing allocations remain in `rules-engine`; the unseeded game-initialization fallback still uses fresh entropy.

