### PR TITLE
🃏 Bre of Clan Stoutarm: declined free cast goes to hand (supersedes #2256)

### DIFF
--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/BreOfClanStoutarm.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/BreOfClanStoutarm.kt
@@ -59,6 +59,12 @@ val BreOfClanStoutarm = card("Bre of Clan Stoutarm") {
     // less than or equal to the amount of life you gained this turn.
     // Otherwise, put it into your hand.
     triggeredAbility {
+        // Every road out of the "may cast" ends in your hand — the mana value being too high, and
+        // declining the offered cast — so both branches below move the same stored card the same way.
+        val nonlandToHand = MoveCollectionEffect(
+            from = "nonland",
+            destination = CardDestination.ToZone(Zone.HAND)
+        )
         trigger = Triggers.YourEndStep
         interveningIf = Conditions.YouGainedLifeThisTurn
         effect = Effects.Composite(listOf(
@@ -82,22 +88,19 @@ val BreOfClanStoutarm = card("Bre of Clan Stoutarm") {
                 ),
                 // MV ≤ life gained: you may cast it for free *while this ability resolves* (the
                 // printed ruling — you can't wait to cast it later), so cast inline from exile
-                // rather than granting deferred may-play permission. Declining puts it into your
-                // hand, same as the MV > life-gained branch — nothing stays behind in exile.
+                // rather than granting deferred may-play permission.
                 effect = MayEffect(
                     Effects.CastFromCollectionWithoutPayingCost("nonland"),
-                    otherwise = MoveCollectionEffect(
-                        from = "nonland",
-                        destination = CardDestination.ToZone(Zone.HAND)
-                    )
+                    otherwise = nonlandToHand
                 ),
-                // Otherwise (MV > life gained), put the nonland into your hand. The "Otherwise" is
-                // tied to the mana-value comparison, not to declining the cast — cf. Solstice
-                // Revelations' distinct "if you don't cast that card this way" wording.
-                elseEffect = MoveCollectionEffect(
-                    from = "nonland",
-                    destination = CardDestination.ToZone(Zone.HAND)
-                )
+                // "Otherwise" covers every way you don't cast it — the mana value being too high,
+                // and declining the offer above. Matter Reshaper prints the same shape ("You may put
+                // that card onto the battlefield if it's a permanent card with mana value 3 or less.
+                // Otherwise, put that card into your hand.") and is ruled "If you don't put the card
+                // onto the battlefield for any reason, you put the card into your hand." Cf. Fecund
+                // Greenshell and Aid from the Cowl, both ruled the same way. Nothing is ever left
+                // stranded in exile.
+                elseEffect = nonlandToHand
             )
         ))
     }

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/BreOfClanStoutarm.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/BreOfClanStoutarm.kt
@@ -82,8 +82,15 @@ val BreOfClanStoutarm = card("Bre of Clan Stoutarm") {
                 ),
                 // MV ≤ life gained: you may cast it for free *while this ability resolves* (the
                 // printed ruling — you can't wait to cast it later), so cast inline from exile
-                // rather than granting deferred may-play permission. Declining leaves it in exile.
-                effect = MayEffect(Effects.CastFromCollectionWithoutPayingCost("nonland")),
+                // rather than granting deferred may-play permission. Declining puts it into your
+                // hand, same as the MV > life-gained branch — nothing stays behind in exile.
+                effect = MayEffect(
+                    Effects.CastFromCollectionWithoutPayingCost("nonland"),
+                    otherwise = MoveCollectionEffect(
+                        from = "nonland",
+                        destination = CardDestination.ToZone(Zone.HAND)
+                    )
+                ),
                 // Otherwise (MV > life gained), put the nonland into your hand. The "Otherwise" is
                 // tied to the mana-value comparison, not to declining the cast — cf. Solstice
                 // Revelations' distinct "if you don't cast that card this way" wording.

--- a/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BreOfClanStoutarmTest.kt
+++ b/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BreOfClanStoutarmTest.kt
@@ -287,6 +287,9 @@ class BreOfClanStoutarmTest : ScenarioTestBase() {
                 withClue("It is not left stranded in exile") {
                     namesInExile(game, 1).contains("Cheap Ogre") shouldBe false
                 }
+                withClue("The land exiled along the way stays in exile (only the nonland moves)") {
+                    namesInExile(game, 1).contains("Forest") shouldBe true
+                }
             }
         }
     }

--- a/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BreOfClanStoutarmTest.kt
+++ b/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BreOfClanStoutarmTest.kt
@@ -28,7 +28,8 @@ import io.kotest.matchers.shouldBe
  * Per the printed rulings, casting the exiled card happens *while Bre's ability is resolving*
  * (an inline "you may cast it for free" choice), not as deferred permission to cast later. When
  * the nonland's mana value exceeds the life gained, there is no cast option and the card is put
- * straight into hand.
+ * straight into hand. Declining an offered free cast also puts the card into hand — nothing is
+ * ever left stranded in exile.
  *
  * The library is seeded with a land on top of the nonland so the "exile until a nonland" walk
  * exiles more than one card — the lands stay in exile; only the nonland is ever put into hand.
@@ -258,7 +259,7 @@ class BreOfClanStoutarmTest : ScenarioTestBase() {
                 }
             }
 
-            test("mana value ≤ life gained: declining the free cast leaves it in exile (not hand)") {
+            test("mana value ≤ life gained: declining the free cast puts it into hand (not exile)") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")
                     .withCardOnBattlefield(1, "Bre of Clan Stoutarm")
@@ -275,15 +276,16 @@ class BreOfClanStoutarmTest : ScenarioTestBase() {
 
                 game.passUntilPhase(Phase.ENDING, Step.END)
                 game.resolveStack()
-                // Decline the free cast. "Otherwise" (put into hand) only applies when MV > life, so
-                // a declined castable card stays in exile rather than going to hand.
+                // Decline the free cast. Nothing is left stranded in exile — a declined card goes to
+                // hand just like the MV > life-gained branch does.
                 game.answerYesNo(false)
+                game.resolveStack()
 
-                withClue("Declined free-cast → Cheap Ogre stays in exile") {
-                    namesInExile(game, 1).contains("Cheap Ogre") shouldBe true
+                withClue("Declined free-cast → Cheap Ogre is put into hand") {
+                    namesInHand(game, 1).contains("Cheap Ogre") shouldBe true
                 }
-                withClue("It is not put into hand (the MV ≤ life branch never moves to hand)") {
-                    namesInHand(game, 1).contains("Cheap Ogre") shouldBe false
+                withClue("It is not left stranded in exile") {
+                    namesInExile(game, 1).contains("Cheap Ogre") shouldBe false
                 }
             }
         }

--- a/mtg-sets/src/test/resources/snapshots/cards/ECL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ECL.json
@@ -2214,6 +2214,14 @@
                                 "then": {
                                     "type": "CastFromCollectionWithoutPayingCost",
                                     "from": "nonland"
+                                },
+                                "otherwise": {
+                                    "type": "MoveCollection",
+                                    "from": "nonland",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Hand"
+                                    }
                                 }
                             },
                             "otherwise": {


### PR DESCRIPTION
Supersedes #2256 by @javogt — carries their commit verbatim and adds the follow-ups from review. Base is `main`; #2256 can be closed once this merges (or @javogt can cherry-pick the second commit onto their branch, either works).

## The rules call

Bre reads: *"You may cast that card without paying its mana cost if the spell's mana value is less than or equal to the amount of life you gained this turn. **Otherwise**, put it into your hand."*

We had the `Otherwise` attached only to the mana-value comparison, so a player who was *offered* the free cast and declined watched the card sit in exile forever. @javogt's read is the right one: `Otherwise` covers every way you don't cast it.

**Matter Reshaper** prints Bre's shape verbatim — a "may" with a trailing `if`-clause, then `Otherwise`:

> reveal the top card of your library. You may put that card onto the battlefield if it's a permanent card with mana value 3 or less. Otherwise, put that card into your hand.

and is ruled: **"If you don't put the card onto the battlefield for any reason, you put the card into your hand."** Two more on the same shape:

- **Fecund Greenshell** — *"If the top card of your library is a land card, you may choose to put it into your hand rather than onto the battlefield tapped."*
- **Aid from the Cowl** — *"If the revealed card is not a permanent card **or if you choose not to put it onto the battlefield**, you may put it on the bottom of your library."*

The Solstice Revelations argument in our old comment doesn't hold up. That card says "If you don't cast that card this way" precisely because it has *no* `Otherwise` — one clause has to cover both the mana-value failure and the decline. Different wording for the same behavior, not a contrast case. Same for Rashmi, Yennett and Descendants' Path.

## What the second commit adds

- **Re-bless `snapshots/cards/ECL.json`.** Adding `otherwise` to the inner `Gate.MayDecide` changes the serialized script, so `CardDefinitionSnapshotTest` fails on #2256 as it stands. Only Bre's node moves (8 lines).
- **Replace the `elseEffect` comment.** It still argued the pre-fix reading and would have led the next reader to revert this. Now cites the rulings above.
- **Hoist the shared `MoveCollectionEffect`** into `nonlandToHand` — both branches built it identically, and sharing it makes "both roads lead to hand" legible at a glance.
- **Assert the walked-past land stays exiled** in the decline scenario, so the new `otherwise` branch is shown to move only the stored `nonland` and not the whole `allRevealed` gather.

No new SDK vocabulary: `MayEffect`'s `otherwise` already existed and is documented for exactly this.

## Known gap, not addressed here

Under "for any reason", a mana-value-≤-life card that *can't* legally be cast (no legal target) should also end up in hand. `otherwise` only fires on a decline, and `FeasibilityCheck` currently offers only `ControlsPermanentMatching` / `HasCardsInZone` — no castability variant — so that card is presumably still stranded. That's `add-feature` territory; this PR strictly narrows the gap rather than widening it.

## Verification

- `just test-class BreOfClanStoutarmTest` — 6/6 green, including the new land-stays-exiled clue
- `:mtg-sets:test` (snapshot + linter + facade boundary) — green after the re-bless
- `just check-card-printing "Bre of Clan Stoutarm"` — canonical is in ECL, its earliest real printing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNSobr19162TD13iBSH7Af