### PR TITLE
Add four Ravnica transmute cards

### DIFF
--- a/backlog/sets/ravnica-city-of-guilds/cards.md
+++ b/backlog/sets/ravnica-city-of-guilds/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards
 **Release Date:** October 7, 2005
-**Implemented:** 256 / 291
+**Implemented:** 260 / 291
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 37    | 33   |
@@ -73,7 +73,7 @@
 - [x] Flow of Ideas
 - [x] Followed Footsteps
 - [x] Grayscaled Gharial
-- [ ] Grozoth
+- [x] Grozoth
 - [x] Halcyon Glaze
 - [x] Hunted Phantasm
 - [x] Induce Paranoia
@@ -106,7 +106,7 @@
 - [x] Dark Confidant
 - [x] Darkblast
 - [x] Dimir House Guard
-- [ ] Dimir Machinations
+- [x] Dimir Machinations
 - [x] Disembowel
 - [x] Empty the Catacombs
 - [x] Golgari Thug
@@ -121,13 +121,13 @@
 - [x] Mortipede
 - [x] Necromantic Thirst
 - [ ] Necroplasm
-- [ ] Netherborn Phalanx
+- [x] Netherborn Phalanx
 - [x] Nightmare Void
 - [x] Ribbons of Night
 - [x] Roofstalker Wight
 - [x] Sadistic Augermage
 - [x] Sewerdreg
-- [ ] Shred Memory
+- [x] Shred Memory
 - [ ] Sins of the Past
 - [x] Stinkweed Imp
 - [x] Strands of Undeath

--- a/backlog/sets/ravnica-city-of-guilds/progress.md
+++ b/backlog/sets/ravnica-city-of-guilds/progress.md
@@ -3,7 +3,7 @@
 Branch: `worktree-rav-completion`. Baseline: `4f09fec7e2`. Draft PR: #2236.
 
 The goal is all 291 cards, their required engine functionality, and full set verification.
-The initial source inventory was 239/291; the current inventory is **256/291**, with 35 missing.
+The initial source inventory was 239/291; the current inventory is **260/291**, with 31 missing.
 The checklist is an inventory, not proof of rules correctness. Existing generated definitions
 also need field and behavior review before completion can be claimed.
 
@@ -73,8 +73,8 @@ Assay compared 103 cards with no divergences; it declines Brownscale's full text
 
 - Finish the two remaining dredge cards: Golgari Grave-Troll (verify the reanimation counter count), and Necroplasm (source counters
   after it leaves before its end-step trigger resolves).
-- Finish the six remaining transmute cards: Clutch of the Undercity, Dimir Machinations,
-  Grozoth, Netherborn Phalanx, Perplex, Shred Memory.
+- Finish the two remaining transmute cards: Clutch of the Undercity and Perplex. Dimir
+  Machinations, Grozoth, Netherborn Phalanx, and Shred Memory shipped separately.
 - Complete the other card-specific investigations in `mechanics.md` and all unchecked cards.
 - Verify client interactions for new capabilities, and run the appropriate engine/server/client gates.
 - Run the verify-set workflow over every card, printing, and token-art mapping; include self-play.

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DimirMachinations.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DimirMachinations.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.transmute
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dimir Machinations
+ * {2}{B}
+ * Sorcery
+ * Look at the top three cards of target player's library. Exile any number of those cards, then
+ * put the rest back in any order.
+ * Transmute {1}{B}{B}
+ *
+ * The Cruel Fate shape with an unbounded split: gather the top three of the *target's* library,
+ * `chooseAnyNumberSplit` so zero through three may be exiled, exile the chosen ones, and put the
+ * remainder back on top of that same library. "In any order" is the default
+ * `CardOrder.ControllerChooses` on `toLibraryTop` — the spell's controller orders them, not the
+ * library's owner, and the ordering happens even when only one card is left (a no-op prompt the
+ * engine skips).
+ */
+val DimirMachinations = card("Dimir Machinations") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top three cards of target player's library. Exile any number of those cards, then put the rest back in any order.\n" +
+        "Transmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same mana value as this card, reveal it, put it into your hand, then shuffle. Transmute only as a sorcery.)"
+
+    spell {
+        target("target player", Targets.Player)
+        effect = Effects.Pipeline {
+            val looked = gather(
+                CardSource.TopOfLibrary(DynamicAmount.Fixed(3), Player.TargetPlayer)
+            )
+            val (exiled, rest) = chooseAnyNumberSplit(
+                from = looked,
+                prompt = "Exile any number of those cards",
+                selectedLabel = "Exile",
+                remainderLabel = "Put back on top",
+            )
+            exile(exiled)
+            toLibraryTop(rest, Player.TargetPlayer)
+        }
+    }
+
+    transmute("{1}{B}{B}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "84"
+        artist = "Greg Staples"
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/14bfd72a-78c1-4167-89bf-ea1fccccd5b1.jpg?1783943671"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Grozoth.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Grozoth.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.transmute
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Grozoth
+ * {6}{U}{U}{U}
+ * Creature — Leviathan
+ * 9/9
+ * Defender
+ * When this creature enters, you may search your library for any number of cards that have mana
+ * value 9, reveal them, put them into your hand, then shuffle.
+ * {4}: This creature loses defender until end of turn.
+ * Transmute {1}{U}{U}
+ *
+ * The search is the ordinary library pipeline with an *unbounded* selection, so it is written
+ * inline via `Effects.Pipeline` rather than `Patterns.Library.searchLibrary` (which only offers
+ * `ChooseUpTo(count)`). The consent gate wraps the whole pipeline — declining skips the shuffle
+ * too, the Goblin Matron rule — while `chooseAnyNumber` separately allows finding nothing.
+ *
+ * "Loses defender until end of turn" is [Effects.RemoveKeyword]'s default `Duration.EndOfTurn`, a
+ * layer-6 removal; activating twice in a turn is redundant rather than cumulative.
+ *
+ * Grozoth's mana value is 9 and transmute searches for a card with the *discarded card's* mana
+ * value, so both halves of this card fetch the same nine-drops — the printed joke.
+ */
+val Grozoth = card("Grozoth") {
+    manaCost = "{6}{U}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Leviathan"
+    power = 9
+    toughness = 9
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "When this creature enters, you may search your library for any number of cards that have mana value 9, reveal them, put them into your hand, then shuffle.\n" +
+        "{4}: This creature loses defender until end of turn.\n" +
+        "Transmute {1}{U}{U} ({1}{U}{U}, Discard this card: Search your library for a card with the same mana value as this card, reveal it, put it into your hand, then shuffle. Transmute only as a sorcery.)"
+
+    keywords(Keyword.DEFENDER)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            Effects.Pipeline {
+                val searchable = gather(
+                    CardSource.FromZone(Zone.LIBRARY, Player.You, GameObjectFilter.Any.manaValue(9))
+                )
+                val found = chooseAnyNumber(
+                    from = searchable,
+                    prompt = "Search your library for any number of cards with mana value 9",
+                )
+                toHand(found, revealed = true)
+                run(ShuffleLibraryEffect())
+            }
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{4}")
+        effect = Effects.RemoveKeyword(Keyword.DEFENDER, EffectTarget.Self)
+    }
+
+    transmute("{1}{U}{U}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "53"
+        artist = "Cyril Van Der Haegen"
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96d81c13-93de-4cf6-bb15-d387ed259c50.jpg?1783943685"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/NetherbornPhalanx.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/NetherbornPhalanx.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.transmute
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Netherborn Phalanx
+ * {5}{B}
+ * Creature — Horror
+ * 2/4
+ * When this creature enters, each opponent loses 1 life for each creature they control.
+ * Transmute {1}{B}{B}
+ *
+ * "Each opponent loses 1 life for each creature *they* control" is a per-player amount, not one
+ * total, so it is a [Effects.ForEachPlayer] sweep over [Player.EachOpponent] rather than a single
+ * `LoseLife` with a global count. Each iteration rebinds the controller, which makes
+ * [EffectTarget.Controller] the opponent being processed and `Player.You` inside the
+ * [DynamicAmount.Count] *that same* opponent — so a player with three creatures loses 3 while a
+ * player with none loses 0, instead of both losing the table-wide total.
+ */
+val NetherbornPhalanx = card("Netherborn Phalanx") {
+    manaCost = "{5}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror"
+    power = 2
+    toughness = 4
+    oracleText = "When this creature enters, each opponent loses 1 life for each creature they control.\n" +
+        "Transmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same mana value as this card, reveal it, put it into your hand, then shuffle. Transmute only as a sorcery.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ForEachPlayer(
+            Player.EachOpponent,
+            listOf(
+                Effects.LoseLife(
+                    DynamicAmount.Count(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Creature),
+                    EffectTarget.Controller
+                )
+            )
+        )
+    }
+
+    transmute("{1}{B}{B}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "99"
+        artist = "Christopher Rush"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b665e905-cb06-48b7-9f50-5916277e237d.jpg?1783943666"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ShredMemory.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ShredMemory.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.transmute
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Shred Memory
+ * {1}{B}
+ * Instant
+ * Exile up to four target cards from a single graveyard.
+ * Transmute {1}{B}{B}
+ *
+ * "From a single graveyard" is the cross-target [TargetObject.sameOwner] constraint (Arashin
+ * Sunshield / Qutrub Forayer shape) — every chosen card must share an owner, checked by
+ * `TargetValidator` at cast time. "Up to four" is `count = 4, optional = true`, so zero is a legal
+ * choice and the spell still resolves. The payoff is a [ForEachTargetEffect] over
+ * [EffectTarget.ContextTarget], since a multi-slot target requirement binds no single handle.
+ */
+val ShredMemory = card("Shred Memory") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Exile up to four target cards from a single graveyard.\n" +
+        "Transmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same mana value as this card, reveal it, put it into your hand, then shuffle. Transmute only as a sorcery.)"
+
+    spell {
+        target(
+            "up to four target cards from a single graveyard",
+            TargetObject(
+                count = 4,
+                optional = true,
+                filter = TargetFilter.CardInGraveyard,
+                sameOwner = true,
+            ),
+        )
+        effect = ForEachTargetEffect(
+            effects = listOf(Effects.Move(EffectTarget.ContextTarget(0), Zone.EXILE))
+        )
+    }
+
+    transmute("{1}{B}{B}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Hideaki Takamura"
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e38192e5-814f-4269-bae8-13867a73e7fa.jpg?1783943663"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DimirMachinationsScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DimirMachinationsScenarioTest.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dimir Machinations — "Look at the top three cards of target player's library. Exile any number
+ * of those cards, then put the rest back in any order."
+ *
+ * The scenario builder appends library cards top-down, so the first `withCardInLibrary` call is
+ * the top card.
+ */
+class DimirMachinationsScenarioTest : ScenarioTestBase() {
+    init {
+        test("exiles the chosen cards and returns the rest to the top") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Dimir Machinations")
+                .withLandsOnBattlefield(1, "Swamp", 3)
+                .withCardInLibrary(2, "Grizzly Bears")
+                .withCardInLibrary(2, "Hill Giant")
+                .withCardInLibrary(2, "Island")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            game.castSpellTargetingPlayer(1, "Dimir Machinations", 2).error shouldBe null
+            game.resolveStack()
+
+            val decision = game.state.pendingDecision as SelectCardsDecision
+            decision.options.size shouldBe 3
+            val bears = game.findCardsInLibrary(2, "Grizzly Bears").single()
+            val giant = game.findCardsInLibrary(2, "Hill Giant").single()
+            game.selectCards(listOf(bears, giant)).error shouldBe null
+            // Even a single returning card goes through the "in any order" prompt.
+            game.keepLibraryOrder().error shouldBe null
+            game.resolveStack()
+
+            game.isInExile(2, "Grizzly Bears") shouldBe true
+            game.isInExile(2, "Hill Giant") shouldBe true
+            // Island was the third card looked at and goes back; Forest was never touched.
+            game.state.getZone(game.player2Id, Zone.LIBRARY).size shouldBe 2
+            game.findCardsInLibrary(2, "Island").size shouldBe 1
+            game.findCardsInLibrary(2, "Forest").size shouldBe 1
+        }
+
+        test("exiling nothing puts all three back") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Dimir Machinations")
+                .withLandsOnBattlefield(1, "Swamp", 3)
+                .withCardInLibrary(2, "Grizzly Bears")
+                .withCardInLibrary(2, "Hill Giant")
+                .withCardInLibrary(2, "Island")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            game.castSpellTargetingPlayer(1, "Dimir Machinations", 2).error shouldBe null
+            game.resolveStack()
+            game.selectCards(emptyList()).error shouldBe null
+            // Three cards go back, so the controller orders them; keep them as they are.
+            game.keepLibraryOrder().error shouldBe null
+            game.resolveStack()
+
+            game.state.getZone(game.player2Id, Zone.LIBRARY).size shouldBe 3
+            game.state.getZone(game.player2Id, Zone.EXILE).size shouldBe 0
+        }
+
+        test("the caster's own library is untouched when an opponent is targeted") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Dimir Machinations")
+                .withLandsOnBattlefield(1, "Swamp", 3)
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(2, "Hill Giant")
+                .withCardInLibrary(2, "Island")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            game.castSpellTargetingPlayer(1, "Dimir Machinations", 2).error shouldBe null
+            game.resolveStack()
+
+            val decision = game.state.pendingDecision as SelectCardsDecision
+            // Only the two cards P2 actually has, never P1's.
+            decision.options.size shouldBe 2
+            game.selectCards(emptyList()).error shouldBe null
+            game.keepLibraryOrder().error shouldBe null
+            game.resolveStack()
+
+            game.state.getZone(game.player1Id, Zone.LIBRARY).size shouldBe 1
+        }
+
+        test("transmute searches for a card with mana value three") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Dimir Machinations")
+                .withCardInLibrary(1, "Dimir Machinations")
+                .withCardInLibrary(1, "Hill Giant")
+                .withLandsOnBattlefield(1, "Swamp", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            val source = game.findCardsInHand(1, "Dimir Machinations").single()
+            val ability = cardRegistry.getCard("Dimir Machinations")!!
+                .activatedAbilities.single { it.activateFromZone == Zone.HAND }
+            game.execute(ActivateAbility(game.player1Id, source, ability.id)).error shouldBe null
+            game.isInGraveyard(1, "Dimir Machinations") shouldBe true
+            game.resolveStack()
+
+            // Hill Giant's mana value is four, so only the second copy matches.
+            val match = game.findCardsInLibrary(1, "Dimir Machinations").single()
+            (game.state.pendingDecision as SelectCardsDecision).options shouldBe listOf(match)
+            game.selectCards(listOf(match)).error shouldBe null
+            game.resolveStack()
+            game.isInHand(1, "Dimir Machinations") shouldBe true
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GrozothScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GrozothScenarioTest.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.matchers.shouldBe
+
+/**
+ * Grozoth — defender, an unbounded nine-drop tutor on entry, a {4} defender shed, and transmute.
+ *
+ * Grozoth's own mana value is nine, so a second copy in the library is a legal find for both the
+ * entry trigger and for transmute.
+ */
+class GrozothScenarioTest : ScenarioTestBase() {
+    init {
+        test("the entry trigger finds any number of mana value nine cards") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Grozoth")
+                .withLandsOnBattlefield(1, "Island", 9)
+                .withCardInLibrary(1, "Grozoth")
+                .withCardInLibrary(1, "Grozoth")
+                .withCardInLibrary(1, "Hill Giant")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            game.castSpell(1, "Grozoth").error shouldBe null
+            game.resolveStack()
+
+            // "You may search" — the consent gate wraps the whole search.
+            game.answerYesNo(true).error shouldBe null
+            val decision = game.state.pendingDecision as SelectCardsDecision
+            // Hill Giant's mana value is three, so it is not offered.
+            decision.options.size shouldBe 2
+            game.selectCards(decision.options).error shouldBe null
+            game.resolveStack()
+
+            game.findCardsInHand(1, "Grozoth").size shouldBe 2
+            game.findCardsInLibrary(1, "Hill Giant").size shouldBe 1
+        }
+
+        test("finding nothing is a legal choice") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Grozoth")
+                .withLandsOnBattlefield(1, "Island", 9)
+                .withCardInLibrary(1, "Grozoth")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            game.castSpell(1, "Grozoth").error shouldBe null
+            game.resolveStack()
+            game.answerYesNo(true).error shouldBe null
+            game.selectCards(emptyList()).error shouldBe null
+            game.resolveStack()
+
+            game.findCardsInLibrary(1, "Grozoth").size shouldBe 1
+            game.handSize(1) shouldBe 0
+        }
+
+        test("declining the may skips the search entirely") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Grozoth")
+                .withLandsOnBattlefield(1, "Island", 9)
+                .withCardInLibrary(1, "Grozoth")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            game.castSpell(1, "Grozoth").error shouldBe null
+            game.resolveStack()
+            game.answerYesNo(false).error shouldBe null
+            game.resolveStack()
+
+            game.hasPendingDecision() shouldBe false
+            game.findCardsInLibrary(1, "Grozoth").size shouldBe 1
+            game.handSize(1) shouldBe 0
+            game.isOnBattlefield("Grozoth") shouldBe true
+        }
+
+        test("paying four sheds defender for the turn") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Grozoth")
+                .withLandsOnBattlefield(1, "Island", 4)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            val grozoth = game.findPermanent("Grozoth")!!
+            game.state.projectedState.hasKeyword(grozoth, Keyword.DEFENDER) shouldBe true
+
+            val ability = cardRegistry.getCard("Grozoth")!!
+                .activatedAbilities.single { it.activateFromZone != Zone.HAND }
+            game.execute(ActivateAbility(game.player1Id, grozoth, ability.id)).error shouldBe null
+            game.resolveStack()
+
+            game.state.projectedState.hasKeyword(grozoth, Keyword.DEFENDER) shouldBe false
+        }
+
+        test("transmute searches for a card with mana value nine") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Grozoth")
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInLibrary(1, "Grozoth")
+                .withLandsOnBattlefield(1, "Island", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            val source = game.findCardsInHand(1, "Grozoth").single()
+            val ability = cardRegistry.getCard("Grozoth")!!
+                .activatedAbilities.single { it.activateFromZone == Zone.HAND }
+            game.execute(ActivateAbility(game.player1Id, source, ability.id)).error shouldBe null
+            game.isInGraveyard(1, "Grozoth") shouldBe true
+            game.resolveStack()
+
+            val match = game.findCardsInLibrary(1, "Grozoth").single()
+            (game.state.pendingDecision as SelectCardsDecision).options shouldBe listOf(match)
+            game.selectCards(listOf(match)).error shouldBe null
+            game.resolveStack()
+            game.isInHand(1, "Grozoth") shouldBe true
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NetherbornPhalanxScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NetherbornPhalanxScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.matchers.shouldBe
+
+/**
+ * Netherborn Phalanx — "each opponent loses 1 life for each creature they control".
+ *
+ * The interesting claim is that the amount is read **per opponent**, from that opponent's own
+ * battlefield, rather than once from a table-wide or controller-relative count.
+ */
+class NetherbornPhalanxScenarioTest : ScenarioTestBase() {
+    init {
+        test("each opponent loses life equal to their own creature count") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Netherborn Phalanx")
+                .withLandsOnBattlefield(1, "Swamp", 6)
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withCardOnBattlefield(2, "Hill Giant")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            game.castSpell(1, "Netherborn Phalanx").error shouldBe null
+            game.resolveStack()
+
+            game.getLifeTotal(2) shouldBe 18
+            game.getLifeTotal(1) shouldBe 20
+        }
+
+        test("the controller's own creatures are not counted") {
+            // P1 fields three creatures (the Phalanx plus two others), P2 exactly one. A global or
+            // controller-relative count would drain P2 for three or four; the printed card drains
+            // for one.
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Netherborn Phalanx")
+                .withLandsOnBattlefield(1, "Swamp", 6)
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardOnBattlefield(1, "Hill Giant")
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            game.castSpell(1, "Netherborn Phalanx").error shouldBe null
+            game.resolveStack()
+
+            game.getLifeTotal(2) shouldBe 19
+            game.getLifeTotal(1) shouldBe 20
+        }
+
+        test("an opponent with no creatures loses no life") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Netherborn Phalanx")
+                .withLandsOnBattlefield(1, "Swamp", 6)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            game.castSpell(1, "Netherborn Phalanx").error shouldBe null
+            game.resolveStack()
+
+            game.getLifeTotal(2) shouldBe 20
+            game.isOnBattlefield("Netherborn Phalanx") shouldBe true
+        }
+
+        test("transmute searches for a card with mana value six") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Netherborn Phalanx")
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInLibrary(1, "Netherborn Phalanx")
+                .withLandsOnBattlefield(1, "Swamp", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            val source = game.findCardsInHand(1, "Netherborn Phalanx").single()
+            val ability = cardRegistry.getCard("Netherborn Phalanx")!!
+                .activatedAbilities.single { it.activateFromZone == Zone.HAND }
+            game.execute(ActivateAbility(game.player1Id, source, ability.id)).error shouldBe null
+            game.isInGraveyard(1, "Netherborn Phalanx") shouldBe true
+            game.resolveStack()
+
+            // Only the six-drop matches; Hill Giant's mana value is four.
+            val match = game.findCardsInLibrary(1, "Netherborn Phalanx").single()
+            (game.state.pendingDecision as SelectCardsDecision).options shouldBe listOf(match)
+            game.selectCards(listOf(match)).error shouldBe null
+            game.resolveStack()
+            game.isInHand(1, "Netherborn Phalanx") shouldBe true
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ShredMemoryScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ShredMemoryScenarioTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Shred Memory — "Exile up to four target cards from a single graveyard."
+ *
+ * Two claims worth proving: the "single graveyard" constraint really rejects a mixed set of
+ * targets, and "up to four" tolerates fewer than four (including zero).
+ */
+class ShredMemoryScenarioTest : ScenarioTestBase() {
+    init {
+        fun graveyardTargets(game: TestGame, ownerNumber: Int, names: List<String>): List<ChosenTarget> {
+            val ownerId = if (ownerNumber == 1) game.player1Id else game.player2Id
+            return names.map { name ->
+                ChosenTarget.Card(
+                    game.findCardsInGraveyard(ownerNumber, name).first(),
+                    ownerId,
+                    Zone.GRAVEYARD
+                )
+            }
+        }
+
+        test("exiles four cards from one opponent's graveyard") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Shred Memory")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .withCardInGraveyard(2, "Grizzly Bears")
+                .withCardInGraveyard(2, "Hill Giant")
+                .withCardInGraveyard(2, "Island")
+                .withCardInGraveyard(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            val spell = game.findCardsInHand(1, "Shred Memory").single()
+            val targets = graveyardTargets(
+                game, 2, listOf("Grizzly Bears", "Hill Giant", "Island", "Forest")
+            )
+            game.execute(CastSpell(game.player1Id, spell, targets)).error shouldBe null
+            game.resolveStack()
+
+            game.graveyardSize(2) shouldBe 0
+            game.isInExile(2, "Grizzly Bears") shouldBe true
+            game.isInExile(2, "Hill Giant") shouldBe true
+            game.isInExile(2, "Island") shouldBe true
+            game.isInExile(2, "Forest") shouldBe true
+        }
+
+        test("targets may not be spread across two graveyards") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Shred Memory")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .withCardInGraveyard(1, "Grizzly Bears")
+                .withCardInGraveyard(2, "Hill Giant")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            val spell = game.findCardsInHand(1, "Shred Memory").single()
+            val targets = graveyardTargets(game, 1, listOf("Grizzly Bears")) +
+                graveyardTargets(game, 2, listOf("Hill Giant"))
+            game.execute(CastSpell(game.player1Id, spell, targets)).error shouldNotBe null
+
+            game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+            game.isInGraveyard(2, "Hill Giant") shouldBe true
+        }
+
+        test("fewer than four targets is legal") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Shred Memory")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .withCardInGraveyard(2, "Grizzly Bears")
+                .withCardInGraveyard(2, "Hill Giant")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            val spell = game.findCardsInHand(1, "Shred Memory").single()
+            game.execute(
+                CastSpell(game.player1Id, spell, graveyardTargets(game, 2, listOf("Hill Giant")))
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.isInExile(2, "Hill Giant") shouldBe true
+            game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+        }
+
+        test("zero targets still resolves") {
+            val game = scenario().withPlayers("P1", "P2")
+                .withCardInHand(1, "Shred Memory")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .withCardInGraveyard(2, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+
+            val spell = game.findCardsInHand(1, "Shred Memory").single()
+            game.execute(CastSpell(game.player1Id, spell, emptyList())).error shouldBe null
+            game.resolveStack()
+
+            game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+            game.isInGraveyard(1, "Shred Memory") shouldBe true
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -3234,6 +3234,135 @@
     ]
 }
 
+// Dimir Machinations
+{
+    "name": "Dimir Machinations",
+    "manaCost": "{2}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top three cards of target player's library. Exile any number of those cards, then put the rest back in any order.\nTransmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same mana value as this card, reveal it, put it into your hand, then shuffle. Transmute only as a sorcery.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "player": "TargetPlayer"
+                    },
+                    "storeAs": "gathered0"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "gathered0",
+                    "selection": "ChooseAnyNumber",
+                    "storeSelected": "selected1",
+                    "storeRemainder": "remainder1",
+                    "prompt": "Exile any number of those cards",
+                    "selectedLabel": "Exile",
+                    "remainderLabel": "Put back on top"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "selected1",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Exile"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "remainder1",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "player": "TargetPlayer",
+                        "placement": "Top"
+                    },
+                    "order": "ControllerChooses"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}{B}"
+                            }
+                        },
+                        "CostDiscardSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "mv=3"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "activateFromZone": "Hand",
+                "descriptionOverride": "Transmute {1}{B}{B} — Discard this card to search for a card with the same mana value."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "rarity": "UNCOMMON",
+        "artist": "Greg Staples",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/14bfd72a-78c1-4167-89bf-ea1fccccd5b1.jpg?1783943671"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Dimir Signet
 {
     "name": "Dimir Signet",
@@ -6208,6 +6337,149 @@
     ]
 }
 
+// Grozoth
+{
+    "name": "Grozoth",
+    "manaCost": "{6}{U}{U}{U}",
+    "typeLine": "Creature — Leviathan",
+    "oracleText": "Defender (This creature can't attack.)\nWhen this creature enters, you may search your library for any number of cards that have mana value 9, reveal them, put them into your hand, then shuffle.\n{4}: This creature loses defender until end of turn.\nTransmute {1}{U}{U} ({1}{U}{U}, Discard this card: Search your library for a card with the same mana value as this card, reveal it, put it into your hand, then shuffle. Transmute only as a sorcery.)",
+    "creatureStats": {
+        "power": 9,
+        "toughness": 9
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "mv=9"
+                                },
+                                "storeAs": "gathered0"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "gathered0",
+                                "selection": "ChooseAnyNumber",
+                                "storeSelected": "selected1",
+                                "prompt": "Search your library for any number of cards with mana value 9"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "selected1",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
+                            },
+                            "ShuffleLibrary"
+                        ]
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
+                },
+                "effect": {
+                    "type": "RemoveKeyword",
+                    "keyword": "DEFENDER",
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}{U}"
+                            }
+                        },
+                        "CostDiscardSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "mv=9"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "activateFromZone": "Hand",
+                "descriptionOverride": "Transmute {1}{U}{U} — Discard this card to search for a card with the same mana value."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "53",
+        "rarity": "RARE",
+        "artist": "Cyril Van Der Haegen",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96d81c13-93de-4cf6-bb15-d387ed259c50.jpg?1783943685"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Guardian of Vitu-Ghazi
 {
     "name": "Guardian of Vitu-Ghazi",
@@ -8447,6 +8719,113 @@
                 "text": "The target is chosen just after any creatures dealt lethal damage at the same time that the enchanted creature dealt damage have been put into the graveyard. That might include the enchanted creature itself, if it had trample and was blocked, for example."
             }
         ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Netherborn Phalanx
+{
+    "name": "Netherborn Phalanx",
+    "manaCost": "{5}{B}",
+    "typeLine": "Creature — Horror",
+    "oracleText": "When this creature enters, each opponent loses 1 life for each creature they control.\nTransmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same mana value as this card, reveal it, put it into your hand, then shuffle. Transmute only as a sorcery.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "EachOpponent"
+                    },
+                    "body": {
+                        "type": "LoseLife",
+                        "amount": {
+                            "type": "Count",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "creature"
+                        },
+                        "target": "Controller"
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}{B}"
+                            }
+                        },
+                        "CostDiscardSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "mv=6"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "activateFromZone": "Hand",
+                "descriptionOverride": "Transmute {1}{B}{B} — Discard this card to search for a card with the same mana value."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "rarity": "UNCOMMON",
+        "artist": "Christopher Rush",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b665e905-cb06-48b7-9f50-5916277e237d.jpg?1783943666"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -11397,6 +11776,107 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Shred Memory
+{
+    "name": "Shred Memory",
+    "manaCost": "{1}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Exile up to four target cards from a single graveyard.\nTransmute {1}{B}{B} ({1}{B}{B}, Discard this card: Search your library for a card with the same mana value as this card, reveal it, put it into your hand, then shuffle. Transmute only as a sorcery.)",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "MoveToZone",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                },
+                "destination": "Exile"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 4,
+                "optional": true,
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Graveyard"
+                },
+                "id": "up to four target cards from a single graveyard",
+                "sameOwner": true
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}{B}"
+                            }
+                        },
+                        "CostDiscardSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "mv=2"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "activateFromZone": "Hand",
+                "descriptionOverride": "Transmute {1}{B}{B} — Discard this card to search for a card with the same mana value."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "artist": "Hideaki Takamura",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e38192e5-814f-4269-bae8-13867a73e7fa.jpg?1783943663"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 


### PR DESCRIPTION
Four of the six unimplemented transmute cards in Ravnica: City of Guilds. All four compose existing primitives — no new SDK vocabulary — and reuse the `transmute(cost)` helper already in the tree.

- **Netherborn Phalanx** `{5}{B}` — ETB "each opponent loses 1 life for each creature they control", as `Effects.ForEachPlayer(Player.EachOpponent, …)` wrapping a `DynamicAmount.Count`. Each iteration rebinds the controller, so the count is read from *that* opponent's battlefield rather than a table-wide total.
- **Shred Memory** `{1}{B}` — "exile up to four target cards from a single graveyard", as `TargetObject(count = 4, optional = true, sameOwner = true)` (the Arashin Sunshield / Qutrub Forayer constraint) exiled through `ForEachTargetEffect`.
- **Dimir Machinations** `{2}{B}` — the Cruel Fate shape with an unbounded split: gather the target's top three, `chooseAnyNumberSplit`, exile the chosen ones, put the rest back on top in an order the controller picks. Written as an inline `Effects.Pipeline`.
- **Grozoth** `{6}{U}{U}{U}` — defender; an entry trigger searching for *any number* of mana-value-9 cards; `{4}` to shed defender for the turn. `Patterns.Library.searchLibrary` only offers `ChooseUpTo(count)`, so the unbounded search is an inline pipeline with `chooseAnyNumber`. The `MayEffect` wraps the whole pipeline, so declining skips the shuffle too (the Goblin Matron rule). Grozoth's own mana value is 9, so transmute and the entry trigger fetch the same nine-drops.

Nothing was dropped from the batch. The two transmute cards still outstanding are Clutch of the Undercity and Perplex; `progress.md`'s remaining-work list is updated to match.

## Tests

17 scenarios across four files, one per card:

- `NetherbornPhalanxScenarioTest` — per-opponent drain, the controller's own creatures explicitly *not* counted, an opponent with zero creatures, transmute at mana value six.
- `ShredMemoryScenarioTest` — four from one graveyard, a mixed-graveyard target set rejected, fewer than four, zero targets still resolving.
- `DimirMachinationsScenarioTest` — exile two of three with the third returned, exile none, the caster's own library untouched, transmute at mana value three.
- `GrozothScenarioTest` — the unbounded find, finding nothing, declining the "may" (no search, no shuffle), the `{4}` defender shed read off projected state, transmute at mana value nine.

## Verification

- `just build` — green (3m 30s).
- `just rebless-cards` — the RAV golden gains exactly these four cards: 480 lines added, **0 removed**, no existing entry touched.
- `just check-card-printing` — all four are canonical in RAV, their earliest real printing. (Netherborn Phalanx's GK1 reprint is in an unscaffolded set, so no row is due.)
- `just assay-differential --set RAV` — 103 compared, 0 divergent. Assay declines transmute, so it does not independently verify these four; the differential is here to show none of the set's other cards moved.
- Every `image_uris.normal` re-checked HTTP 200; every mechanical field re-verified against the Scryfall RAV dump.
- Backlog: RAV 256/291 → 260/291 via `just fix-backlog`.

No new visual or UX mechanic, so no E2E test: every decision lands on an existing component (`GraveyardTargetingUI`, `LibrarySearchUI`, the reorder and yes/no prompts), each on a path an already-shipped card exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvLRhVP3UzWZrq3NWeSqWu