### PR TITLE
Add three Lorwyn clash cards

### DIFF
--- a/backlog/sets/lorwyn/cards.md
+++ b/backlog/sets/lorwyn/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 cards
 **Release Date:** October 12, 2007
-**Implemented:** 254 / 286
+**Implemented:** 257 / 286
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 49    | 43   |
@@ -54,7 +54,7 @@
 - [x] Oaken Brawler
 - [x] Oblivion Ring
 - [x] Plover Knights
-- [ ] Pollen Lullaby
+- [x] Pollen Lullaby
 - [ ] Purity
 - [x] Sentry Oak
 - [x] Shields of Velis Vel
@@ -101,7 +101,7 @@
 - [x] Pestermite
 - [x] Ponder
 - [x] Protective Bubble
-- [ ] Ringskipper
+- [x] Ringskipper
 - [ ] Scattering Stroke
 - [x] Scion of Oona
 - [x] Sentinels of Glen Elendra
@@ -169,7 +169,7 @@
 - [x] Thorntooth Witch
 - [x] Thoughtseize
 - [x] Warren Pilferers
-- [ ] Weed Strangle
+- [x] Weed Strangle
 
 ### Red
 - [x] Adder-Staff Boggart

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/PollenLullaby.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/PollenLullaby.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.SkipUntapEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pollen Lullaby
+ * {1}{W}
+ * Instant
+ *
+ * Prevent all combat damage that would be dealt this turn. Clash with an opponent. If you win,
+ * creatures that player controls don't untap during the player's next untap step.
+ *
+ * The fog resolves unconditionally and first — a lost clash still prevents the damage — so it sits
+ * ahead of [Patterns.Mechanic.clash] rather than on either of its legs.
+ *
+ * "That player" is the *clash* opponent, not a target: the card chooses nobody, and
+ * [Patterns.Mechanic.clash] writes the chosen opponent into the source's durable `OPPONENT` slot,
+ * which [Player.ChosenOpponent] reads back. Using the chosen slot rather than a fresh
+ * `Chooser.Opponent` is what keeps a multiplayer clash from freezing a player who never clashed.
+ * `affectsLands = false` because the printed clause names creatures only — the Exhaustion/Blinding
+ * Beam axis on [SkipUntapEffect], not a narrower effect.
+ */
+val PollenLullaby = card("Pollen Lullaby") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Prevent all combat damage that would be dealt this turn. Clash with an opponent. " +
+        "If you win, creatures that player controls don't untap during the player's next untap step. " +
+        "(Each clashing player reveals the top card of their library, then puts that card on their " +
+        "choice of the top or bottom. A player wins if their card had a greater mana value.)"
+
+    spell {
+        effect = Effects.PreventAllCombatDamage()
+            .then(
+                Patterns.Mechanic.clash(
+                    SkipUntapEffect(
+                        target = EffectTarget.PlayerRef(Player.ChosenOpponent),
+                        affectsCreatures = true,
+                        affectsLands = false
+                    )
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "36"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/deb2156a-8a77-4954-b557-1bdaf3ba171a.jpg?1783942910"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Ringskipper.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Ringskipper.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ringskipper
+ * {1}{U}
+ * Creature — Faerie Wizard
+ * 1/1
+ *
+ * Flying
+ * When this creature dies, clash with an opponent. If you win, return this card to its owner's hand.
+ *
+ * The clash is unconditional and the *return* is the win rider, so the whole ability is
+ * [Patterns.Mechanic.clash] with the return on the `ifYouWin` leg — a lost clash still resolved the
+ * clash itself, which matters for "whenever you clash" watchers on either side of the table.
+ *
+ * By the time the dies trigger resolves the source is already in its owner's graveyard, so
+ * [EffectTarget.Self] picks it up there (Angelic Destiny's shape). The move is
+ * [Effects.ReturnToHandFromGraveyard] rather than a plain return because the printed ruling calls
+ * the guard out explicitly — "if Ringskipper is removed from the graveyard before the ability
+ * resolves, you still clash, but nothing will happen if you win" — and that `fromZone = GRAVEYARD`
+ * guard is the only thing that re-examines the card at resolution, since the clause names no target.
+ */
+val Ringskipper = card("Ringskipper") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "When this creature dies, clash with an opponent. If you win, return this card to its " +
+        "owner's hand. (Each clashing player reveals the top card of their library, then puts that " +
+        "card on their choice of the top or bottom. A player wins if their card had a greater mana value.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Patterns.Mechanic.clash(
+            Effects.ReturnToHandFromGraveyard(EffectTarget.Self)
+        )
+        description = "Clash with an opponent. If you win, return this card to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "81"
+        artist = "Heather Hudson"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72d3ae1f-5442-4725-a16a-502f13359a85.jpg?1783942899"
+        ruling(
+            "2007-10-01",
+            "If Ringskipper is removed from the graveyard before the ability resolves, you still " +
+                "clash, but nothing will happen if you win."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WeedStrangle.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WeedStrangle.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/** Pipeline slot holding the destroyed creature's toughness, frozen before the destruction. */
+private const val STRANGLED_TOUGHNESS = "strangledToughness"
+
+/**
+ * Weed Strangle
+ * {3}{B}{B}
+ * Sorcery
+ *
+ * Destroy target creature. Clash with an opponent. If you win, you gain life equal to that
+ * creature's toughness.
+ *
+ * The life gain reads a creature that the spell's own earlier step already destroyed, so the
+ * toughness has to be **frozen before the move**: [com.wingedsheep.sdk.scripting.values.EntityReference.Target]
+ * is deliberately `LIVE_ONLY` (a departed target reads as absent, CR 608.2b), and there is no
+ * target LKI snapshot to fall back on. [Effects.StoreNumber] evaluates
+ * [DynamicAmounts.targetToughness] once, up front, and the win rider reads it back through
+ * [DynamicAmount.VariableReference]. That also matches the printed intent — the creature's
+ * toughness as it last existed on the battlefield — and stays correct for an indestructible or
+ * regenerated target, which is still on the board but whose toughness the freeze already captured.
+ *
+ * Freezing *before* the clash rather than inside the win branch matters for a second reason: the
+ * clash pauses twice for the two top-or-bottom decisions, and the read happens on the far side of
+ * both, inside the gate's `then`. The store therefore has to survive a gated pause, which is
+ * exactly what `WeedStrangleScenarioTest` forces with two clash-legal libraries.
+ */
+val WeedStrangle = card("Weed Strangle") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature. Clash with an opponent. If you win, you gain life equal " +
+        "to that creature's toughness. (Each clashing player reveals the top card of their library, " +
+        "then puts that card on their choice of the top or bottom. A player wins if their card had " +
+        "a greater mana value.)"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.StoreNumber(STRANGLED_TOUGHNESS, DynamicAmounts.targetToughness())
+            .then(Effects.Destroy(creature))
+            .then(
+                Patterns.Mechanic.clash(
+                    Effects.GainLife(DynamicAmount.VariableReference(STRANGLED_TOUGHNESS))
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "147"
+        artist = "Jesper Ejsing"
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c1f7fb79-19a8-483a-bf91-e687f7da4e9c.jpg?1783942880"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PollenLullabyScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PollenLullabyScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.player.SkipUntapComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.PollenLullaby
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Pollen Lullaby fogs unconditionally and, on a clash win, freezes the *clash* opponent's creatures.
+ *
+ * The freeze names a player the card never targeted — it is the opponent chosen by the clash, read
+ * back through `Player.ChosenOpponent` — so these tests are the evidence for that read, and for the
+ * fog resolving whether or not the clash is won.
+ */
+class PollenLullabyScenarioTest : FunSpec({
+    val boulder = card("Lullaby Boulder") { manaCost = "{5}"; typeLine = "Artifact"; oracleText = "" }
+
+    fun driver() = GameTestDriver().apply {
+        registerCards(TestCards.all + listOf(PollenLullaby, boulder))
+        initMirrorMatch(Deck.of("Plains" to 40), startingPlayer = 0)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    /** Answer both clash top-or-bottom prompts, keeping each revealed card on top. */
+    fun GameTestDriver.resolveClashDecisions() {
+        repeat(2) {
+            val decision = pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            submitCardSelection(decision.playerId, emptyList()).error shouldBe null
+        }
+    }
+
+    for (win in listOf(true, false)) {
+        test("clash win=$win — the clash opponent's creatures are frozen only on a win") {
+            val d = driver()
+            d.putCardOnTopOfLibrary(d.player1, if (win) "Lullaby Boulder" else "Plains")
+            d.putCardOnTopOfLibrary(d.player2, if (win) "Plains" else "Lullaby Boulder")
+
+            val spell = d.putCardInHand(d.player1, "Pollen Lullaby")
+            d.giveMana(d.player1, Color.WHITE, 2)
+            d.castSpell(d.player1, spell, emptyList()).error shouldBe null
+            d.bothPass().error shouldBe null
+            d.resolveClashDecisions()
+            d.pendingDecision shouldBe null
+
+            val marker = d.state.getEntity(d.player2)?.get<SkipUntapComponent>()
+            if (win) {
+                // The freeze lands on the clash opponent, whom nothing targeted, and it is the
+                // creatures-only axis — the printed clause never mentions lands.
+                marker?.affectsCreatures shouldBe true
+                marker?.affectsLands shouldBe false
+            } else {
+                marker.shouldBeNull()
+            }
+            // Either way the caster is untouched — "that player" is the opponent, not both.
+            d.state.getEntity(d.player1)?.get<SkipUntapComponent>().shouldBeNull()
+        }
+    }
+
+    test("the fog resolves even when the clash is lost") {
+        val d = driver()
+        val attacker = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        d.removeSummoningSickness(attacker)
+        d.putCardOnTopOfLibrary(d.player1, "Plains")
+        d.putCardOnTopOfLibrary(d.player2, "Lullaby Boulder")
+
+        val spell = d.putCardInHand(d.player1, "Pollen Lullaby")
+        d.giveMana(d.player1, Color.WHITE, 2)
+        d.castSpell(d.player1, spell, emptyList()).error shouldBe null
+        d.bothPass().error shouldBe null
+        d.resolveClashDecisions()
+        d.pendingDecision shouldBe null
+
+        val startingLife = d.getLifeTotal(d.player2)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(d.player1, listOf(attacker), d.player2).error shouldBe null
+        d.passPriorityUntil(Step.END_COMBAT)
+
+        d.getLifeTotal(d.player2) shouldBe startingLife
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RingskipperScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RingskipperScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.Ringskipper
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Ringskipper's dies trigger clashes and, on a win, returns *itself* from the graveyard.
+ *
+ * What these prove that the snapshot net can't: the ability resolves after its own source has left
+ * the battlefield, so `EffectTarget.Self` has to find the card in the graveyard — across the clash's
+ * two top-or-bottom pauses — and the `fromZone = GRAVEYARD` guard has to hold when the card has
+ * moved on, which is exactly the printed ruling.
+ */
+class RingskipperScenarioTest : FunSpec({
+    val boulder = card("Skipper Boulder") { manaCost = "{5}"; typeLine = "Artifact"; oracleText = "" }
+
+    fun driver() = GameTestDriver().apply {
+        registerCards(TestCards.all + listOf(Ringskipper, boulder))
+        initMirrorMatch(Deck.of("Island" to 40), startingPlayer = 0)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    /** Answer both clash top-or-bottom prompts, keeping each revealed card on top. */
+    fun GameTestDriver.resolveClashDecisions() {
+        repeat(2) {
+            val decision = pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            submitCardSelection(decision.playerId, emptyList()).error shouldBe null
+        }
+    }
+
+    for (win in listOf(true, false)) {
+        test("clash win=$win — Ringskipper returns to hand only on a win") {
+            val d = driver()
+            val faerie = d.putCreatureOnBattlefield(d.player1, "Ringskipper")
+            d.putCardOnTopOfLibrary(d.player1, if (win) "Skipper Boulder" else "Island")
+            d.putCardOnTopOfLibrary(d.player2, if (win) "Island" else "Skipper Boulder")
+
+            val bolt = d.putCardInHand(d.player1, "Lightning Bolt")
+            d.giveMana(d.player1, Color.RED, 1)
+            d.castSpell(d.player1, bolt, listOf(faerie)).error shouldBe null
+            d.bothPass().error shouldBe null
+
+            // The dies trigger goes on the stack; let it resolve, then answer the clash.
+            d.bothPass().error shouldBe null
+            d.resolveClashDecisions()
+
+            d.pendingDecision shouldBe null
+            if (win) {
+                d.state.getZone(ZoneKey(d.player1, Zone.HAND)).contains(faerie) shouldBe true
+            } else {
+                d.state.getZone(ZoneKey(d.player1, Zone.GRAVEYARD)).contains(faerie) shouldBe true
+            }
+        }
+    }
+
+    test("winning the clash does nothing if the card has already left the graveyard") {
+        val d = driver()
+        val faerie = d.putCreatureOnBattlefield(d.player1, "Ringskipper")
+        d.putCardOnTopOfLibrary(d.player1, "Skipper Boulder")
+        d.putCardOnTopOfLibrary(d.player2, "Island")
+
+        val bolt = d.putCardInHand(d.player1, "Lightning Bolt")
+        val purge = d.putCardInHand(d.player1, "Coffin Purge")
+        d.giveMana(d.player1, Color.RED, 1)
+        d.giveMana(d.player1, Color.BLACK, 1)
+        d.castSpell(d.player1, bolt, listOf(faerie)).error shouldBe null
+        d.bothPass().error shouldBe null
+
+        // The dies trigger is on the stack; exile the card out of the graveyard in response.
+        d.castSpellWithTargets(
+            d.player1,
+            purge,
+            listOf(ChosenTarget.Card(faerie, d.player1, Zone.GRAVEYARD))
+        ).error shouldBe null
+        d.bothPass().error shouldBe null
+        d.state.getZone(ZoneKey(d.player1, Zone.EXILE)).contains(faerie) shouldBe true
+
+        d.bothPass().error shouldBe null
+        d.resolveClashDecisions()
+
+        d.pendingDecision shouldBe null
+        d.state.getZone(ZoneKey(d.player1, Zone.EXILE)).contains(faerie) shouldBe true
+        d.state.getZone(ZoneKey(d.player1, Zone.HAND)).contains(faerie) shouldBe false
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WeedStrangleScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WeedStrangleScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.WeedStrangle
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Weed Strangle destroys its target and then, on a clash win, gains life equal to that creature's
+ * toughness — a value the spell's own earlier step already removed from the battlefield.
+ *
+ * Two things these tests are actually here to prove, neither of which the snapshot net covers:
+ *
+ *  - The toughness is read as **projected**, not printed. Every case boosts the target with a lord
+ *    so the two numbers differ; a read of base `CardComponent` stats would gain 2 instead of 3.
+ *  - The stored number survives the clash's **pauses**. The clash prompts both players for a
+ *    top-or-bottom decision, and the life gain sits inside the gate's `then` on the far side of
+ *    both, so the store→gate propagation is exercised for real. Each player is given two clash-legal
+ *    library cards so nobody's decision is auto-answered away onto the synchronous path.
+ */
+class WeedStrangleScenarioTest : FunSpec({
+    val boulder = card("Strangle Boulder") { manaCost = "{5}"; typeLine = "Artifact"; oracleText = "" }
+
+    fun driver() = GameTestDriver().apply {
+        registerCards(TestCards.all + listOf(WeedStrangle, boulder))
+        initMirrorMatch(Deck.of("Swamp" to 40), startingPlayer = 0)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    /** Answer both clash top-or-bottom prompts, keeping each revealed card on top. */
+    fun GameTestDriver.resolveClashDecisions() {
+        repeat(2) {
+            val decision = pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            submitCardSelection(decision.playerId, emptyList()).error shouldBe null
+        }
+    }
+
+    for (win in listOf(true, false)) {
+        test("clash win=$win — the target dies either way, life is gained only on a win") {
+            val d = driver()
+            // A 2/2 under a lord: projected toughness 3, printed toughness 2.
+            d.putPermanentOnBattlefield(d.player2, "Glorious Anthem")
+            val bears = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+            d.putCardOnTopOfLibrary(d.player1, if (win) "Strangle Boulder" else "Swamp")
+            d.putCardOnTopOfLibrary(d.player2, if (win) "Swamp" else "Strangle Boulder")
+
+            val spell = d.putCardInHand(d.player1, "Weed Strangle")
+            d.giveMana(d.player1, Color.BLACK, 5)
+            val startingLife = d.getLifeTotal(d.player1)
+
+            d.castSpell(d.player1, spell, listOf(bears)).error shouldBe null
+            d.bothPass().error shouldBe null
+            d.resolveClashDecisions()
+
+            d.pendingDecision shouldBe null
+            d.state.getZone(ZoneKey(d.player2, Zone.GRAVEYARD)).contains(bears) shouldBe true
+            d.getLifeTotal(d.player1) shouldBe startingLife + (if (win) 3 else 0)
+        }
+    }
+
+    test("an indestructible target survives but still pays out its projected toughness") {
+        val d = driver()
+        d.putPermanentOnBattlefield(d.player2, "Glorious Anthem")
+        val darksteel = d.putCreatureOnBattlefield(d.player2, "Darksteel Myr")
+        d.putCardOnTopOfLibrary(d.player1, "Strangle Boulder")
+        d.putCardOnTopOfLibrary(d.player2, "Swamp")
+
+        val spell = d.putCardInHand(d.player1, "Weed Strangle")
+        d.giveMana(d.player1, Color.BLACK, 5)
+        val startingLife = d.getLifeTotal(d.player1)
+
+        d.castSpell(d.player1, spell, listOf(darksteel)).error shouldBe null
+        d.bothPass().error shouldBe null
+        d.resolveClashDecisions()
+
+        d.pendingDecision shouldBe null
+        d.state.getZone(ZoneKey(d.player2, Zone.BATTLEFIELD)).contains(darksteel) shouldBe true
+        // Darksteel Myr is 0/1 printed; the lord makes it 1/2.
+        d.getLifeTotal(d.player1) shouldBe startingLife + 2
+    }
+
+    test("an illegal target fizzles the whole spell, clash included") {
+        val d = driver()
+        val bears = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        val spell = d.putCardInHand(d.player1, "Weed Strangle")
+        val bolt = d.putCardInHand(d.player1, "Lightning Bolt")
+        d.giveMana(d.player1, Color.BLACK, 5)
+        d.giveMana(d.player1, Color.RED, 1)
+        val startingLife = d.getLifeTotal(d.player1)
+
+        d.castSpell(d.player1, spell, listOf(bears)).error shouldBe null
+        d.castSpell(d.player1, bolt, listOf(bears)).error shouldBe null
+        d.bothPass().error shouldBe null
+        d.bothPass().error shouldBe null
+
+        d.pendingDecision shouldBe null
+        d.state.getZone(ZoneKey(d.player2, Zone.GRAVEYARD)).contains(bears) shouldBe true
+        d.state.getZone(ZoneKey(d.player1, Zone.GRAVEYARD)).contains(spell) shouldBe true
+        d.getLifeTotal(d.player1) shouldBe startingLife
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/PollenLullabyReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/PollenLullabyReprint.kt
@@ -1,0 +1,16 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+val PollenLullabyReprint = Printing(
+    oracleId = "1f64d70d-ea38-4419-be91-8b68aab3401e",
+    name = "Pollen Lullaby",
+    setCode = "CMD",
+    collectorNumber = "26",
+    scryfallId = "5d033d41-2b64-4b9b-98d2-d32bb21f080f",
+    artist = "Warren Mahy",
+    imageUri = "https://cards.scryfall.io/normal/front/5/d/5d033d41-2b64-4b9b-98d2-d32bb21f080f.jpg?1783941248",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -11428,6 +11428,63 @@
     ]
 }
 
+// Pollen Lullaby
+{
+    "name": "Pollen Lullaby",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Prevent all combat damage that would be dealt this turn. Clash with an opponent. If you win, creatures that player controls don't untap during the player's next untap step. (Each clashing player reveals the top card of their library, then puts that card on their choice of the top or bottom. A player wins if their card had a greater mana value.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "PreventDamageShield",
+                    "scope": "CombatOnly"
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "ChooseOpponentForSource",
+                                    "prompt": "Choose an opponent to clash with"
+                                },
+                                "Clash"
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "clashWon"
+                        }
+                    },
+                    "then": {
+                        "type": "SkipUntap",
+                        "target": {
+                            "type": "PlayerRef",
+                            "player": "ChosenOpponent"
+                        },
+                        "affectsLands": false
+                    },
+                    "descriptionOverride": "Clash with an opponent. If you win, creatures the chosen player controls don't untap during their next untap step"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "UNCOMMON",
+        "artist": "Warren Mahy",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/deb2156a-8a77-4954-b557-1bdaf3ba171a.jpg?1783942910"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ponder
 {
     "name": "Ponder",
@@ -11991,6 +12048,75 @@
             }
         ]
     }
+}
+
+// Ringskipper
+{
+    "name": "Ringskipper",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Faerie Wizard",
+    "oracleText": "Flying\nWhen this creature dies, clash with an opponent. If you win, return this card to its owner's hand. (Each clashing player reveals the top card of their library, then puts that card on their choice of the top or bottom. A player wins if their card had a greater mana value.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "ChooseOpponentForSource",
+                                    "prompt": "Choose an opponent to clash with"
+                                },
+                                "Clash"
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "clashWon"
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Hand",
+                        "fromZone": "Graveyard"
+                    },
+                    "descriptionOverride": "Clash with an opponent. If you win, return this creature to its owner's hand"
+                },
+                "descriptionOverride": "Clash with an opponent. If you win, return this card to its owner's hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "81",
+        "artist": "Heather Hudson",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72d3ae1f-5442-4725-a16a-502f13359a85.jpg?1783942899",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "If Ringskipper is removed from the graveyard before the ability resolves, you still clash, but nothing will happen if you win."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // Rootgrapple
@@ -15777,6 +15903,84 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Weed Strangle
+{
+    "name": "Weed Strangle",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature. Clash with an opponent. If you win, you gain life equal to that creature's toughness. (Each clashing player reveals the top card of their library, then puts that card on their choice of the top or bottom. A player wins if their card had a greater mana value.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "StoreNumber",
+                    "name": "strangledToughness",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "Toughness"
+                    }
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "ChooseOpponentForSource",
+                                    "prompt": "Choose an opponent to clash with"
+                                },
+                                "Clash"
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "clashWon"
+                        }
+                    },
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "VariableReference",
+                            "variableName": "strangledToughness"
+                        }
+                    },
+                    "descriptionOverride": "Clash with an opponent. If you win, you gain the stored strangledToughness life"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "artist": "Jesper Ejsing",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c1f7fb79-19a8-483a-bf91-e687f7da4e9c.jpg?1783942880"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/SkipUntapExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/SkipUntapExecutor.kt
@@ -3,19 +3,27 @@ package com.wingedsheep.engine.handlers.effects.player
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.player.SkipUntapComponent
-import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.sdk.scripting.effects.SkipUntapEffect
 import kotlin.reflect.KClass
 
 /**
  * Executor for SkipUntapEffect.
- * "Creatures and lands target player controls don't untap during their next untap step."
+ * "Creatures and lands [that player] controls don't untap during their next untap step."
  *
- * This adds a SkipUntapComponent to the target player. When that player's
+ * This adds a SkipUntapComponent to the affected player. When that player's
  * next untap step occurs, the specified permanent types (creatures and/or lands)
  * are skipped and the component is removed.
+ *
+ * The affected player comes from the effect's own [SkipUntapEffect.target], resolved through the
+ * shared player resolver. That matters for the cards whose clause names a player it never
+ * *targeted*: Pollen Lullaby freezes the clash opponent, read back from the source's chosen-opponent
+ * slot via [com.wingedsheep.sdk.scripting.references.Player.ChosenOpponent], and there is no entry
+ * in `context.targets` to find them in. The resolver still routes the default
+ * `PlayerRef(TargetPlayer)` back to the first chosen target, so the targeted cards (Exhaustion,
+ * Mana Vapors, Blinding Beam) are unchanged.
  */
 class SkipUntapExecutor : EffectExecutor<SkipUntapEffect> {
 
@@ -26,15 +34,10 @@ class SkipUntapExecutor : EffectExecutor<SkipUntapEffect> {
         effect: SkipUntapEffect,
         context: EffectContext
     ): EffectResult {
-        // Get the target player from the context
-        val targetPlayerId = context.targets.firstOrNull()?.let { target ->
-            when (target) {
-                is ChosenTarget.Player -> target.playerId
-                else -> null
-            }
-        } ?: return EffectResult.error(state, "No valid player target for SkipUntapEffect")
+        val targetPlayerId = TargetResolutionUtils.resolvePlayerTarget(effect.target, context, state)
+            ?: return EffectResult.error(state, "No valid player target for SkipUntapEffect")
 
-        // Add the SkipUntapComponent to the target player
+        // Add the SkipUntapComponent to the affected player
         val newState = state.updateEntity(targetPlayerId) { container ->
             container.with(
                 SkipUntapComponent(


### PR DESCRIPTION
Three Lorwyn clash cards, all composing existing primitives, plus the one engine fix the third needed.

Lorwyn goes 254 / 286 → 257 / 286.

### Cards

- **Ringskipper** {1}{U} 1/1 Faerie Wizard — flying; dies → clash, and on a win return itself from the graveyard. `Triggers.Dies` over `Patterns.Mechanic.clash`, with `Effects.ReturnToHandFromGraveyard(Self)` on the win leg. The clash is unconditional, so losing still resolves it for anyone watching "whenever you clash". The `fromZone` guard is the printed ruling — the clause names no target, so nothing else re-examines the card at resolution.
- **Weed Strangle** {3}{B}{B} Sorcery — destroy, clash, gain life equal to that creature's toughness. `Effects.StoreNumber` freezes `DynamicAmounts.targetToughness` *before* the destruction; the win rider reads it back via `DynamicAmount.VariableReference`. `EntityReference.Target` is deliberately `LIVE_ONLY` (CR 608.2b) with no snapshot behind it, so reading after the move would have silently gained 0.
- **Pollen Lullaby** {1}{W} Instant — fog, clash, and on a win freeze the clash opponent's creatures. `Effects.PreventAllCombatDamage()` ahead of the clash, then `SkipUntapEffect` at `Player.ChosenOpponent` with `affectsLands = false`. Carries its CMD reprint row.

### Engine fix

`SkipUntapExecutor` declared a `target: EffectTarget` and never read it — it took `context.targets.firstOrNull()` instead. That works only for the cards that *target* a player (Exhaustion, Mana Vapors, Blinding Beam) and errors with "No valid player target" for any clause naming a player it never targeted, which is exactly Pollen Lullaby's shape. It now resolves its own field through `TargetResolutionUtils.resolvePlayerTarget`, which routes `PlayerRef(ChosenOpponent)` to the chosen-opponent slot and still routes the default `PlayerRef(TargetPlayer)` back to the first chosen target, so the targeted cards are untouched.

### Dropped from the batch

- **Entangling Trap** — "Whenever you clash, tap target creature an opponent controls. **If you won**, …". `Triggers.WheneverYouClash` exists (its KDoc names this very card), but `ClashedEvent.won` is not plumbed into `TriggerContext` and no condition reads it, so the win rider can't be expressed inside the trigger. Splitting it into two abilities would not share the target. `add-feature`. Same gap blocks **Rebellion of the Flamekin**.
- **Captivating Glance** — needs "*that player* gains control", and `GainControlEffect` has no controller axis (`GainControlByActivePlayer` is the wrong player on your own end step). A missing axis on an existing type, but still new vocabulary.

### Verification

- `just test` — green, 4m 2s, 116 tasks.
- Eleven new scenarios across three per-card files, all passing. Weed Strangle's boost every target with a lord so projected ≠ printed toughness, and give both players two clash-legal library cards so the top-or-bottom prompts actually fire — the store has to survive a *gated pause*, not just the synchronous path.
- `just rebless-cards` — 204 pure insertions in `LRW.json`, only these three cards, every prior LRW entry unchanged.
- `just check-card-printing` clean for all three, including the CMD reprint row.
- `just assay-differential --set LRW` — 108/111 agree; the 3 divergences (Boggart Sprite-Chaser, Epic Proportions, Kithkin Greatheart) are the pre-existing equivalent static folds already recorded in `progress.md`. All three new cards are declined by the grammar — clash isn't covered — so the scenario tests are the behavioural evidence.

No client change: all three reuse the existing clash decision UI and targeting flow. No manual playthrough or e2e run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYF4tXDreErFzrrbEWbmGn
