### PR TITLE
Add two Lorwyn cards: Aquitect's Will and Scattering Stroke

### DIFF
--- a/backlog/sets/lorwyn/cards.md
+++ b/backlog/sets/lorwyn/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 cards
 **Release Date:** October 12, 2007
-**Implemented:** 257 / 286
+**Implemented:** 259 / 286
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 49    | 43   |
@@ -72,7 +72,7 @@
 ### Blue
 - [x] Aethersnipe
 - [x] Amoeboid Changeling
-- [ ] Aquitect's Will
+- [x] Aquitect's Will
 - [x] Benthicore
 - [x] Broken Ambitions
 - [ ] Captivating Glance
@@ -102,7 +102,7 @@
 - [x] Ponder
 - [x] Protective Bubble
 - [x] Ringskipper
-- [ ] Scattering Stroke
+- [x] Scattering Stroke
 - [x] Scion of Oona
 - [x] Sentinels of Glen Elendra
 - [x] Shapesharer

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AquitectsWill.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AquitectsWill.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddSubtypeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Aquitect's Will
+ * {U}
+ * Kindred Sorcery — Merfolk
+ *
+ * Put a flood counter on target land. That land is an Island in addition to its other types for
+ * as long as it has a flood counter on it. If you control a Merfolk, draw a card.
+ *
+ * The Island half is a **resolution-created continuous effect with no permanent behind it** — the
+ * sorcery is in the graveyard by the time the effect matters — so it cannot use the
+ * [com.wingedsheep.sdk.scripting.AddLandTypeByCounter] static that Quicksilver Fountain and Eluge
+ * carry: that one is a global Layer 4 static borne by a battlefield permanent and stops applying
+ * when its source leaves. [Duration.WhileAffectedHasCounter] is the source-independent form of the
+ * same gate, watching the counter on the *affected* land rather than on a source, which is exactly
+ * what "for as long as it has a flood counter on it" (CR 611.2b) says. Losing the counter ends the
+ * effect for good: re-adding one does not resurrect it, matching the rule that a "for as long as"
+ * effect whose condition has become false is over rather than suspended.
+ *
+ * Layer 4 `AddSubtype("Island")` is the same modification the static path emits, so the land gains
+ * the intrinsic `{T}: Add {U}` (CR 305.6) and keeps its own land types and abilities.
+ *
+ * "If you control a Merfolk" is the bare tribal noun, so it reads *permanents* rather than
+ * creatures — Lorwyn's Kindred noncreature Merfolk (Merrow Commerce, a resolved Kindred permanent)
+ * count, and the check happens on resolution, after the counter is placed.
+ */
+val AquitectsWill = card("Aquitect's Will") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Kindred Sorcery — Merfolk"
+    oracleText = "Put a flood counter on target land. That land is an Island in addition to its " +
+        "other types for as long as it has a flood counter on it. If you control a Merfolk, draw a card."
+
+    spell {
+        val land = target("target land", Targets.Land)
+        effect = Effects.AddCounters(Counters.FLOOD, 1, land)
+            .then(
+                AddSubtypeEffect(
+                    subtype = "Island",
+                    target = land,
+                    duration = Duration.WhileAffectedHasCounter(Counters.FLOOD)
+                )
+            )
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.YouControl(GameObjectFilter.Any.withSubtype("Merfolk")),
+                    effect = Effects.DrawCards(1)
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "Jeff Easley"
+        flavorText = "There is nowhere on Lorwyn that the Merrow Lanes cannot go."
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd13d2c1-3db7-4fdc-9321-57c9d6e8c3ae.jpg?1783942906"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ScatteringStroke.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ScatteringStroke.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/** Pipeline slot holding the countered spell's mana value, frozen before the counter. */
+private const val SCATTERED_MANA_VALUE = "scatteredManaValue"
+
+/**
+ * Scattering Stroke
+ * {2}{U}{U}
+ * Instant
+ *
+ * Counter target spell. Clash with an opponent. If you win, at the beginning of your next main
+ * phase, you may add an amount of {C} equal to that spell's mana value.
+ *
+ * Three time-shifts stack up here, and each one is a place the amount can silently read zero:
+ *
+ *  1. **"That spell" is already gone.** The counter moves it to its owner's graveyard before the
+ *     clash even begins, and [com.wingedsheep.sdk.scripting.values.EntityReference.Target] is
+ *     `LIVE_ONLY` by design (CR 608.2b) with no target LKI behind it. So the mana value is frozen
+ *     up front with [Effects.StoreNumber] and read back through
+ *     [DynamicAmount.VariableReference] — the same shape Weed Strangle uses for a destroyed
+ *     creature's toughness. Mana Sculpt solves the same problem the other way, by creating its
+ *     delayed trigger *before* the counter; that isn't available here because the clash sits
+ *     between the two and decides whether the trigger exists at all.
+ *  2. **The clash pauses twice** for the two top-or-bottom decisions, so the win rider runs on the
+ *     far side of a gated pause and the stored number has to survive it.
+ *  3. **The payoff fires a phase later**, when the resolution pipeline that holds the stored number
+ *     is gone. `CreateDelayedTriggerExecutor` snapshots an
+ *     [com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect]'s amount into a literal at
+ *     creation time for exactly this reason, and it recurses through the [MayEffect] consent gate
+ *     to reach it — so the number is baked in while the pipeline can still answer.
+ *
+ * "You may" is a resolution-time consent gate on the delayed trigger, not a choice made now: the
+ * 2007-10-01 ruling says you decide as the delayed ability resolves, and it is all-or-nothing.
+ *
+ * "Your next main phase" is modelled as the controller's next precombat main phase
+ * ([Step.PRECOMBAT_MAIN] gated to [Player.You]) — the same reading Mana Sculpt uses.
+ * [DelayedTriggerTiming.CURRENT_TURN_OR_LATER] lets the current turn qualify, which is what an
+ * instant cast in your own upkeep wants.
+ */
+val ScatteringStroke = card("Scattering Stroke") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell. Clash with an opponent. If you win, at the beginning of " +
+        "your next main phase, you may add an amount of {C} equal to that spell's mana value. " +
+        "(Each clashing player reveals the top card of their library, then puts that card on their " +
+        "choice of the top or bottom. A player wins if their card had a greater mana value.)"
+
+    spell {
+        target("target spell", Targets.Spell)
+        effect = Effects.StoreNumber(SCATTERED_MANA_VALUE, DynamicAmounts.targetManaValue())
+            .then(Effects.CounterSpell())
+            .then(
+                Patterns.Mechanic.clash(
+                    CreateDelayedTriggerEffect(
+                        step = Step.PRECOMBAT_MAIN,
+                        fireOnPlayer = EffectTarget.PlayerRef(Player.You),
+                        timing = DelayedTriggerTiming.CURRENT_TURN_OR_LATER,
+                        effect = MayEffect(
+                            Effects.AddColorlessMana(DynamicAmount.VariableReference(SCATTERED_MANA_VALUE))
+                        )
+                    )
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "82"
+        artist = "Franz Vohwinkel"
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c536c1ce-a012-4d77-ab29-8574be164731.jpg?1783942899"
+        ruling(
+            "2007-10-01",
+            "You decide whether or not to add that much {C} as the delayed triggered ability " +
+                "resolves at the beginning of your next main phase. You don't decide before then."
+        )
+        ruling("2007-10-01", "You can't add just some of the mana. You either add all the mana or none of it.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AquitectsWillScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AquitectsWillScenarioTest.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.AquitectsWill
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Aquitect's Will — "Put a flood counter on target land. That land is an Island in addition to its
+ * other types for as long as it has a flood counter on it. If you control a Merfolk, draw a card."
+ *
+ * The Island half is the part worth proving. Every other card in the corpus that turns a flooded
+ * land into an Island (Quicksilver Fountain, Eluge) does it with a *global static borne by a
+ * permanent*, which stops applying when that permanent leaves. Aquitect's Will is a sorcery: by the
+ * time anyone cares it is in the graveyard, so the effect has to be a source-independent floating
+ * one gated on the counter. These tests pin the three ways that distinction shows up:
+ *
+ *  - **In addition to**, not instead of — the land keeps its printed type and mana ability, and
+ *    gains the Island's `{T}: Add {U}` (CR 305.6).
+ *  - **It outlives the sorcery and the turn** — a duration bug would make it expire in cleanup.
+ *  - **The counter is the gate** — remove it and the land stops being an Island (CR 611.2b).
+ */
+class AquitectsWillScenarioTest : FunSpec({
+
+    // Forced during spec construction rather than in the first test body: `TestCards.all` scans the
+    // whole card corpus, and paying that under a per-test timeout is what flakes a single-spec run.
+    val cards = TestCards.all + AquitectsWill
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(cards)
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    // Projected subtype casing is not normalized across the layer system, so compare lowercased.
+    fun GameTestDriver.subtypes(land: EntityId): Set<String> =
+        state.projectedState.getSubtypes(land).map { it.lowercase() }.toSet()
+
+    fun GameTestDriver.floodCounters(land: EntityId): Int =
+        state.getEntity(land)?.get<CountersComponent>()?.getCount(CounterType.FLOOD) ?: 0
+
+    /** Cast the Will at [land], resolving it. */
+    fun GameTestDriver.castWill(land: EntityId) {
+        val spell = putCardInHand(player1, "Aquitect's Will")
+        giveMana(player1, Color.BLUE, 1)
+        castSpell(player1, spell, listOf(land)).error shouldBe null
+        bothPass().error shouldBe null
+    }
+
+    test("the flooded land becomes an Island in addition to its other types") {
+        val d = driver()
+        val mountain = d.putLandOnBattlefield(d.player1, "Mountain")
+
+        d.castWill(mountain)
+
+        d.floodCounters(mountain) shouldBe 1
+        withClue("\"in addition to its other types\" — the Mountain is not replaced") {
+            d.subtypes(mountain) shouldBe setOf("mountain", "island")
+        }
+    }
+
+    test("an opponent's land is a legal target too — the card says target land, not one you control") {
+        val d = driver()
+        val theirs = d.putLandOnBattlefield(d.player2, "Forest")
+
+        d.castWill(theirs)
+
+        d.floodCounters(theirs) shouldBe 1
+        d.subtypes(theirs) shouldBe setOf("forest", "island")
+    }
+
+    test("the land stays an Island after the sorcery is in the graveyard and the turn has ended") {
+        val d = driver()
+        val mountain = d.putLandOnBattlefield(d.player1, "Mountain")
+
+        d.castWill(mountain)
+        d.assertInGraveyard(d.player1, "Aquitect's Will")
+
+        // Roll into the opponent's turn: a duration bug (EndOfTurn instead of the counter gate)
+        // would have cleanup strip the Island here.
+        d.passPriorityUntil(Step.END)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        withClue("\"for as long as it has a flood counter\" is not \"until end of turn\"") {
+            d.subtypes(mountain) shouldBe setOf("mountain", "island")
+        }
+    }
+
+    test("removing the flood counter ends the Island-ness") {
+        val d = driver()
+        val mountain = d.putLandOnBattlefield(d.player1, "Mountain")
+
+        d.castWill(mountain)
+        d.subtypes(mountain) shouldBe setOf("mountain", "island")
+
+        d.addComponent(mountain, CountersComponent(emptyMap()))
+
+        withClue("the counter is the gate, so the type change goes with it (CR 611.2b)") {
+            d.subtypes(mountain) shouldBe setOf("mountain")
+        }
+    }
+
+    test("the draw rider fires only when you control a Merfolk") {
+        for (controlsMerfolk in listOf(true, false)) {
+            val d = driver()
+            val forest = d.putLandOnBattlefield(d.player1, "Forest")
+            // The bare tribal noun reads permanents; a Merfolk creature is the ordinary case, and
+            // putting it on the *opponent's* side in the negative case proves the "you control"
+            // half rather than merely the "a Merfolk exists" half.
+            d.putCreatureOnBattlefield(
+                if (controlsMerfolk) d.player1 else d.player2,
+                "Merfolk of the Pearl Trident"
+            )
+            val handBefore = d.getHandSize(d.player1)
+
+            d.castWill(forest)
+
+            withClue("controlsMerfolk=$controlsMerfolk") {
+                // The Will itself left the hand as it was cast, so the baseline is handBefore.
+                d.getHandSize(d.player1) shouldBe handBefore + (if (controlsMerfolk) 1 else 0)
+            }
+            d.subtypes(forest) shouldBe setOf("forest", "island")
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ScatteringStrokeScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ScatteringStrokeScenarioTest.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.ScatteringStroke
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scattering Stroke — "Counter target spell. Clash with an opponent. If you win, at the beginning of
+ * your next main phase, you may add an amount of {C} equal to that spell's mana value."
+ *
+ * The mana value has to survive three separate erasures before anyone can spend it, and each one
+ * would silently pay out **zero** rather than fail loudly:
+ *
+ *  1. The counter puts "that spell" in the graveyard before the clash starts, and a target read is
+ *     `LIVE_ONLY` (CR 608.2b). Hence the up-front `Effects.StoreNumber`.
+ *  2. The clash pauses twice for the top-or-bottom decisions, so the win rider runs on the far side
+ *     of a gated pause — both players are given a clash-legal library here so those prompts are
+ *     genuinely asked rather than auto-answered onto the synchronous path.
+ *  3. The payoff fires a phase later, when the resolution pipeline is gone, so the delayed trigger
+ *     has to bake the number in at creation time.
+ *
+ * Player 2 is deliberately the Stroke's controller: "your next main phase" then lands on the *next*
+ * turn's precombat main rather than on a phase the caster is already standing in, which is the case
+ * that actually crosses a turn boundary. The countered spell costs {5}, a mana value distinct from
+ * both Scattering Stroke's own 4 and from zero, so a wrong read is visible rather than plausible.
+ */
+class ScatteringStrokeScenarioTest : FunSpec({
+
+    /** Costs {5}: a mana value distinct from Scattering Stroke's own 4 and from zero. */
+    val boulder = card("Scattering Boulder") { manaCost = "{5}"; typeLine = "Artifact"; oracleText = "" }
+
+    // Built during spec construction: `TestCards.all` scans the whole card corpus, and paying that
+    // inside the first test body puts it under the per-test timeout.
+    val cards = TestCards.all + listOf(ScatteringStroke, boulder)
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(cards)
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** Colorless mana currently floating in [player]'s pool. */
+    fun GameTestDriver.colorlessInPool(player: EntityId): Int =
+        state.getEntity(player)?.get<ManaPoolComponent>()?.colorless ?: 0
+
+    /**
+     * Player 1 casts a {5} artifact; player 2 counters it with Scattering Stroke and clashes.
+     * [win] stacks the two libraries so the Stroke's controller wins or loses the clash.
+     */
+    fun GameTestDriver.counterABoulder(win: Boolean): EntityId {
+        val boulderCard = putCardInHand(player1, "Scattering Boulder")
+        giveColorlessMana(player1, 5)
+        castSpell(player1, boulderCard).error shouldBe null
+        passPriority(player1).error shouldBe null
+
+        val stroke = putCardInHand(player2, "Scattering Stroke")
+        giveMana(player2, Color.BLUE, 4)
+        castSpellWithTargets(player2, stroke, listOf(ChosenTarget.Spell(boulderCard))).error shouldBe null
+
+        // A real card on top for each player, so both top-or-bottom prompts are actually asked.
+        // Islands are mana value 0, so whoever gets the Boulder wins.
+        putCardOnTopOfLibrary(player2, if (win) "Scattering Boulder" else "Island")
+        putCardOnTopOfLibrary(player1, if (win) "Island" else "Scattering Boulder")
+
+        bothPass().error shouldBe null
+        repeat(2) {
+            val choice = pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            submitCardSelection(choice.playerId, emptyList()).error shouldBe null
+        }
+
+        pendingDecision shouldBe null
+        withClue("the counter happens on a win and a loss alike") {
+            state.getZone(ZoneKey(player1, Zone.GRAVEYARD)).contains(boulderCard) shouldBe true
+        }
+        return boulderCard
+    }
+
+    /** Roll into player 2's next turn, stopping the moment their precombat main begins. */
+    fun GameTestDriver.advanceToStrokeControllersMainPhase() {
+        passPriorityUntil(Step.END)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+        state.activePlayerId shouldBe player2
+    }
+
+    test("winning the clash pays out the countered spell's mana value at your next main phase") {
+        val d = driver()
+        d.counterABoulder(win = true)
+
+        withClue("the payoff is a delayed trigger — nothing is added while the Stroke resolves") {
+            d.colorlessInPool(d.player2) shouldBe 0
+        }
+
+        d.advanceToStrokeControllersMainPhase()
+        d.bothPass().error shouldBe null
+
+        val consent = d.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        withClue("the delayed ability belongs to the Stroke's controller") {
+            consent.playerId shouldBe d.player2
+        }
+        d.submitYesNo(d.player2, true).error shouldBe null
+
+        withClue("{C} equal to the countered spell's mana value — 5, not the Stroke's own 4, and not 0") {
+            d.colorlessInPool(d.player2) shouldBe 5
+        }
+    }
+
+    test("declining the may adds nothing — it is all or nothing") {
+        val d = driver()
+        d.counterABoulder(win = true)
+
+        d.advanceToStrokeControllersMainPhase()
+        d.bothPass().error shouldBe null
+
+        d.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        d.submitYesNo(d.player2, false).error shouldBe null
+
+        d.colorlessInPool(d.player2) shouldBe 0
+    }
+
+    test("losing the clash counters the spell but schedules no delayed ability at all") {
+        val d = driver()
+        d.counterABoulder(win = false)
+
+        d.advanceToStrokeControllersMainPhase()
+
+        withClue("no trigger was created, so the main phase begins with an empty stack") {
+            d.state.stack.isEmpty() shouldBe true
+        }
+        d.bothPass().error shouldBe null
+        d.pendingDecision shouldBe null
+        d.colorlessInPool(d.player2) shouldBe 0
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/ScatteringStrokeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/ScatteringStrokeReprint.kt
@@ -1,0 +1,16 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+val ScatteringStrokeReprint = Printing(
+    oracleId = "314a9604-34ec-4529-bd14-7b63be28669f",
+    name = "Scattering Stroke",
+    setCode = "CMD",
+    collectorNumber = "60",
+    scryfallId = "20652385-465f-408b-adea-13a14fb05642",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/2/0/20652385-465f-408b-adea-13a14fb05642.jpg?1783941234",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -349,6 +349,79 @@
     ]
 }
 
+// Aquitect's Will
+{
+    "name": "Aquitect's Will",
+    "manaCost": "{U}",
+    "typeLine": "Kindred Sorcery — Merfolk",
+    "oracleText": "Put a flood counter on target land. That land is an Island in addition to its other types for as long as it has a flood counter on it. If you control a Merfolk, draw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "AddCounters",
+                    "counterType": "flood",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target land"
+                    }
+                },
+                {
+                    "type": "AddSubtype",
+                    "subtype": "Island",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target land"
+                    },
+                    "duration": {
+                        "type": "WhileAffectedHasCounter",
+                        "counterType": "flood"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "Merfolk"
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "land"
+                },
+                "id": "target land"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "Jeff Easley",
+        "flavorText": "There is nowhere on Lorwyn that the Merrow Lanes cannot go.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd13d2c1-3db7-4fdc-9321-57c9d6e8c3ae.jpg?1783942906"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Arbiter of Knollridge
 {
     "name": "Arbiter of Knollridge",
@@ -12294,6 +12367,100 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Scattering Stroke
+{
+    "name": "Scattering Stroke",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell. Clash with an opponent. If you win, at the beginning of your next main phase, you may add an amount of {C} equal to that spell's mana value. (Each clashing player reveals the top card of their library, then puts that card on their choice of the top or bottom. A player wins if their card had a greater mana value.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "StoreNumber",
+                    "name": "scatteredManaValue",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "ManaValue"
+                    }
+                },
+                "Counter",
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "ChooseOpponentForSource",
+                                    "prompt": "Choose an opponent to clash with"
+                                },
+                                "Clash"
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "clashWon"
+                        }
+                    },
+                    "then": {
+                        "type": "CreateDelayedTrigger",
+                        "step": "PRECOMBAT_MAIN",
+                        "effect": {
+                            "type": "Gated",
+                            "gate": "Gate.MayDecide",
+                            "then": {
+                                "type": "AddColorlessMana",
+                                "amount": {
+                                    "type": "VariableReference",
+                                    "variableName": "scatteredManaValue"
+                                }
+                            }
+                        },
+                        "fireOnPlayer": {
+                            "type": "PlayerRef",
+                            "player": "You"
+                        }
+                    },
+                    "descriptionOverride": "Clash with an opponent. If you win, create a delayed trigger at the beginning of the next Precombat Main Phase"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                },
+                "id": "target spell"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "rarity": "UNCOMMON",
+        "artist": "Franz Vohwinkel",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c536c1ce-a012-4d77-ab29-8574be164731.jpg?1783942899",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "You decide whether or not to add that much {C} as the delayed triggered ability resolves at the beginning of your next main phase. You don't decide before then."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "You can't add just some of the mana. You either add all the mana or none of it."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 


### PR DESCRIPTION
Two more Lorwyn cards, both pure composition over existing primitives. Lorwyn **257 → 259 / 286**.

### Aquitect's Will — `{U}` Kindred Sorcery — Merfolk
"Put a flood counter on target land. That land is an Island in addition to its other types for as long as it has a flood counter on it. If you control a Merfolk, draw a card."

Every other card in the corpus that floods a land into an Island (Quicksilver Fountain, Eluge) carries the global `AddLandTypeByCounter` static on a *permanent*, which stops applying the moment that permanent leaves. A sorcery has no permanent, so this is the source-independent form: `AddSubtypeEffect("Island")` under `Duration.WhileAffectedHasCounter(flood)`, which watches the counter on the *affected* land rather than on a source. It emits the same Layer 4 `AddSubtype` modification the static path does, so the land keeps its own types and gains the Island's intrinsic `{T}: Add {U}` (CR 305.6), and losing the counter ends the effect for good (CR 611.2b).

"If you control a Merfolk" is the bare tribal noun, so it reads permanents rather than creatures — Lorwyn's Kindred noncreature Merfolk count.

### Scattering Stroke — `{2}{U}{U}` Instant
"Counter target spell. Clash with an opponent. If you win, at the beginning of your next main phase, you may add an amount of {C} equal to that spell's mana value."

Composes `Patterns.Mechanic.clash` with `CreateDelayedTriggerEffect` and the may gate. The whole difficulty is that the mana value has to survive three erasures, each of which would silently pay out **zero** rather than fail loudly:

1. **The counter puts "that spell" in the graveyard before the clash begins**, and a target read is `LIVE_ONLY` (CR 608.2b) with no target LKI behind it — so `StoreNumber` freezes the mana value up front and the win rider reads it back through a `VariableReference` (Weed Strangle's shape). Mana Sculpt solves the same problem by creating its delayed trigger *before* the counter; that isn't available here, because the clash sits between the two and decides whether the trigger exists at all.
2. **The clash pauses twice** for the top-or-bottom decisions, so the win rider runs on the far side of a gated pause.
3. **The payoff fires a phase later**, when the pipeline holding the number is gone — `CreateDelayedTriggerExecutor` already snapshots an `AddColorlessMana` amount at creation time and recurses through the `MayEffect` consent gate to reach it.

"You may" is a resolution-time consent gate on the delayed ability, per the 2007-10-01 ruling that you decide as it resolves and it is all or nothing. Also adds the CMD reprint row.

### Tests

Eight scenarios, all passing.

- **Aquitect's Will (5)** — the in-addition-to reading (a flooded Mountain is `{mountain, island}`); an opponent's land as a legal target; survival past the sorcery hitting the graveyard *and* past end of turn (a duration bug would have cleanup strip it); the counter coming off; and the Merfolk-gated draw checked from both sides, with the negative case putting the Merfolk on the *opponent's* board so it proves the "you control" half rather than merely "a Merfolk exists".
- **Scattering Stroke (3)** — player 2 is deliberately the Stroke's controller so "your next main phase" actually crosses a turn boundary. The win pays out the countered spell's mana value (5, distinguishable from the Stroke's own 4 and from 0); the decline pays nothing; a lost clash still counters the spell but schedules no delayed ability at all. Both players get a clash-legal library so the two top-or-bottom prompts are genuinely asked rather than auto-answered onto the synchronous path.

### Verification

- `just test-class AquitectsWillScenarioTest` — 5/5 pass. `just test-class ScatteringStrokeScenarioTest` — 3/3 pass.
- `just build` — the only two failures were the expected `CardDefinitionSnapshotTest` LRW diff, and one unrelated `game-server` flake (see below).
- `just rebless-cards` — the LRW golden is **additions only**: 167 lines added, 0 removed, and the only entries that moved are these two cards.
- `just check-card-printing` for both — canonical in LRW (each card's earliest real printing); Scattering Stroke's CMD reprint has its row, Aquitect's Will's only other printing (DDT) isn't scaffolded.
- `just assay-differential --set LRW` — 111 compared, **108 agree**, 3 DIVERGENT, and those three are the same previously-classified equivalent static folds already recorded in `backlog/sets/lorwyn/assay-review.md` (Boggart Sprite-Chaser, Epic Proportions, Kithkin Greatheart). No new divergence; neither new card is covered by the grammar, so their scenario tests are the behavioural evidence.
- Fresh Scryfall fields re-checked field by field, and all three image URLs return HTTP 200.

**Unrelated pre-existing flake, disclosed:** the full `just build` had one `game-server` failure — `FreeForAllLobbyTest > the host picks each AI seat's deck separately` (a 15s `eventually` block that saw `auto` instead of `sets`). It touches lobby/AI-deck code that this PR does not go near, and the whole class passes in isolation (`just test-class FreeForAllLobbyTest`, 1m 11s). It looks like a timing flake under a loaded box — my run shared the machine with another Gradle slot.

### Not done

No manual playthrough or e2e run — neither card introduces a new decision component. Aquitect's Will reuses battlefield targeting; Scattering Stroke reuses spell targeting, the clash prompts, and the existing yes/no decision UI.

### Lorwyn's remaining tail

For the record, 27 of the 29 remaining Lorwyn cards are blocked on missing engine vocabulary, not effort — champion (9 cards), the reveal-or-pay `AdditionalCost` leg (5), the Incarnations' "put into a graveyard from anywhere" self-trigger (5, and `TriggerDetector` scans no hand/library/stack), clash-won inside a `WheneverYouClash` trigger (2), a filtered `AnyTarget` for Needle Drop, an X-valued loyalty cost for Chandra Nalaar, a filter-based global cast restriction for Gaddock Teeg, a controller axis on `GainControlEffect` for Captivating Glance, keyword-by-graveyard-contents for Cairn Wanderer, and a same-name-as-a-spell-cast-this-turn free cast for Twinning Glass. Each is `add-feature`. These two were the only composition-only cards left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYF4tXDreErFzrrbEWbmGn
