### PR TITLE
Add three Ravnica: City of Guilds cards

### DIFF
--- a/backlog/sets/ravnica-city-of-guilds/cards.md
+++ b/backlog/sets/ravnica-city-of-guilds/cards.md
@@ -2,14 +2,14 @@
 
 **Set Size:** 291 cards
 **Release Date:** October 7, 2005
-**Implemented:** 260 / 291
+**Implemented:** 263 / 291
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 37    | 33   |
-| Blue       | 39    | 33   |
-| Black      | 37    | 27   |
+| Blue       | 39    | 34   |
+| Black      | 37    | 35   |
 | Red        | 39    | 37   |
-| Green      | 37    | 34   |
+| Green      | 37    | 37   |
 | Multicolor | 64    | 54   |
 | Artifact   | 21    | 16   |
 | Land       | 17    | 17   |
@@ -99,7 +99,7 @@
 - [x] Zephyr Spirit
 
 ### Black
-- [ ] Blood Funnel
+- [x] Blood Funnel
 - [x] Brainspoil
 - [x] Carrion Howler
 - [x] Clinging Darkness
@@ -120,7 +120,7 @@
 - [x] Moonlight Bargain
 - [x] Mortipede
 - [x] Necromantic Thirst
-- [ ] Necroplasm
+- [x] Necroplasm
 - [x] Netherborn Phalanx
 - [x] Nightmare Void
 - [x] Ribbons of Night
@@ -193,7 +193,7 @@
 - [x] Fists of Ironwood
 - [x] Gather Courage
 - [x] Golgari Brownscale
-- [ ] Golgari Grave-Troll
+- [x] Golgari Grave-Troll
 - [x] Goliath Spider
 - [x] Greater Mossdog
 - [x] Hunted Troll

--- a/backlog/sets/ravnica-city-of-guilds/progress.md
+++ b/backlog/sets/ravnica-city-of-guilds/progress.md
@@ -71,8 +71,11 @@ Assay compared 103 cards with no divergences; it declines Brownscale's full text
 
 ## Remaining work
 
-- Finish the two remaining dredge cards: Golgari Grave-Troll (verify the reanimation counter count), and Necroplasm (source counters
-  after it leaves before its end-step trigger resolves).
+- ~~Finish the two remaining dredge cards~~ — done. Golgari Grave-Troll and Necroplasm both compose
+  existing primitives (`EntersWithDynamicCounters` over a graveyard count, `Effects.Regenerate` behind a
+  `RemoveCounterFromSelf` cost, and a `manaValueEqualsDynamic` destroy filter reading the source's counter
+  count). Blood Funnel shipped in the same unit as a `PayOrSufferEffect` punisher. Sixteen scenarios cover
+  them; Necroplasm's C16 reprint row was added. Dredge is now complete for the set.
 - Finish the two remaining transmute cards: Clutch of the Undercity and Perplex. Dimir
   Machinations, Grozoth, Netherborn Phalanx, and Shred Memory shipped separately.
 - Complete the other card-specific investigations in `mechanics.md` and all unchecked cards.

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BloodFunnel.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BloodFunnel.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.effects.CounterEffect
+import com.wingedsheep.sdk.scripting.effects.CounterTargetSource
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+
+/**
+ * Blood Funnel
+ * {1}{B}
+ * Enchantment
+ * Noncreature spells you cast cost {2} less to cast.
+ * Whenever you cast a noncreature spell, counter that spell unless you sacrifice a creature.
+ *
+ * A discount you pay for in bodies. The two halves are independent: the reduction is a plain
+ * [ModifySpellCost] on noncreature spells you cast, and the tax is the punisher shape —
+ * [PayOrSufferEffect] with a sacrifice cost and, as the *suffer* branch, a [CounterEffect] aimed
+ * at [CounterTargetSource.TriggeringEntity] (the spell that just triggered it).
+ *
+ * `PayOrSufferEffect` checks affordability before prompting, so a controller with no creature
+ * isn't offered an impossible "sacrifice?" — their spell is simply countered. Note that the
+ * trigger fires on *every* noncreature spell you cast, discounted or not: casting one with the
+ * Funnel out always demands a creature.
+ *
+ * The trigger resolves above the spell that caused it, so the sacrifice happens (and the spell
+ * dies) before that spell would resolve.
+ */
+val BloodFunnel = card("Blood Funnel") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Noncreature spells you cast cost {2} less to cast.\n" +
+        "Whenever you cast a noncreature spell, counter that spell unless you sacrifice a creature."
+
+    // "Noncreature spells you cast cost {2} less to cast."
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Noncreature),
+            modification = CostModification.ReduceGeneric(2)
+        )
+    }
+
+    // "Whenever you cast a noncreature spell, counter that spell unless you sacrifice a creature."
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = PayOrSufferEffect(
+            cost = Costs.pay.Sacrifice(GameObjectFilter.Creature),
+            suffer = CounterEffect(targetSource = CounterTargetSource.TriggeringEntity),
+            consequenceDescription = "counter that spell"
+        )
+        description = "Whenever you cast a noncreature spell, counter that spell unless you sacrifice a creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "77"
+        artist = "Thomas M. Baxa"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5f4e8084-4b9e-48e0-bf59-d45543e176f8.jpg?1783943674"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GolgariGraveTroll.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GolgariGraveTroll.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Golgari Grave-Troll
+ * {4}{G}
+ * Creature — Troll Skeleton
+ * 0/0
+ * This creature enters with a +1/+1 counter on it for each creature card in your graveyard.
+ * {1}, Remove a +1/+1 counter from this creature: Regenerate this creature.
+ * Dredge 6
+ *
+ * A 0/0 whose whole body is the graveyard it came out of. The three lines compose without new
+ * vocabulary: [EntersWithDynamicCounters] over a `Count(You, GRAVEYARD, Creature)` for the entry,
+ * the existing `RemoveCounterFromSelf` cost atom plus `Effects.Regenerate` for the shield, and
+ * [KeywordAbility.dredge] for the recursion.
+ *
+ * The counter count is taken as the Troll enters, so a Grave-Troll returned *from* the graveyard
+ * straight to the battlefield still counts itself — it hasn't left the graveyard when the
+ * as-enters replacement measures (per the 2018 ruling below).
+ *
+ * The regeneration shield is bought with the Troll's own body: each activation shrinks it by one,
+ * so damage already marked on it can turn lethal the moment a counter comes off, killing it before
+ * the activated ability it paid for ever resolves.
+ */
+val GolgariGraveTroll = card("Golgari Grave-Troll") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Troll Skeleton"
+    power = 0
+    toughness = 0
+    oracleText = "This creature enters with a +1/+1 counter on it for each creature card in your graveyard.\n" +
+        "{1}, Remove a +1/+1 counter from this creature: Regenerate this creature.\n" +
+        "Dredge 6 (If you would draw a card, you may mill six cards instead. If you do, return this card from your graveyard to your hand.)"
+
+    // "This creature enters with a +1/+1 counter on it for each creature card in your graveyard."
+    replacementEffect(
+        EntersWithDynamicCounters(
+            count = DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.Creature)
+        )
+    )
+
+    // "{1}, Remove a +1/+1 counter from this creature: Regenerate this creature."
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.RemoveCounterFromSelf(Counters.PLUS_ONE_PLUS_ONE, 1)
+        )
+        effect = Effects.Regenerate(EffectTarget.Self)
+        description = "{1}, Remove a +1/+1 counter from this creature: Regenerate this creature."
+    }
+
+    keywordAbility(KeywordAbility.dredge(6))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "167"
+        artist = "Greg Hildebrandt"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f61b50e6-2166-435d-bf48-c4a0cff9999c.jpg?1783943637"
+        ruling(
+            "2018-12-07",
+            "Because damage remains marked on a creature until it's removed as the turn ends, " +
+                "nonlethal damage dealt to Golgari Grave-Troll may become lethal if you remove +1/+1 " +
+                "counters from it during that turn. In this case, it dies before you can resolve the " +
+                "activated ability that will regenerate it."
+        )
+        ruling(
+            "2018-12-07",
+            "If you return Golgari Grave-Troll from your graveyard directly to the battlefield, " +
+                "its first ability counts itself."
+        )
+        ruling(
+            "2024-01-12",
+            "You can't attempt to use a dredge ability if you don't have enough cards in your library."
+        )
+        ruling(
+            "2024-01-12",
+            "Dredge can replace any card draw, not only the one during your draw step."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Necroplasm.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Necroplasm.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Necroplasm
+ * {1}{B}{B}
+ * Creature — Ooze
+ * 1/1
+ * At the beginning of your upkeep, put a +1/+1 counter on this creature.
+ * At the beginning of your end step, destroy each creature with mana value equal to the number of
+ * +1/+1 counters on this creature.
+ * Dredge 2
+ *
+ * A sweeper on a clock: the counter added each upkeep is also the mana value the end step sweeps,
+ * so it eats one-drops on the turn it lands, two-drops next turn, and so on up the curve.
+ *
+ * The destroy filter reads the counter count off the source at resolution
+ * (`manaValueEqualsDynamic` over an [EntityNumericProperty.CounterCount] on
+ * [EntityReference.Source]) rather than baking a number in — the whole point of the card is that
+ * the number moves. Necroplasm's own mana value is 3, so a third counter includes it in its own
+ * sweep; nothing special is needed for that, it simply matches its own filter.
+ *
+ * Dredge 2 is what makes the escalation reusable: the Ooze that swept itself away comes back for
+ * a draw and starts the count over at one.
+ */
+val Necroplasm = card("Necroplasm") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Ooze"
+    power = 1
+    toughness = 1
+    oracleText = "At the beginning of your upkeep, put a +1/+1 counter on this creature.\n" +
+        "At the beginning of your end step, destroy each creature with mana value equal to the number of +1/+1 counters on this creature.\n" +
+        "Dredge 2 (If you would draw a card, you may mill two cards instead. If you do, return this card from your graveyard to your hand.)"
+
+    // "At the beginning of your upkeep, put a +1/+1 counter on this creature."
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "At the beginning of your upkeep, put a +1/+1 counter on this creature."
+    }
+
+    // "At the beginning of your end step, destroy each creature with mana value equal to the
+    //  number of +1/+1 counters on this creature."
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.DestroyAll(
+            GameObjectFilter.Creature.manaValueEqualsDynamic(
+                DynamicAmount.EntityProperty(
+                    EntityReference.Source,
+                    EntityNumericProperty.CounterCount(CounterTypeFilter.PlusOnePlusOne)
+                )
+            )
+        )
+        description = "At the beginning of your end step, destroy each creature with mana value " +
+            "equal to the number of +1/+1 counters on this creature."
+    }
+
+    keywordAbility(KeywordAbility.dredge(2))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "98"
+        artist = "rk post"
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/372424cf-85b3-4a78-bcf2-0543b0b88c0b.jpg?1783943665"
+        ruling(
+            "2024-01-12",
+            "You can't attempt to use a dredge ability if you don't have enough cards in your library."
+        )
+        ruling(
+            "2024-01-12",
+            "Dredge can replace any card draw, not only the one during your draw step."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodFunnelScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodFunnelScenarioTest.kt
@@ -1,0 +1,163 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Blood Funnel (RAV #77) — a {2} discount on noncreature spells, paid for in creatures: every
+ * noncreature spell you cast is countered unless you sacrifice one.
+ *
+ * The discount is proved the only honest way — by casting a spell the player could not otherwise
+ * afford — and the tax is proved on all three of its branches: pay, decline, and nothing to pay
+ * with (where the punisher must not raise a pointless prompt).
+ */
+class BloodFunnelScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Blood Funnel") {
+
+            test("a noncreature spell you could not otherwise afford becomes castable") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Blood Funnel")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Inspiration") // {3}{U}
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("{3}{U} reduced by {2} is {1}{U} — two Islands cover it") {
+                    game.castSpellTargetingPlayer(1, "Inspiration", 1).error shouldBe null
+                }
+            }
+
+            test("without the Funnel the same two lands can't pay for it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Inspiration")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Inspiration", 1).error shouldNotBe null
+            }
+
+            test("sacrificing a creature lets the spell resolve") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Blood Funnel")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Inspiration")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.castSpellTargetingPlayer(1, "Inspiration", 1).error shouldBe null
+                game.resolveStack()
+
+                val decision = game.state.pendingDecision
+                decision.shouldNotBeNull()
+                decision.shouldBeInstanceOf<SelectCardsDecision>()
+                game.submitDecision(CardsSelectedResponse(decision.id, decision.options.take(1)))
+                game.resolveStack()
+
+                withClue("the Bears paid the toll and Inspiration drew its two cards") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                    // -1 for the Inspiration that left the hand, +2 for the draws
+                    game.handSize(1) shouldBe handBefore + 1
+                    game.isInGraveyard(1, "Inspiration") shouldBe true
+                }
+            }
+
+            test("declining to sacrifice counters your own spell") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Blood Funnel")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Inspiration")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Inspiration", 1).error shouldBe null
+                game.resolveStack()
+                game.state.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+                game.skipSelection()
+                game.resolveStack()
+
+                withClue("no sacrifice means the spell is countered — no draws, Bears intact") {
+                    game.findPermanent("Grizzly Bears") shouldNotBe null
+                    game.isInGraveyard(1, "Inspiration") shouldBe true
+                    game.librarySize(1) shouldBe 2
+                }
+            }
+
+            test("with no creature to sacrifice the spell is countered without a prompt") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Blood Funnel")
+                    .withCardInHand(1, "Inspiration")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Inspiration", 1).error shouldBe null
+                game.resolveStack()
+
+                withClue("an unpayable cost skips straight to the suffer branch") {
+                    game.hasPendingDecision() shouldBe false
+                    game.isInGraveyard(1, "Inspiration") shouldBe true
+                    game.librarySize(1) shouldBe 2
+                }
+            }
+
+            test("creature spells are neither discounted nor taxed") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Blood Funnel")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Centaur Courser") // {2}{G}
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("no reduction applies, so the full {2}{G} must be available") {
+                    game.castSpell(1, "Centaur Courser").error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("and the Funnel's trigger never fires on a creature spell") {
+                    game.hasPendingDecision() shouldBe false
+                    game.findPermanent("Centaur Courser") shouldNotBe null
+                    game.findPermanent("Grizzly Bears") shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GolgariGraveTrollScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GolgariGraveTrollScenarioTest.kt
@@ -1,0 +1,199 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.rav.cards.GolgariGraveTroll
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Golgari Grave-Troll (RAV #167) — a 0/0 that is only as big as the graveyard it came from, buys
+ * regeneration with its own counters, and dredges itself back.
+ *
+ * The three things worth proving are the three that could each silently no-op: the as-enters
+ * count reads *creature* cards only, the regeneration shield actually replaces a destruction (and
+ * costs a counter to raise), and dredge 6 mills its printed number rather than the default one.
+ */
+class GolgariGraveTrollScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+    private val regenerateAbility = GolgariGraveTroll.activatedAbilities.single().id
+
+    private fun plusCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Golgari Grave-Troll") {
+
+            test("enters with one +1/+1 counter per creature card in your graveyard, ignoring the rest") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Golgari Grave-Troll")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Centaur Courser")
+                    .withCardInGraveyard(1, "Votary of the Conclave")
+                    .withCardInGraveyard(1, "Murder") // an instant — must not be counted
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Golgari Grave-Troll").error shouldBe null
+                game.resolveStack()
+
+                val troll = game.findPermanent("Golgari Grave-Troll")
+                troll shouldNotBe null
+                withClue("three creature cards in the graveyard, the instant doesn't count") {
+                    plusCounters(game, troll!!) shouldBe 3
+                }
+                withClue("a 0/0 body plus three counters is a 3/3") {
+                    projector.project(game.state).getPower(troll!!) shouldBe 3
+                    projector.project(game.state).getToughness(troll) shouldBe 3
+                }
+            }
+
+            test("an empty graveyard leaves a 0/0 that dies to state-based actions") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Golgari Grave-Troll")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Golgari Grave-Troll").error shouldBe null
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("no creature cards to count means no counters, and a 0/0 can't stay") {
+                    game.findPermanent("Golgari Grave-Troll") shouldBe null
+                    game.isInGraveyard(1, "Golgari Grave-Troll") shouldBe true
+                }
+            }
+
+            test("regeneration costs a +1/+1 counter and replaces a destroy, leaving it tapped") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Golgari Grave-Troll")
+                    .withCardInHand(1, "Murder")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Centaur Courser")
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Golgari Grave-Troll").error shouldBe null
+                game.resolveStack()
+                val troll = game.findPermanent("Golgari Grave-Troll")!!
+                plusCounters(game, troll) shouldBe 2
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = troll,
+                        abilityId = regenerateAbility
+                    )
+                )
+                withClue("activation should succeed: ${activation.error}") { activation.error shouldBe null }
+                game.resolveStack()
+
+                withClue("the counter is spent paying for the shield") {
+                    plusCounters(game, troll) shouldBe 1
+                }
+
+                game.castSpell(1, "Murder", troll).error shouldBe null
+                game.resolveStack()
+
+                withClue("the shield replaces the destruction — the Troll survives, tapped") {
+                    game.findPermanent("Golgari Grave-Troll") shouldNotBe null
+                    game.state.getEntity(troll)?.has<TappedComponent>() shouldBe true
+                    plusCounters(game, troll) shouldBe 1
+                }
+            }
+
+            test("without a shield the same destroy effect kills it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Golgari Grave-Troll")
+                    .withCardInHand(1, "Murder")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Centaur Courser")
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Golgari Grave-Troll").error shouldBe null
+                game.resolveStack()
+                val troll = game.findPermanent("Golgari Grave-Troll")!!
+
+                game.castSpell(1, "Murder", troll).error shouldBe null
+                game.resolveStack()
+
+                game.findPermanent("Golgari Grave-Troll") shouldBe null
+                game.isInGraveyard(1, "Golgari Grave-Troll") shouldBe true
+            }
+
+            test("dredge 6 replaces a draw by milling six and returning the Troll") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Golgari Grave-Troll")
+                    .withCardInHand(1, "Inspiration")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                repeat(8) { builder = builder.withCardInLibrary(1, "Forest") }
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Inspiration", 1).error shouldBe null
+                game.resolveStack()
+
+                val offer = game.state.pendingDecision
+                (offer as YesNoDecision).context.sourceName shouldBe "Golgari Grave-Troll"
+                game.answerYesNo(true).error shouldBe null
+                game.resolveStack()
+
+                withClue("dredge 6 mills six and returns the Troll; the second draw still happens") {
+                    game.isInHand(1, "Golgari Grave-Troll") shouldBe true
+                    game.findCardsInGraveyard(1, "Forest").size shouldBe 6
+                    game.librarySize(1) shouldBe 1
+                }
+            }
+
+            test("dredge is not offered when the library is too small to mill six") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Golgari Grave-Troll")
+                    .withCardInHand(1, "Inspiration")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Inspiration", 1).error shouldBe null
+                game.resolveStack()
+
+                withClue("five cards can't pay a six-card mill, so the draw is never replaced") {
+                    game.isInHand(1, "Golgari Grave-Troll") shouldBe false
+                    game.isInGraveyard(1, "Golgari Grave-Troll") shouldBe true
+                    game.librarySize(1) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NecroplasmScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NecroplasmScenarioTest.kt
@@ -1,0 +1,143 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Necroplasm (RAV #98) — a self-escalating sweeper: one +1/+1 counter each upkeep, and each end
+ * step it destroys every creature whose mana value equals its current counter count.
+ *
+ * The interesting claim is that the destroy filter *reads* the counter count at resolution rather
+ * than baking a number in, so the tests pin both halves of that: with one counter it takes the
+ * one-drop and leaves the two-drop alone.
+ */
+class NecroplasmScenarioTest : ScenarioTestBase() {
+
+    private fun plusCounters(game: TestGame, id: com.wingedsheep.sdk.model.EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Necroplasm") {
+
+            test("the upkeep counter sets the mana value the end step sweeps") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Necroplasm")
+                    .withCardOnBattlefield(1, "Votary of the Conclave") // {W}, mana value 1
+                    .withCardOnBattlefield(1, "Grizzly Bears") // {1}{G}, mana value 2
+                repeat(4) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(4) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                val necroplasm = game.findPermanent("Necroplasm")!!
+
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                withClue("the upkeep trigger put exactly one counter on") {
+                    plusCounters(game, necroplasm) shouldBe 1
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("one counter destroys mana value 1 and nothing else") {
+                    game.findPermanent("Votary of the Conclave") shouldBe null
+                    game.isInGraveyard(1, "Votary of the Conclave") shouldBe true
+                    game.findPermanent("Grizzly Bears") shouldNotBe null
+                }
+                withClue("Necroplasm's own mana value is 3, so one counter never reaches it") {
+                    game.findPermanent("Necroplasm") shouldNotBe null
+                }
+            }
+
+            test("the sweep is symmetric — it takes an opponent's matching creature too") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Necroplasm")
+                    .withCardOnBattlefield(2, "Votary of the Conclave")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                repeat(4) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(4) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                game.findPermanent("Votary of the Conclave") shouldBe null
+                game.isInGraveyard(2, "Votary of the Conclave") shouldBe true
+                game.findPermanent("Grizzly Bears") shouldNotBe null
+            }
+
+            test("dredge 2 replaces a draw by milling two and returning Necroplasm") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Necroplasm")
+                    .withCardInHand(1, "Inspiration")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Inspiration", 1).error shouldBe null
+                game.resolveStack()
+
+                val offer = game.state.pendingDecision
+                (offer as YesNoDecision).context.sourceName shouldBe "Necroplasm"
+                game.answerYesNo(true).error shouldBe null
+                game.resolveStack()
+
+                withClue("dredge 2 mills two and returns the Ooze; the second draw still happens") {
+                    game.isInHand(1, "Necroplasm") shouldBe true
+                    game.findCardsInGraveyard(1, "Forest").size shouldBe 2
+                    game.librarySize(1) shouldBe 2
+                }
+            }
+
+            // CR 121.2a: each draw is a separate event, so a two-card draw offers dredge twice.
+            // Declining the first must not silently consume the second draw's offer.
+            test("declining dredge on both draws draws normally and leaves Necroplasm in the graveyard") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Necroplasm")
+                    .withCardInHand(1, "Inspiration")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Inspiration", 1).error shouldBe null
+                game.resolveStack()
+                game.answerYesNo(false).error shouldBe null
+                game.resolveStack()
+
+                withClue("the second draw gets its own offer") {
+                    (game.state.pendingDecision as YesNoDecision).context.sourceName shouldBe "Necroplasm"
+                }
+                game.answerYesNo(false).error shouldBe null
+                game.resolveStack()
+
+                withClue("both draws are ordinary draws") {
+                    game.isInGraveyard(1, "Necroplasm") shouldBe true
+                    game.findCardsInGraveyard(1, "Forest").size shouldBe 0
+                    game.librarySize(1) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/NecroplasmReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/NecroplasmReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Necroplasm reprint in C16. The canonical CardDefinition lives in
+ * Ravnica: City of Guilds (`rav`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val NecroplasmReprint = Printing(
+    oracleId = "aa1c40fb-c230-4e7f-99b1-4e2e8c39a168",
+    name = "Necroplasm",
+    setCode = "C16",
+    collectorNumber = "115",
+    scryfallId = "e01e9321-e981-4006-b3c5-bbe14c65b31e",
+    artist = "rk post",
+    imageUri = "https://cards.scryfall.io/normal/front/e/0/e01e9321-e981-4006-b3c5-bbe14c65b31e.jpg?1783937067",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -417,6 +417,68 @@
     ]
 }
 
+// Blood Funnel
+{
+    "name": "Blood Funnel",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "Noncreature spells you cast cost {2} less to cast.\nWhenever you cast a noncreature spell, counter that spell unless you sacrifice a creature.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomSacrifice",
+                            "filter": "creature"
+                        }
+                    },
+                    "suffer": {
+                        "type": "Counter",
+                        "targetSource": "CounterTargetSource.TriggeringEntity"
+                    },
+                    "consequenceDescription": "counter that spell"
+                },
+                "descriptionOverride": "Whenever you cast a noncreature spell, counter that spell unless you sacrifice a creature."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "noncreature"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "rarity": "RARE",
+        "artist": "Thomas M. Baxa",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f4e8084-4b9e-48e0-bf59-d45543e176f8.jpg?1783943674"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Bloodbond March
 {
     "name": "Bloodbond March",
@@ -5802,6 +5864,97 @@
     ]
 }
 
+// Golgari Grave-Troll
+{
+    "name": "Golgari Grave-Troll",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Troll Skeleton",
+    "oracleText": "This creature enters with a +1/+1 counter on it for each creature card in your graveyard.\n{1}, Remove a +1/+1 counter from this creature: Regenerate this creature.\nDredge 6 (If you would draw a card, you may mill six cards instead. If you do, return this card from your graveyard to your hand.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "DREDGE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Dredge",
+            "amount": 6
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "+1/+1",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                },
+                "descriptionOverride": "{1}, Remove a +1/+1 counter from this creature: Regenerate this creature."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": {
+                    "type": "Count",
+                    "player": "You",
+                    "zone": "Graveyard",
+                    "filter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "167",
+        "rarity": "RARE",
+        "artist": "Greg Hildebrandt",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f61b50e6-2166-435d-bf48-c4a0cff9999c.jpg?1783943637",
+        "rulings": [
+            {
+                "date": "2018-12-07",
+                "text": "Because damage remains marked on a creature until it's removed as the turn ends, nonlethal damage dealt to Golgari Grave-Troll may become lethal if you remove +1/+1 counters from it during that turn. In this case, it dies before you can resolve the activated ability that will regenerate it."
+            },
+            {
+                "date": "2018-12-07",
+                "text": "If you return Golgari Grave-Troll from your graveyard directly to the battlefield, its first ability counts itself."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "You can't attempt to use a dredge ability if you don't have enough cards in your library."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "Dredge can replace any card draw, not only the one during your draw step."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Golgari Guildmage
 {
     "name": "Golgari Guildmage",
@@ -8717,6 +8870,111 @@
             {
                 "date": "2005-10-01",
                 "text": "The target is chosen just after any creatures dealt lethal damage at the same time that the enchanted creature dealt damage have been put into the graveyard. That might include the enchanted creature itself, if it had trample and was blocked, for example."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Necroplasm
+{
+    "name": "Necroplasm",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Creature — Ooze",
+    "oracleText": "At the beginning of your upkeep, put a +1/+1 counter on this creature.\nAt the beginning of your end step, destroy each creature with mana value equal to the number of +1/+1 counters on this creature.\nDredge 2 (If you would draw a card, you may mill two cards instead. If you do, return this card from your graveyard to your hand.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DREDGE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Dredge",
+            "amount": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, put a +1/+1 counter on this creature."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        {
+                                            "type": "ManaValueEqualsDynamic",
+                                            "amount": {
+                                                "type": "EntityProperty",
+                                                "entity": "Source",
+                                                "numericProperty": {
+                                                    "type": "CounterCount",
+                                                    "counterType": "PlusOnePlusOne"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "destroyAll_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "destroyAll_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy"
+                        }
+                    ]
+                },
+                "descriptionOverride": "At the beginning of your end step, destroy each creature with mana value equal to the number of +1/+1 counters on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "98",
+        "rarity": "RARE",
+        "artist": "rk post",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/372424cf-85b3-4a78-bcf2-0543b0b88c0b.jpg?1783943665",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "You can't attempt to use a dredge ability if you don't have enough cards in your library."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "Dredge can replace any card draw, not only the one during your draw step."
             }
         ]
     },


### PR DESCRIPTION
Three Ravnica: City of Guilds cards, each built entirely from existing `Effects.*` / `Patterns.*` — no new SDK vocabulary. RAV goes **260 → 263 / 291**, and this closes out the set's dredge work: both cards `progress.md` listed as the remaining dredge tail are now done.

## Cards

**Golgari Grave-Troll** ({4}{G}, 0/0 Troll Skeleton, #167) — a 0/0 sized by the graveyard it came from.
- entry: `EntersWithDynamicCounters(count = Count(You, GRAVEYARD, Creature))`
- shield: `Effects.Regenerate(Self)` behind `Costs.Composite(Mana("{1}"), RemoveCounterFromSelf("+1/+1", 1))`
- recursion: `KeywordAbility.dredge(6)`

**Necroplasm** ({1}{B}{B}, 1/1 Ooze, #98) — a sweeper on a clock: a counter each upkeep, and each end step it destroys every creature whose mana value equals its counter count.
- `Triggers.YourUpkeep` → `AddCounters("+1/+1", 1, Self)`
- `Triggers.YourEndStep` → `DestroyAll(Creature.manaValueEqualsDynamic(EntityProperty(Source, CounterCount(PlusOnePlusOne))))`. The filter *reads* the count at resolution rather than baking a number in — that escalation is the card.
- `KeywordAbility.dredge(2)`, plus a `Printing` row for the C16 reprint (canonical stays in RAV, its earliest real printing)

**Blood Funnel** ({1}{B} Enchantment, #77) — a {2} discount on noncreature spells, paid for in creatures.
- `ModifySpellCost(YouCast(Noncreature), ReduceGeneric(2))`
- `Triggers.YouCastNoncreature` → `PayOrSufferEffect(cost = Sacrifice(Creature), suffer = CounterEffect(targetSource = TriggeringEntity))`. `PayOrSufferEffect` checks affordability before prompting, so a controller with no creature is never offered an impossible "sacrifice?" — the spell is simply countered.

## Tests

16 scenarios across three per-card files:

- **Grave-Troll** (6): the entry count ignores noncreature cards; an empty graveyard leaves a 0/0 that dies to SBAs; regeneration spends a counter and replaces a destroy, leaving it tapped; the unshielded control dies; dredge 6 mills its printed six; dredge is withheld when the library can't cover it.
- **Necroplasm** (4): one counter takes the one-drop, leaves the two-drop, and never reaches the mana-value-3 Ooze itself; the sweep is symmetric across players; dredge 2; declining dredge on **both** draws of a two-card draw — each draw is its own event and gets its own offer, and declining the first must not consume the second's.
- **Blood Funnel** (6): the discount proved by casting a spell two lands could not otherwise afford (against a no-Funnel control), and all three branches of the tax — pay, decline, nothing to pay with. A creature spell is neither discounted nor taxed.

## Dropped from the batch

**Dream Leash** was triaged into this unit and then dropped. Its "you can't choose an untapped permanent as this spell's target as you cast it" is a **cast-time-only** restriction — per the 2005 ruling the host may untap freely once the Aura is attached, and an Aura put onto the battlefield by another effect needn't be tapped at all. But `UnattachedAurasCheck` re-evaluates an Aura's `auraTarget` filter on every state-based-action pass (CR 303.4c / 704.5m, since #1600), so a `tapped()` filter there would destroy the Aura the moment its host untapped. Modelling it faithfully needs a cast-time-only target-restriction axis separate from the enchant filter — `add-feature` work, and its own PR.

## Verification

- `just build` — **green** (5m 24s), full run on the final tree.
- 16 scenarios pass via `just test-class` on each of the three files.
- `just check-card-printing` clean for all three; Necroplasm's missing C16 row was the one thing it caught, and it's added.
- `just assay-differential --set RAV` — 103 compared, **0 divergent**. Assay declines dredge, the dynamic destroy filter, and the punisher clause, so it does not independently verify those; where it *does* read a line it reproduced my script exactly (Grave-Troll's `{1}` + `AtomRemoveCounters` → `Regenerate(Self)`, Blood Funnel's `ModifySpellCost(YouCast(Noncreature), ReduceGeneric(2))`, Necroplasm's upkeep trigger).
- Every mechanical field and oracle line re-checked against a fresh Scryfall fetch; all four image URLs return HTTP 200.
- Snapshot re-blessed: `RAV.json` +258 lines, additions only — no existing entry moved, and no other set's golden changed.
- Backlog ticked to 263/291 (`just check-backlog` in sync). The per-colour table had drifted from the checklist it summarizes for Blue, Black and Green; corrected to match.

### Disclosure

The **first** `just build` on this tree reported three `:ai:test` failures — `FrozenBaselineTest` ("LEGACY_V0's behaviour moved"), and 120-second coroutine timeouts in `SealedDeckGeneratorTest` and `ArenaHarnessTest`. **None reproduced**: the final full build is green and `FrozenBaselineTest` passes on an explicit re-run. Nothing here can reach them anyway — that test plays a hardcoded mono-red Portal deck against a Portal-only registry — and the timeouts look like machine saturation during a 17-minute run sharing the box. Flagging it so the first-run output isn't a surprise if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvLRhVP3UzWZrq3NWeSqWu
