### PR TITLE
Add two Lorwyn cards

### DIFF
--- a/backlog/sets/lorwyn/cards.md
+++ b/backlog/sets/lorwyn/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 cards
 **Release Date:** October 12, 2007
-**Implemented:** 259 / 286
+**Implemented:** 261 / 286
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 49    | 43   |
@@ -75,7 +75,7 @@
 - [x] Aquitect's Will
 - [x] Benthicore
 - [x] Broken Ambitions
-- [ ] Captivating Glance
+- [x] Captivating Glance
 - [x] Cryptic Command
 - [x] Deeptread Merrow
 - [x] Drowner of Secrets
@@ -276,7 +276,7 @@
 ### Multicolor
 - [x] Brion Stoutarm
 - [x] Doran, the Siege Tower
-- [ ] Gaddock Teeg
+- [x] Gaddock Teeg
 - [x] Horde of Notions
 - [x] Nath of the Gilt-Leaf
 - [x] Sygg, River Guide

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/CaptivatingGlance.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/CaptivatingGlance.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.GiveControlToTargetPlayerEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Captivating Glance
+ * {2}{U}
+ * Enchantment — Aura
+ * Enchant creature
+ * At the beginning of your end step, clash with an opponent. If you win, gain control of enchanted
+ * creature. Otherwise, that player gains control of enchanted creature.
+ *
+ * The card `Patterns.Mechanic.clash`'s `otherwise` leg was written for: both branches of the printed
+ * "If you win … Otherwise …" are control changes, differing only in *who* ends up with the creature.
+ *
+ * The two halves are two existing effects, not one with a controller axis:
+ *  - the win leg is [Effects.GainControl], which always gives the ability's controller control;
+ *  - the lose leg is [GiveControlToTargetPlayerEffect], the sibling that takes an explicit
+ *    [EffectTarget] for the new controller.
+ *
+ * "That player" is the opponent you clashed with, which the clash pattern has already recorded on
+ * this Aura's `ChoiceSlot.OPPONENT` (its `ChooseOpponentForSourceEffect` prefix) — so the lose leg
+ * reads it back as [Player.ChosenOpponent] rather than re-picking. That matters even though the two
+ * are the same player in a two-player game: per the Scryfall ruling the opponent you clash with need
+ * not control the enchanted creature, and per CR 701.30b the choice is made once for the clash.
+ *
+ * Both executors strip any previous Layer.CONTROL floating effect this Aura put on the same
+ * permanent before adding their own, so the end-step trigger toggles control cleanly turn after turn
+ * rather than stacking a new effect each time. The control change is `Duration.Permanent` and is not
+ * tied to the Aura, matching the ruling that it "continues to apply even if Captivating Glance
+ * leaves the battlefield".
+ */
+val CaptivatingGlance = card("Captivating Glance") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "At the beginning of your end step, clash with an opponent. If you win, gain control of " +
+        "enchanted creature. Otherwise, that player gains control of enchanted creature. (Each " +
+        "clashing player reveals the top card of their library, then puts that card on their " +
+        "choice of the top or bottom. A player wins if their card had a greater mana value.)"
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Patterns.Mechanic.clash(
+            ifYouWin = Effects.GainControl(EffectTarget.EnchantedCreature),
+            otherwise = GiveControlToTargetPlayerEffect(
+                permanent = EffectTarget.EnchantedCreature,
+                newController = EffectTarget.PlayerRef(Player.ChosenOpponent)
+            )
+        )
+        description = "clash with an opponent. If you win, gain control of enchanted creature. " +
+            "Otherwise, that player gains control of enchanted creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "55"
+        artist = "Dan Dos Santos"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/642be353-a46a-4d14-a35a-7716fd552870.jpg?1783942904"
+        ruling(
+            "2007-10-01",
+            "The ability triggers at the end of Captivating Glance's controller's turn. \"You\" " +
+                "refers to the controller of Captivating Glance, not the controller of the " +
+                "enchanted creature."
+        )
+        ruling(
+            "2007-10-01",
+            "The opponent you clash with doesn't have to be the controller of the enchanted creature."
+        )
+        ruling(
+            "2007-10-01",
+            "If you win the clash, you gain control of the enchanted creature. If you don't win the " +
+                "clash, the other player gains control of the enchanted creature (even if that " +
+                "player didn't win the clash either)."
+        )
+        ruling("2007-10-01", "Captivating Glance's controller never changes as a result of this card.")
+        ruling(
+            "2007-10-01",
+            "Captivating Glance may cause a player to gain control of a creature they already " +
+                "control. This layers a new control effect on that creature, but doing so rarely " +
+                "has any visible effect."
+        )
+        ruling(
+            "2007-10-01",
+            "Captivating Glance's control-change effect continues to apply even if Captivating " +
+                "Glance leaves the battlefield."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/GaddockTeeg.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/GaddockTeeg.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PlayersCantCastSpells
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Gaddock Teeg
+ * {G}{W}
+ * Legendary Creature — Kithkin Advisor
+ * 2/2
+ * Noncreature spells with mana value 4 or greater can't be cast.
+ * Noncreature spells with {X} in their mana costs can't be cast.
+ *
+ * Two [PlayersCantCastSpells] statics rather than one: the printed card is two separate clauses over
+ * two unrelated properties of the cost, and the primitive's `spellFilter` is a conjunction, so a
+ * single filter could not express their union. `affected = Player.Each` is the "can't be cast"
+ * (rather than "your opponents can't cast") wording — the lock binds Teeg's controller too.
+ *
+ * Both clauses read the *printed* cost off the card being cast, which is what the two rulings ask
+ * for and what the filter predicates already do:
+ *  - `manaValueAtLeast(4)` is the card's mana value, so alternative costs, additional costs and cost
+ *    reductions don't move it (2018-12-07 ruling).
+ *  - `hasXInManaCost()` inspects the printed cost's `{X}` symbol rather than a chosen value, so it
+ *    catches an {X} spell in hand — where X is still 0 (CR 202.3b) and the first clause would miss
+ *    it. That is exactly why the card prints two clauses.
+ *
+ * Lands are unaffected: playing a land is not casting a spell.
+ */
+val GaddockTeeg = card("Gaddock Teeg") {
+    manaCost = "{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Kithkin Advisor"
+    power = 2
+    toughness = 2
+    oracleText = "Noncreature spells with mana value 4 or greater can't be cast.\n" +
+        "Noncreature spells with {X} in their mana costs can't be cast."
+
+    staticAbility {
+        ability = PlayersCantCastSpells(
+            affected = Player.Each,
+            spellFilter = GameObjectFilter.Any.notCreature().manaValueAtLeast(4)
+        )
+    }
+
+    staticAbility {
+        ability = PlayersCantCastSpells(
+            affected = Player.Each,
+            spellFilter = GameObjectFilter.Any.notCreature().hasXInManaCost()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "248"
+        artist = "Greg Staples"
+        flavorText = "So great is his wisdom and spirit that many who have met him say that they " +
+            "stood before a giant of a man and talked to the wisest of the four winds."
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/32c16e1b-f4ce-409f-928a-42c666adac9d.jpg?1783942856"
+        ruling(
+            "2018-12-07",
+            "A spell's mana value is determined only by its mana cost. Alternative costs (including " +
+                "casting a spell \"without paying its mana cost\"), additional costs, and cost " +
+                "reductions don't affect a spell's mana value."
+        )
+        ruling(
+            "2007-10-01",
+            "If one half of a split card has a mana value of 3 or less and doesn't have an {X} in " +
+                "its mana cost, Gaddock Teeg lets you cast that half."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CaptivatingGlanceScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CaptivatingGlanceScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.CaptivatingGlance
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Captivating Glance — "At the beginning of your end step, clash with an opponent. If you win, gain
+ * control of enchanted creature. Otherwise, that player gains control of enchanted creature."
+ *
+ * The card is pure composition, but two of its claims are worth proving rather than assuming: that
+ * the clash pattern's `otherwise` leg can still read the opponent the clash chose
+ * (`Player.ChosenOpponent` is written to the Aura by the clash's own prefix, *inside* the gate's
+ * action, and read back *outside* it), and that repeating the trigger toggles control instead of
+ * stacking a new Layer.CONTROL effect each turn.
+ */
+class CaptivatingGlanceScenarioTest : FunSpec({
+
+    // A five-drop, so putting it on top of a library wins the clash against a Plains.
+    val boulder = card("Glance Boulder") { manaCost = "{5}"; typeLine = "Artifact"; oracleText = "" }
+
+    fun GameTestDriver.attachAura(auraId: EntityId, hostId: EntityId) {
+        replaceState(state.updateEntity(auraId) { it.with(AttachedToComponent(hostId)) })
+    }
+
+    fun driver() = GameTestDriver().apply {
+        registerCards(TestCards.all + listOf(CaptivatingGlance, boulder))
+        initMirrorMatch(Deck.of("Plains" to 40), startingPlayer = 0)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    /** Stack the libraries so player 1 wins (or loses) the clash, then resolve both reveals. */
+    fun GameTestDriver.clashThroughEndStep(youWin: Boolean) {
+        putCardOnTopOfLibrary(player1, if (youWin) "Glance Boulder" else "Plains")
+        putCardOnTopOfLibrary(player2, if (youWin) "Plains" else "Glance Boulder")
+        passPriorityUntil(Step.END)
+        // The step trigger is on the stack but unresolved when the step first matches.
+        bothPass().error shouldBe null
+        repeat(2) {
+            val decision = pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            // Empty selection = leave the revealed card on top.
+            submitCardSelection(decision.playerId, emptyList()).error shouldBe null
+        }
+        pendingDecision shouldBe null
+    }
+
+    test("winning the clash takes control of the enchanted creature") {
+        val d = driver()
+        val creature = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        val aura = d.putPermanentOnBattlefield(d.player1, "Captivating Glance")
+        d.attachAura(aura, creature)
+
+        d.state.projectedState.getController(creature) shouldBe d.player2
+        d.clashThroughEndStep(youWin = true)
+        d.state.projectedState.getController(creature) shouldBe d.player1
+        // "Captivating Glance's controller never changes as a result of this card."
+        d.state.projectedState.getController(aura) shouldBe d.player1
+    }
+
+    test("losing the clash hands the enchanted creature to the opponent you clashed with") {
+        val d = driver()
+        // Start it under player 1's control so the losing branch is an observable change.
+        val creature = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        val aura = d.putPermanentOnBattlefield(d.player1, "Captivating Glance")
+        d.attachAura(aura, creature)
+
+        d.clashThroughEndStep(youWin = false)
+        d.state.projectedState.getController(creature) shouldBe d.player2
+    }
+
+    test("the control change survives the Aura leaving the battlefield") {
+        val d = driver()
+        val creature = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        val aura = d.putPermanentOnBattlefield(d.player1, "Captivating Glance")
+        d.attachAura(aura, creature)
+
+        d.clashThroughEndStep(youWin = true)
+        d.state.projectedState.getController(creature) shouldBe d.player1
+
+        d.moveToGraveyard(aura)
+        d.state.projectedState.getController(creature) shouldBe d.player1
+    }
+
+    test("a second clash toggles control back rather than stacking a second control effect") {
+        val d = driver()
+        // This test walks a full turn cycle, so empty both hands first — otherwise the intervening
+        // draw steps push a player over the hand limit and the cleanup discard prompt is picked up
+        // by the next clash's decision loop.
+        (d.getHand(d.player1) + d.getHand(d.player2)).forEach { d.moveToGraveyard(it) }
+
+        val creature = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        val aura = d.putPermanentOnBattlefield(d.player1, "Captivating Glance")
+        d.attachAura(aura, creature)
+
+        d.clashThroughEndStep(youWin = true)
+        d.state.projectedState.getController(creature) shouldBe d.player1
+
+        // Player 2's turn, then back around to player 1's. `passPriorityUntil` stops the instant the
+        // step matches, so the two mains need a step in between to advance rather than no-op. Player
+        // 2's own end step is quiet — the trigger is "your end step", i.e. player 1's.
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.passPriorityUntil(Step.END)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.activePlayer shouldBe d.player1
+
+        d.clashThroughEndStep(youWin = false)
+        d.state.projectedState.getController(creature) shouldBe d.player2
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GaddockTeegScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GaddockTeegScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.GaddockTeeg
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gaddock Teeg — "Noncreature spells with mana value 4 or greater can't be cast. Noncreature spells
+ * with {X} in their mana costs can't be cast."
+ *
+ * Two [com.wingedsheep.sdk.scripting.PlayersCantCastSpells] statics scoped to `Player.Each`. What
+ * the test is for is the *union* of the two clauses and the fact that the lock binds Teeg's own
+ * controller: both are easy to get silently wrong (one clause dropped, or `EachOpponent` copied in
+ * from the family's more common wording), and neither shows up in a snapshot diff.
+ *
+ * Probes are instants so that baseline castability isn't masked by sorcery timing — a
+ * sorcery-speed spell wouldn't enumerate on the opponent's turn regardless of Teeg.
+ */
+class GaddockTeegScenarioTest : FunSpec({
+
+    val bigInstant = card("Teeg Test Deluge") { manaCost = "{3}{U}"; typeLine = "Instant"; oracleText = "" }
+    val smallInstant = card("Teeg Test Ripple") { manaCost = "{2}{U}"; typeLine = "Instant"; oracleText = "" }
+    val xInstant = card("Teeg Test Surge") { manaCost = "{X}{U}"; typeLine = "Instant"; oracleText = "" }
+    val bigCreature = card("Teeg Test Colossus") {
+        manaCost = "{5}{G}"; typeLine = "Creature — Giant"; power = 6; toughness = 6
+    }
+
+    fun driver(startingPlayer: Int = 0) = GameTestDriver().apply {
+        registerCards(TestCards.all + listOf(GaddockTeeg, bigInstant, smallInstant, xInstant, bigCreature))
+        initMirrorMatch(Deck.of("Forest" to 40), startingLife = 20, startingPlayer = startingPlayer)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    fun GameTestDriver.castActionsFor(playerId: EntityId, cardId: EntityId): List<CastSpell> =
+        LegalActionEnumerator.create(cardRegistry)
+            .enumerate(state, playerId)
+            .mapNotNull { it.action as? CastSpell }
+            .filter { it.cardId == cardId }
+
+    test("a noncreature spell with mana value 4 can't be cast by the opponent") {
+        val d = driver()
+        d.putCreatureOnBattlefield(d.player1, "Gaddock Teeg")
+        val spell = d.putCardInHand(d.player2, "Teeg Test Deluge")
+        d.giveMana(d.player2, Color.BLUE, 4)
+
+        d.castActionsFor(d.player2, spell) shouldHaveSize 0
+    }
+
+    test("the lock binds Teeg's own controller too — the wording is \"can't be cast\"") {
+        val d = driver()
+        d.putCreatureOnBattlefield(d.player1, "Gaddock Teeg")
+        val spell = d.putCardInHand(d.player1, "Teeg Test Deluge")
+        d.giveMana(d.player1, Color.BLUE, 4)
+
+        d.castActionsFor(d.player1, spell) shouldHaveSize 0
+    }
+
+    test("a cheaper noncreature spell is unaffected") {
+        val d = driver()
+        d.putCreatureOnBattlefield(d.player1, "Gaddock Teeg")
+        val spell = d.putCardInHand(d.player2, "Teeg Test Ripple")
+        d.giveMana(d.player2, Color.BLUE, 3)
+
+        d.castActionsFor(d.player2, spell).isNotEmpty() shouldBe true
+    }
+
+    test("a big creature spell is unaffected — the restriction is noncreature only") {
+        val d = driver()
+        d.putCreatureOnBattlefield(d.player1, "Gaddock Teeg")
+        val spell = d.putCardInHand(d.player1, "Teeg Test Colossus")
+        d.giveMana(d.player1, Color.GREEN, 6)
+
+        d.castActionsFor(d.player1, spell).isNotEmpty() shouldBe true
+    }
+
+    test("an {X} noncreature spell is blocked by the second clause, which the first would miss") {
+        val d = driver()
+        // Sanity: {X}{U} has mana value 1 in hand (CR 202.3b), so clause one alone lets it through.
+        val without = driver()
+        val freeSpell = without.putCardInHand(without.player2, "Teeg Test Surge")
+        without.giveMana(without.player2, Color.BLUE, 3)
+        without.castActionsFor(without.player2, freeSpell).isNotEmpty() shouldBe true
+
+        d.putCreatureOnBattlefield(d.player1, "Gaddock Teeg")
+        val spell = d.putCardInHand(d.player2, "Teeg Test Surge")
+        d.giveMana(d.player2, Color.BLUE, 3)
+
+        d.castActionsFor(d.player2, spell) shouldHaveSize 0
+    }
+
+    test("the lock lifts when Teeg leaves the battlefield") {
+        val d = driver()
+        val teeg = d.putCreatureOnBattlefield(d.player1, "Gaddock Teeg")
+        val spell = d.putCardInHand(d.player2, "Teeg Test Deluge")
+        d.giveMana(d.player2, Color.BLUE, 4)
+        d.castActionsFor(d.player2, spell) shouldHaveSize 0
+
+        d.moveToGraveyard(teeg)
+        d.castActionsFor(d.player2, spell).isNotEmpty() shouldBe true
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -2190,6 +2190,100 @@
     ]
 }
 
+// Captivating Glance
+{
+    "name": "Captivating Glance",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nAt the beginning of your end step, clash with an opponent. If you win, gain control of enchanted creature. Otherwise, that player gains control of enchanted creature. (Each clashing player reveals the top card of their library, then puts that card on their choice of the top or bottom. A player wins if their card had a greater mana value.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "ChooseOpponentForSource",
+                                    "prompt": "Choose an opponent to clash with"
+                                },
+                                "Clash"
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "clashWon"
+                        }
+                    },
+                    "then": {
+                        "type": "GainControl",
+                        "target": "EnchantedCreature"
+                    },
+                    "otherwise": {
+                        "type": "GiveControlToTargetPlayer",
+                        "newController": {
+                            "type": "PlayerRef",
+                            "player": "ChosenOpponent"
+                        }
+                    },
+                    "descriptionOverride": "Clash with an opponent. If you win, gain control of enchanted creature. Otherwise, target opponent gains control of enchanted creature"
+                },
+                "descriptionOverride": "clash with an opponent. If you win, gain control of enchanted creature. Otherwise, that player gains control of enchanted creature."
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Dos Santos",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/642be353-a46a-4d14-a35a-7716fd552870.jpg?1783942904",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "The ability triggers at the end of Captivating Glance's controller's turn. \"You\" refers to the controller of Captivating Glance, not the controller of the enchanted creature."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "The opponent you clash with doesn't have to be the controller of the enchanted creature."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "If you win the clash, you gain control of the enchanted creature. If you don't win the clash, the other player gains control of the enchanted creature (even if that player didn't win the clash either)."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "Captivating Glance's controller never changes as a result of this card."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "Captivating Glance may cause a player to gain control of a creature they already control. This layers a new control effect on that creature, but doing so rarely has any visible effect."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "Captivating Glance's control-change effect continues to apply even if Captivating Glance leaves the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Caterwauling Boggart
 {
     "name": "Caterwauling Boggart",
@@ -5242,6 +5336,72 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Gaddock Teeg
+{
+    "name": "Gaddock Teeg",
+    "manaCost": "{G}{W}",
+    "typeLine": "Legendary Creature — Kithkin Advisor",
+    "oracleText": "Noncreature spells with mana value 4 or greater can't be cast.\nNoncreature spells with {X} in their mana costs can't be cast.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "PlayersCantCastSpells",
+                "affected": "Each",
+                "spellFilter": {
+                    "cardPredicates": [
+                        {
+                            "type": "Not",
+                            "predicate": "IsCreature"
+                        },
+                        {
+                            "type": "ManaValueAtLeast",
+                            "min": 4
+                        }
+                    ]
+                }
+            },
+            {
+                "type": "PlayersCantCastSpells",
+                "affected": "Each",
+                "spellFilter": {
+                    "cardPredicates": [
+                        {
+                            "type": "Not",
+                            "predicate": "IsCreature"
+                        },
+                        "HasXInManaCost"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "248",
+        "rarity": "RARE",
+        "artist": "Greg Staples",
+        "flavorText": "So great is his wisdom and spirit that many who have met him say that they stood before a giant of a man and talked to the wisest of the four winds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/32c16e1b-f4ce-409f-928a-42c666adac9d.jpg?1783942856",
+        "rulings": [
+            {
+                "date": "2018-12-07",
+                "text": "A spell's mana value is determined only by its mana cost. Alternative costs (including casting a spell \"without paying its mana cost\"), additional costs, and cost reductions don't affect a spell's mana value."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "If one half of a split card has a mana value of 3 or less and doesn't have an {X} in its mana cost, Gaddock Teeg lets you cast that half."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }
 


### PR DESCRIPTION
Lorwyn **259 → 261 / 286**. Both cards are pure composition; both got a scenario test anyway, because what makes them work is a claim about existing primitives that no snapshot would catch.

## Cards

- **Captivating Glance** `{2}{U}` Aura — "At the beginning of your end step, clash with an opponent. If you win, gain control of enchanted creature. Otherwise, that player gains control of enchanted creature." The card `Patterns.Mechanic.clash`'s `otherwise` leg was written for. Both branches are control changes differing only in *who* ends up with the creature, which is two existing effects rather than one with a controller axis: `Effects.GainControl` on the win leg, `GiveControlToTargetPlayerEffect` on the lose leg, reading the clash's own opponent back as `Player.ChosenOpponent`.
- **Gaddock Teeg** `{G}{W}` 2/2 — two `PlayersCantCastSpells` statics scoped to `Player.Each`. Two statics, not one: the clauses are over unrelated properties of the cost and `spellFilter` is a conjunction, so a single filter can't express their union. `Player.Each` is the "can't be cast" wording — the lock binds Teeg's own controller too.

## Two triage notes that turned out to be wrong

Both cards were on the LRW blocked list from #2263, and re-probing is what unblocked them:

- Captivating Glance was filed as needing "a controller axis on `GainControlEffect`". The axis exists — as a *sibling effect* (`GiveControlToTargetPlayerEffect`), not a field. `Patterns.Mechanic.clash`'s KDoc even names this card as the reason its `otherwise` parameter exists.
- Gaddock Teeg was filed as needing "a filter-based global cast restriction". `PlayersCantCastSpells` has had a `spellFilter` all along, and `CardPredicate.HasXInManaCost` / `ManaValueAtLeast` are both already in the vocabulary.

## Tests

`CaptivatingGlanceScenarioTest` pins the two things that could have gone silently wrong: the chosen opponent is written to the Aura *inside* the gate's action and read back *outside* it, and both control executors strip the previous Layer.CONTROL effect so a repeated trigger toggles rather than stacks. It also covers the ruling that the control change outlives the Aura. `GaddockTeegScenarioTest` covers the union of the two clauses — including an `{X}` instant in hand, whose mana value is still 0 (CR 202.3b) and which the first clause alone would let through — plus the controller-binds-too case and the lock lifting when Teeg leaves.

## The rest of the LRW tail

The remaining 25 cards are all `add-feature`, and the split is unchanged from #2263: champion (9), the reveal-or-pay `AdditionalCost` leg (5 — `CostAtom.RevealFromHand` exists but `CastSpellHandler` explicitly doesn't produce reveals as spell additional costs), the Incarnations' put-into-a-graveyard-from-anywhere self-trigger (5 — `NON_BATTLEFIELD_EVENT_TRIGGER_ZONES` is still graveyard+command only), clash-won inside `WheneverYouClash` (2 — the `won` flag is on `ClashedEvent` but not carried into `TriggerContext`), a filtered `AnyTarget` (Needle Drop), X-valued loyalty (Chandra Nalaar), keyword-by-graveyard-contents (Cairn Wanderer), and a same-name-as-a-spell-cast-this-turn free cast (Twinning Glass).

## Verification

`just build` green. `just rebless-cards` moved only these two cards in `LRW.json`. `just assay-differential --set LRW` shows 3 DIVERGENT rows — Boggart Sprite-Chaser, Epic Proportions, Kithkin Greatheart — all pre-existing and untouched by this branch; neither new card is in Assay's compared set (the grammar declines both). `just check-card-printing` clean for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvLRhVP3UzWZrq3NWeSqWu
