### PR TITLE
Add the reveal-from-hand additional cost and Lorwyn's five reveal-or-pay cards

### DIFF
--- a/backlog/sets/lorwyn/cards.md
+++ b/backlog/sets/lorwyn/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 cards
 **Release Date:** October 12, 2007
-**Implemented:** 261 / 286
+**Implemented:** 266 / 286
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 49    | 43   |
@@ -36,7 +36,7 @@
 - [x] Galepowder Mage
 - [x] Goldmeadow Dodger
 - [x] Goldmeadow Harrier
-- [ ] Goldmeadow Stalwart
+- [x] Goldmeadow Stalwart
 - [x] Harpoon Sniper
 - [x] Hillcomber Giant
 - [x] Hoofprints of the Stag
@@ -106,7 +106,7 @@
 - [x] Scion of Oona
 - [x] Sentinels of Glen Elendra
 - [x] Shapesharer
-- [ ] Silvergill Adept
+- [x] Silvergill Adept
 - [x] Silvergill Douser
 - [x] Sower of Temptation
 - [x] Spellstutter Sprite
@@ -164,7 +164,7 @@
 - [x] Shriekmaw
 - [x] Skeletal Changeling
 - [x] Spiderwig Boggart
-- [ ] Squeaking Pie Sneak
+- [x] Squeaking Pie Sneak
 - [x] Thieving Sprite
 - [x] Thorntooth Witch
 - [x] Thoughtseize
@@ -189,7 +189,7 @@
 - [x] Crush Underfoot
 - [x] Faultgrinder
 - [x] Fire-Belly Changeling
-- [ ] Flamekin Bladewhirl
+- [x] Flamekin Bladewhirl
 - [x] Flamekin Brawler
 - [x] Flamekin Harbinger
 - [x] Flamekin Spitfire
@@ -271,7 +271,7 @@
 - [x] Woodland Changeling
 - [x] Woodland Guidance
 - [ ] Wren's Run Packmaster
-- [ ] Wren's Run Vanquisher
+- [x] Wren's Run Vanquisher
 
 ### Multicolor
 - [x] Brion Stoutarm

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -771,7 +771,8 @@ definitions construct these through the facade, e.g. `Costs.additional.Sacrifice
   cost as a whole is always payable. Which leg was taken is recovered at payment time from **which
   `additionalCostPayment` field the client populated**, so `cost` must be a selection-carrying cost
   — a `Behold`, or an atom cost over `Sacrifice` / `Discard` / `ExileFrom` / `TapPermanents` /
-  `ReturnToHand` — and must not share its field with another additional cost on the same card.
+  `ReturnToHand` / `RevealFromHand` — and must not share its field with another additional cost on
+  the same card.
   `CastSpellHandler.reduceCostAlternatives` then rewrites the whole cost to that plain leg cost (leg
   paid) or drops it (pay path), so validation, payment, LKI snapshots, behold's pipeline storage and
   discard tracking (CR 701.8) reuse the leg's own paths verbatim. `BlightOrPay` stays a separate
@@ -781,6 +782,23 @@ definitions construct these through the facade, e.g. `Costs.additional.Sacrifice
   storeAs = storeAs), …)`; the behold path surfaces as a `costType = "Behold"` cost over one
   candidate pool spanning battlefield *and* hand, and stores the chosen cards under `storeAs` for
   downstream costs/effects exactly as a plain `Behold` does.
+- `Costs.additional.RevealFromHand(filter = Filters.Any, count = 1)` — "as an additional cost to
+  cast this spell, reveal a [filter] card from your hand". `Atom(CostAtom.RevealFromHand(filter,
+  count))`; surfaces as a `costType = "RevealCard"` cost over `validRevealTargets` (the caster's
+  hand, minus the spell being cast) and the picks come back as
+  `additionalCostPayment.revealedCards`. **Paying moves nothing** — CR 701.20b: revealing a card
+  doesn't cause it to leave the zone it's in — so the revealed card is still in hand and still
+  castable afterwards; the payment is a `CardsRevealedEvent` and nothing else. As a *mandatory*
+  cost it fails closed: with no matching card in hand the spell isn't castable at all.
+- `Costs.additional.RevealFromHandOrPay(filter = Filters.Any, alternativeManaCost, count = 1)` —
+  "reveal a [filter] card from your hand or pay {mana}" (Lorwyn's tribal cycle: Wren's Run
+  Vanquisher, Silvergill Adept, Goldmeadow Stalwart, Squeaking Pie Sneak, Flamekin Bladewhirl).
+  `OrPay(RevealFromHand(filter, count), …)`. **Not `BeholdOrPay`**: CR 701.4a defines "behold a
+  [quality]" as "reveal a [quality] card from your hand **or** choose a [quality] permanent you
+  control", so behold's candidate pool also spans the battlefield and would wrongly let a permanent
+  pay a hand-only reveal. That width is also why the reveal has its own `revealedCards` payment
+  field rather than sharing `beheldCards` — on an `OrPay` leg the populated field is the only thing
+  telling the engine which leg the caster took.
 - `Costs.additional.ExileFromGraveyardOrPay(exileCount, alternativeManaCost, filter = Filters.Any)`
   — "exile N cards from your graveyard or pay {mana}" (Soaring Stoneglider: "exile two cards from
   your graveyard or pay {1}{W}"). `OrPay(Atom(CostAtom.ExileFrom(GRAVEYARD, filter, exileCount)), …)`;

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -732,11 +732,39 @@ object Costs {
         /**
          * Pay [cost] or pay [alternativeManaCost] instead — the general "do X or pay {N}" shape
          * ([AdditionalCost.OrPay]). [cost] must be a selection-carrying cost: a [Behold], or an
-         * atom cost over sacrifice / discard / exile-from-a-zone / tap / return-to-hand. The named
-         * shapes below are the printed wordings, and a new one is a one-line facade over this.
+         * atom cost over sacrifice / discard / exile-from-a-zone / tap / return-to-hand /
+         * reveal-from-hand. The named shapes below are the printed wordings, and a new one is a
+         * one-line facade over this.
          */
         fun OrPay(cost: AdditionalCost, alternativeManaCost: String): AdditionalCost =
             AdditionalCost.OrPay(cost, alternativeManaCost)
+
+        /**
+         * Reveal [count] cards matching [filter] from your hand. The cards stay in hand
+         * (CR 701.20b) — paying publishes them and nothing else.
+         *
+         * Narrower than [Behold] on purpose: CR 701.4a defines behold as "reveal a [quality] card
+         * from your hand **or** choose a [quality] permanent you control", so a behold cost is also
+         * payable off the battlefield and this one never is.
+         */
+        fun RevealFromHand(
+            filter: GameObjectFilter = GameObjectFilter.Any,
+            count: Int = 1,
+        ): AdditionalCost = AdditionalCost.Atom(CostAtom.RevealFromHand(filter, count))
+
+        /**
+         * Reveal a [filter] card from your hand, or pay [alternativeManaCost] instead — Lorwyn's
+         * tribal "reveal an Elf card from your hand or pay {3}" (Wren's Run Vanquisher, Silvergill
+         * Adept, Goldmeadow Stalwart, Squeaking Pie Sneak, Flamekin Bladewhirl).
+         *
+         * Not [BeholdOrPay]: behold's candidate pool spans the battlefield too (CR 701.4a), which
+         * would wrongly let a permanent pay a hand-only reveal.
+         */
+        fun RevealFromHandOrPay(
+            filter: GameObjectFilter = GameObjectFilter.Any,
+            alternativeManaCost: String,
+            count: Int = 1,
+        ): AdditionalCost = OrPay(RevealFromHand(filter, count), alternativeManaCost)
 
         /** Behold a [filter] card or pay [alternativeManaCost] instead (Lys Alana Dignitary). */
         fun BeholdOrPay(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
@@ -313,7 +313,7 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
      *
      *  - [cost] must be a *selection-carrying* cost, i.e. one whose payment lands in its own field:
      *    [Behold], or an [Atom] over [CostAtom.Sacrifice], [CostAtom.Discard], [CostAtom.ExileFrom],
-     *    [CostAtom.TapPermanents], [CostAtom.ReturnToHand]. Costs that are auto-paid with no
+     *    [CostAtom.TapPermanents], [CostAtom.ReturnToHand], [CostAtom.RevealFromHand]. Costs that are auto-paid with no
      *    selection ([CostAtom.PayLife], [CostAtom.Mill]) leave no trace to read the choice from, so
      *    they can't sit on this leg.
      *  - Don't pair it on one card with another additional cost that consumes the *same* payment
@@ -503,6 +503,22 @@ data class AdditionalCostPayment(
     /** Cards chosen via Behold (from battlefield or hand) */
     val beheldCards: List<EntityId> = emptyList(),
 
+    /**
+     * Cards revealed from hand for a [com.wingedsheep.sdk.scripting.costs.CostAtom.RevealFromHand]
+     * cost — "reveal an Elf card from your hand" (Wren's Run Vanquisher).
+     *
+     * Its own channel rather than [beheldCards] because behold is the strictly *wider* action:
+     * CR 701.4a defines "behold a [quality]" as "reveal a [quality] card from your hand **or**
+     * choose a [quality] permanent you control", so a behold payment can be a battlefield
+     * permanent and a reveal payment never can. Sharing the field would let a caster satisfy a
+     * hand-only reveal cost with a permanent, and would make the two indistinguishable on the
+     * [AdditionalCost.OrPay] leg, whose whole disambiguation is which field the client populated.
+     *
+     * The cards stay in hand (CR 701.20b — revealing doesn't move a card), so paying emits a
+     * `CardsRevealedEvent` and changes no zone.
+     */
+    val revealedCards: List<EntityId> = emptyList(),
+
     /** Permanents that were tapped */
     val tappedPermanents: List<EntityId> = emptyList(),
 
@@ -540,6 +556,7 @@ data class AdditionalCostPayment(
                 exiledCards.isEmpty() &&
                 variableCostPermanents.isEmpty() &&
                 beheldCards.isEmpty() &&
+                revealedCards.isEmpty() &&
                 tappedPermanents.isEmpty() &&
                 bouncedPermanents.isEmpty() &&
                 blightTargets.isEmpty() &&

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FlamekinBladewhirl.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FlamekinBladewhirl.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Flamekin Bladewhirl
+ * {R}
+ * Creature — Elemental Warrior
+ * 2/1
+ * As an additional cost to cast this spell, reveal an Elemental card from your hand or pay {3}.
+ *
+ * An Elemental *card*, so Lorwyn's Kindred noncreature Elementals (Rebellion of the Flamekin,
+ * Fire-Belly Changeling's changeling cousins) pay it as well as Elemental creatures.
+ */
+val FlamekinBladewhirl = card("Flamekin Bladewhirl") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental Warrior"
+    power = 2
+    toughness = 1
+    oracleText = "As an additional cost to cast this spell, reveal an Elemental card from your hand " +
+        "or pay {3}."
+
+    additionalCost(
+        Costs.additional.RevealFromHandOrPay(
+            filter = GameObjectFilter.Any.withSubtype(Subtype.ELEMENTAL),
+            alternativeManaCost = "{3}"
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "165"
+        artist = "Mark Zug"
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b6ea1c8-ca58-4240-adb7-71cd49664414.jpg?1783942876"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/GoldmeadowStalwart.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/GoldmeadowStalwart.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Goldmeadow Stalwart
+ * {W}
+ * Creature — Kithkin Soldier
+ * 2/2
+ * As an additional cost to cast this spell, reveal a Kithkin card from your hand or pay {3}.
+ *
+ * The whole card is its cost — a 2/2 for {W} when the hand is Kithkin, a 2/2 for {3}{W} when it
+ * isn't. Revealing keeps the card in hand (CR 701.20b), so one Kithkin can pay for several of
+ * these across a turn.
+ */
+val GoldmeadowStalwart = card("Goldmeadow Stalwart") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kithkin Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "As an additional cost to cast this spell, reveal a Kithkin card from your hand or pay {3}."
+
+    additionalCost(
+        Costs.additional.RevealFromHandOrPay(
+            filter = GameObjectFilter.Any.withSubtype(Subtype.KITHKIN),
+            alternativeManaCost = "{3}"
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "18"
+        artist = "Wayne Reynolds"
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6a7a9110-6aea-460b-91fa-5f8a507160e7.jpg?1783942915"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SilvergillAdept.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SilvergillAdept.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Silvergill Adept
+ * {1}{U}
+ * Creature — Merfolk Wizard
+ * 2/1
+ * As an additional cost to cast this spell, reveal a Merfolk card from your hand or pay {3}.
+ * When this creature enters, draw a card.
+ *
+ * The filter is any Merfolk *card*, not a Merfolk creature card — Lorwyn's Kindred noncreature
+ * Merfolk (Merrow Commerce) pays this too. Revealing leaves the card in hand (CR 701.20b), so the
+ * Merfolk shown can still be cast the same turn.
+ */
+val SilvergillAdept = card("Silvergill Adept") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    power = 2
+    toughness = 1
+    oracleText = "As an additional cost to cast this spell, reveal a Merfolk card from your hand or " +
+        "pay {3}.\nWhen this creature enters, draw a card."
+
+    additionalCost(
+        Costs.additional.RevealFromHandOrPay(
+            filter = GameObjectFilter.Any.withSubtype(Subtype.MERFOLK),
+            alternativeManaCost = "{3}"
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+        description = "When this creature enters, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "86"
+        artist = "Matt Cavotta"
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9e07a38a-2d88-4b01-9634-f24cbc8d96d6.jpg?1783942897"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SqueakingPieSneak.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SqueakingPieSneak.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Squeaking Pie Sneak
+ * {1}{B}
+ * Creature — Goblin Rogue
+ * 2/2
+ * As an additional cost to cast this spell, reveal a Goblin card from your hand or pay {3}.
+ * Fear
+ *
+ * A Goblin *card* pays it, so Lorwyn's Kindred noncreature Goblins (Tarfire) count.
+ */
+val SqueakingPieSneak = card("Squeaking Pie Sneak") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Goblin Rogue"
+    power = 2
+    toughness = 2
+    oracleText = "As an additional cost to cast this spell, reveal a Goblin card from your hand or " +
+        "pay {3}.\nFear (This creature can't be blocked except by artifact creatures and/or black " +
+        "creatures.)"
+
+    additionalCost(
+        Costs.additional.RevealFromHandOrPay(
+            filter = GameObjectFilter.Any.withSubtype(Subtype.GOBLIN),
+            alternativeManaCost = "{3}"
+        )
+    )
+
+    keywords(Keyword.FEAR)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "142"
+        artist = "Jeff Miracola"
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b7184715-3ed3-4f56-9bf3-ff431cca86be.jpg?1783942883"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WrensRunVanquisher.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WrensRunVanquisher.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Wren's Run Vanquisher
+ * {1}{G}
+ * Creature — Elf Warrior
+ * 3/3
+ * As an additional cost to cast this spell, reveal an Elf card from your hand or pay {3}.
+ * Deathtouch
+ *
+ * The archetype of Lorwyn's reveal-or-pay cycle: a 3/3 deathtouch for {1}{G} out of an Elf hand,
+ * {3}{1}{G} otherwise. The Elf shown stays in hand (CR 701.20b).
+ */
+val WrensRunVanquisher = card("Wren's Run Vanquisher") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "As an additional cost to cast this spell, reveal an Elf card from your hand or " +
+        "pay {3}.\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)"
+
+    additionalCost(
+        Costs.additional.RevealFromHandOrPay(
+            filter = GameObjectFilter.Any.withSubtype(Subtype.ELF),
+            alternativeManaCost = "{3}"
+        )
+    )
+
+    keywords(Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "245"
+        artist = "Paolo Parente"
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f9c411a0-b8dd-4394-852a-a29dbcec953b.jpg?1783942854"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FlamekinBladewhirlScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FlamekinBladewhirlScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.FlamekinBladewhirl
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.FlamekinSpitfire
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Flamekin Bladewhirl (LRW #165) — {R} Creature — Elemental Warrior 2/1.
+ *
+ * "As an additional cost to cast this spell, reveal an Elemental card from your hand or pay {3}."
+ *
+ * A vanilla body behind a tribal cost, so the two prices are the card. The reveal-or-pay machinery
+ * is proved in `RevealFromHandAdditionalCostTest`; this pins the Elemental filter and that the
+ * revealed Elemental is untouched (CR 701.20b).
+ */
+class FlamekinBladewhirlScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(FlamekinBladewhirl, FlamekinSpitfire))
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.castsOf(cardId: EntityId) =
+        LegalActionEnumerator.create(cardRegistry)
+            .enumerate(state, player1)
+            .filter { (it.action as? CastSpell)?.cardId == cardId }
+
+    fun GameTestDriver.tappedMountains(): Int = state.getZone(player1, Zone.BATTLEFIELD).count { id ->
+        state.getEntity(id)?.get<CardComponent>()?.name == "Mountain" &&
+            state.getEntity(id)?.has<TappedComponent>() == true
+    }
+
+    test("an Elemental card in hand casts it for a single Mountain and stays in hand") {
+        val d = driver()
+        d.putLandOnBattlefield(d.player1, "Mountain")
+        val bladewhirl = d.putCardInHand(d.player1, "Flamekin Bladewhirl")
+        val elemental = d.putCardInHand(d.player1, "Flamekin Spitfire")
+
+        val revealLeg = d.castsOf(bladewhirl).firstOrNull { it.additionalCostInfo?.costType == "RevealCard" }
+        revealLeg.shouldNotBeNull()
+        revealLeg.additionalCostInfo!!.validRevealTargets shouldBe listOf(elemental)
+
+        d.submitSuccess(
+            CastSpell(
+                playerId = d.player1,
+                cardId = bladewhirl,
+                additionalCostPayment = AdditionalCostPayment(revealedCards = listOf(elemental)),
+            )
+        )
+        withClue("CR 701.20b — nothing moved") { d.getHand(d.player1) shouldContain elemental }
+        withClue("the base {R} alone") { d.tappedMountains() shouldBe 1 }
+
+        repeat(4) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+        d.state.getZone(d.player1, Zone.BATTLEFIELD).contains(bladewhirl).shouldBeTrue()
+    }
+
+    test("with no Elemental in hand it costs {3}{R}") {
+        val d = driver()
+        repeat(4) { d.putLandOnBattlefield(d.player1, "Mountain") }
+        val bladewhirl = d.putCardInHand(d.player1, "Flamekin Bladewhirl")
+
+        val casts = d.castsOf(bladewhirl)
+        casts.size shouldBe 1
+        casts.single().additionalCostInfo?.costType shouldBe null
+
+        d.submitSuccess(casts.single().action)
+        withClue("{R} + {3} taps all four Mountains") { d.tappedMountains() shouldBe 4 }
+
+        repeat(4) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+        d.state.getZone(d.player1, Zone.BATTLEFIELD).contains(bladewhirl).shouldBeTrue()
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GoldmeadowStalwartScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GoldmeadowStalwartScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.GoldmeadowStalwart
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.KithkinHealer
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Goldmeadow Stalwart (LRW #18) — {W} Creature — Kithkin Soldier 2/2.
+ *
+ * "As an additional cost to cast this spell, reveal a Kithkin card from your hand or pay {3}."
+ *
+ * The whole card is its cost, so the two legs are the whole test: a 2/2 for one Plains out of a
+ * Kithkin hand, and a 2/2 for four Plains out of any other. The reveal-or-pay machinery is proved
+ * in `RevealFromHandAdditionalCostTest`; this pins the Kithkin filter and the two prices.
+ */
+class GoldmeadowStalwartScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(GoldmeadowStalwart, KithkinHealer))
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.castsOf(cardId: EntityId) =
+        LegalActionEnumerator.create(cardRegistry)
+            .enumerate(state, player1)
+            .filter { (it.action as? CastSpell)?.cardId == cardId }
+
+    fun GameTestDriver.tappedPlains(): Int = state.getZone(player1, Zone.BATTLEFIELD).count { id ->
+        state.getEntity(id)?.get<CardComponent>()?.name == "Plains" &&
+            state.getEntity(id)?.has<TappedComponent>() == true
+    }
+
+    test("a Kithkin card in hand makes it a 2/2 for {W}, and that Kithkin stays in hand") {
+        val d = driver()
+        // A single Plains: the {3} leg is out of reach, so this proves the reveal leg was taken.
+        d.putLandOnBattlefield(d.player1, "Plains")
+        val stalwart = d.putCardInHand(d.player1, "Goldmeadow Stalwart")
+        val kithkin = d.putCardInHand(d.player1, "Kithkin Healer")
+
+        val revealLeg = d.castsOf(stalwart).firstOrNull { it.additionalCostInfo?.costType == "RevealCard" }
+        revealLeg.shouldNotBeNull()
+        revealLeg.additionalCostInfo!!.validRevealTargets shouldBe listOf(kithkin)
+
+        d.submitSuccess(
+            CastSpell(
+                playerId = d.player1,
+                cardId = stalwart,
+                additionalCostPayment = AdditionalCostPayment(revealedCards = listOf(kithkin)),
+            )
+        )
+        withClue("CR 701.20b — revealing moved nothing") { d.getHand(d.player1) shouldContain kithkin }
+        withClue("one Plains — the base {W} alone") { d.tappedPlains() shouldBe 1 }
+
+        repeat(4) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+        d.state.getZone(d.player1, Zone.BATTLEFIELD).contains(stalwart).shouldBeTrue()
+    }
+
+    test("with no Kithkin in hand it costs {3}{W} instead") {
+        val d = driver()
+        repeat(4) { d.putLandOnBattlefield(d.player1, "Plains") }
+        val stalwart = d.putCardInHand(d.player1, "Goldmeadow Stalwart")
+
+        val casts = d.castsOf(stalwart)
+        casts.size shouldBe 1
+        casts.single().additionalCostInfo?.costType shouldBe null
+
+        d.submitSuccess(casts.single().action)
+        withClue("{W} + {3} taps all four Plains") { d.tappedPlains() shouldBe 4 }
+
+        repeat(4) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+        d.state.getZone(d.player1, Zone.BATTLEFIELD).contains(stalwart).shouldBeTrue()
+    }
+
+    test("one Plains and no Kithkin means it can't be cast at all") {
+        val d = driver()
+        d.putLandOnBattlefield(d.player1, "Plains")
+        val stalwart = d.putCardInHand(d.player1, "Goldmeadow Stalwart")
+
+        withClue("the pay path needs {3}{W}; the reveal path has nothing to reveal") {
+            d.castsOf(stalwart).isEmpty().shouldBeTrue()
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SilvergillAdeptScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SilvergillAdeptScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.MerrowReejerey
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.SilvergillAdept
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Silvergill Adept (LRW #86) — {1}{U} Creature — Merfolk Wizard 2/1.
+ *
+ * "As an additional cost to cast this spell, reveal a Merfolk card from your hand or pay {3}.
+ *  When this creature enters, draw a card."
+ *
+ * The reveal-or-pay cost itself is proved in `RevealFromHandAdditionalCostTest`; what this pins is
+ * that *this* card is wired to it with a Merfolk filter, that the revealed Merfolk stays in hand
+ * (CR 701.20b), and that the ETB draw still fires on the cheap leg — the whole reason the card is
+ * played.
+ */
+class SilvergillAdeptScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(SilvergillAdept, MerrowReejerey))
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.castsOf(cardId: EntityId) =
+        LegalActionEnumerator.create(cardRegistry)
+            .enumerate(state, player1)
+            .filter { (it.action as? CastSpell)?.cardId == cardId }
+
+    fun GameTestDriver.tappedIslands(): Int = state.getZone(player1, Zone.BATTLEFIELD).count { id ->
+        state.getEntity(id)?.get<CardComponent>()?.name == "Island" &&
+            state.getEntity(id)?.has<TappedComponent>() == true
+    }
+
+    test("revealing a Merfolk card pays the cost, the card stays in hand, and the ETB draw fires") {
+        val d = driver()
+        // Exactly the base {1}{U}: no room for the {3}, so only the reveal leg is affordable.
+        repeat(2) { d.putLandOnBattlefield(d.player1, "Island") }
+        val adept = d.putCardInHand(d.player1, "Silvergill Adept")
+        val merfolk = d.putCardInHand(d.player1, "Merrow Reejerey")
+        val handBefore = d.getHand(d.player1).size
+
+        d.submitSuccess(
+            CastSpell(
+                playerId = d.player1,
+                cardId = adept,
+                additionalCostPayment = AdditionalCostPayment(revealedCards = listOf(merfolk)),
+            )
+        )
+        withClue("CR 701.20b — the revealed Merfolk never left hand") {
+            d.getHand(d.player1) shouldContain merfolk
+        }
+        withClue("only the base {1}{U} was charged") { d.tappedIslands() shouldBe 2 }
+
+        repeat(4) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        d.state.getZone(d.player1, Zone.BATTLEFIELD).contains(adept).shouldBeTrue()
+        withClue("Adept left hand and the ETB drew one, so the hand is back where it started") {
+            d.getHand(d.player1).size shouldBe handBefore
+        }
+    }
+
+    test("the reveal picker offers the Merfolk in hand and not the Adept casting itself") {
+        val d = driver()
+        repeat(5) { d.putLandOnBattlefield(d.player1, "Island") }
+        val adept = d.putCardInHand(d.player1, "Silvergill Adept")
+        val merfolk = d.putCardInHand(d.player1, "Merrow Reejerey")
+
+        val revealLeg = d.castsOf(adept).firstOrNull { it.additionalCostInfo?.costType == "RevealCard" }
+        revealLeg.shouldNotBeNull()
+        withClue("Silvergill Adept is a Merfolk card too, but it is on its way to the stack") {
+            revealLeg.additionalCostInfo!!.validRevealTargets shouldBe listOf(merfolk)
+        }
+    }
+
+    test("with no other Merfolk in hand only the {3} path is offered, and it still draws") {
+        val d = driver()
+        // {1}{U} + {3} = five Islands.
+        repeat(5) { d.putLandOnBattlefield(d.player1, "Island") }
+        val adept = d.putCardInHand(d.player1, "Silvergill Adept")
+        val handBefore = d.getHand(d.player1).size
+
+        val casts = d.castsOf(adept)
+        withClue("nothing to reveal, so the leg path is declined") {
+            casts.size shouldBe 1
+            casts.single().additionalCostInfo?.costType shouldBe null
+        }
+        d.submitSuccess(casts.single().action)
+        withClue("{1}{U} + {3} taps all five Islands") { d.tappedIslands() shouldBe 5 }
+
+        repeat(4) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+        d.state.getZone(d.player1, Zone.BATTLEFIELD).contains(adept).shouldBeTrue()
+        d.getHand(d.player1).size shouldBe handBefore
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SqueakingPieSneakScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SqueakingPieSneakScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.MadAuntie
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.SqueakingPieSneak
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Squeaking Pie Sneak (LRW #142) — {1}{B} Creature — Goblin Rogue 2/2 with fear.
+ *
+ * "As an additional cost to cast this spell, reveal a Goblin card from your hand or pay {3}.
+ *  Fear"
+ *
+ * Pins the Goblin filter on the reveal-or-pay cost and that the creature actually lands with fear
+ * — the two things that make this card what it is. The cost machinery itself is proved in
+ * `RevealFromHandAdditionalCostTest`.
+ */
+class SqueakingPieSneakScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(SqueakingPieSneak, MadAuntie))
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.castsOf(cardId: EntityId) =
+        LegalActionEnumerator.create(cardRegistry)
+            .enumerate(state, player1)
+            .filter { (it.action as? CastSpell)?.cardId == cardId }
+
+    test("revealing a Goblin card casts it for {1}{B}, and it enters with fear") {
+        val d = driver()
+        // Exactly {1}{B} — the {3} leg is unaffordable, so a successful cast is the reveal leg.
+        repeat(2) { d.putLandOnBattlefield(d.player1, "Swamp") }
+        val sneak = d.putCardInHand(d.player1, "Squeaking Pie Sneak")
+        val goblin = d.putCardInHand(d.player1, "Mad Auntie")
+
+        val revealLeg = d.castsOf(sneak).firstOrNull { it.additionalCostInfo?.costType == "RevealCard" }
+        revealLeg.shouldNotBeNull()
+        revealLeg.additionalCostInfo!!.validRevealTargets shouldBe listOf(goblin)
+
+        d.submitSuccess(
+            CastSpell(
+                playerId = d.player1,
+                cardId = sneak,
+                additionalCostPayment = AdditionalCostPayment(revealedCards = listOf(goblin)),
+            )
+        )
+        withClue("CR 701.20b — the Goblin shown is still in hand") {
+            d.getHand(d.player1) shouldContain goblin
+        }
+        repeat(4) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        d.state.getZone(d.player1, Zone.BATTLEFIELD).contains(sneak).shouldBeTrue()
+        withClue("fear is on the resolved permanent") {
+            d.state.projectedState.hasKeyword(sneak, Keyword.FEAR).shouldBeTrue()
+        }
+    }
+
+    test("with no Goblin in hand only the {3} leg is offered") {
+        val d = driver()
+        repeat(5) { d.putLandOnBattlefield(d.player1, "Swamp") }
+        val sneak = d.putCardInHand(d.player1, "Squeaking Pie Sneak")
+
+        val casts = d.castsOf(sneak)
+        casts.size shouldBe 1
+        casts.single().additionalCostInfo?.costType shouldBe null
+        d.submitSuccess(casts.single().action)
+
+        repeat(4) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+        d.state.getZone(d.player1, Zone.BATTLEFIELD).contains(sneak).shouldBeTrue()
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WrensRunVanquisherScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WrensRunVanquisherScenarioTest.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.EyeblightsEnding
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.WarrenScourgeElf
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.WrensRunVanquisher
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wren's Run Vanquisher (LRW #245) — {1}{G} Creature — Elf Warrior 3/3 with deathtouch.
+ *
+ * "As an additional cost to cast this spell, reveal an Elf card from your hand or pay {3}.
+ *  Deathtouch"
+ *
+ * The archetype of Lorwyn's reveal-or-pay cycle. Pins the Elf filter, that a *Kindred noncreature*
+ * Elf card pays it too (Eyeblight's Ending — "an Elf card", not "an Elf creature card"), and that
+ * the body lands with deathtouch. The cost machinery is proved in
+ * `RevealFromHandAdditionalCostTest`.
+ */
+class WrensRunVanquisherScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(WrensRunVanquisher, WarrenScourgeElf, EyeblightsEnding))
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.castsOf(cardId: EntityId) =
+        LegalActionEnumerator.create(cardRegistry)
+            .enumerate(state, player1)
+            .filter { (it.action as? CastSpell)?.cardId == cardId }
+
+    test("revealing an Elf creature card casts it for {1}{G} with deathtouch") {
+        val d = driver()
+        // Exactly {1}{G}: the {3} leg is unaffordable, so a successful cast is the reveal leg.
+        repeat(2) { d.putLandOnBattlefield(d.player1, "Forest") }
+        val vanquisher = d.putCardInHand(d.player1, "Wren's Run Vanquisher")
+        val elf = d.putCardInHand(d.player1, "Warren-Scourge Elf")
+
+        val revealLeg = d.castsOf(vanquisher).firstOrNull { it.additionalCostInfo?.costType == "RevealCard" }
+        revealLeg.shouldNotBeNull()
+        revealLeg.additionalCostInfo!!.validRevealTargets shouldBe listOf(elf)
+
+        d.submitSuccess(
+            CastSpell(
+                playerId = d.player1,
+                cardId = vanquisher,
+                additionalCostPayment = AdditionalCostPayment(revealedCards = listOf(elf)),
+            )
+        )
+        withClue("CR 701.20b — the Elf shown is still in hand") { d.getHand(d.player1) shouldContain elf }
+        repeat(4) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        d.state.getZone(d.player1, Zone.BATTLEFIELD).contains(vanquisher).shouldBeTrue()
+        withClue("deathtouch is on the resolved permanent") {
+            d.state.projectedState.hasKeyword(vanquisher, Keyword.DEATHTOUCH).shouldBeTrue()
+        }
+    }
+
+    test("a Kindred noncreature Elf card pays it — the cost asks for an Elf card, not an Elf creature") {
+        val d = driver()
+        repeat(2) { d.putLandOnBattlefield(d.player1, "Forest") }
+        val vanquisher = d.putCardInHand(d.player1, "Wren's Run Vanquisher")
+        // Eyeblight's Ending is a Kindred Instant — Elf: an Elf card that is never a creature.
+        val kindredElf = d.putCardInHand(d.player1, "Eyeblight's Ending")
+
+        val revealLeg = d.castsOf(vanquisher).firstOrNull { it.additionalCostInfo?.costType == "RevealCard" }
+        revealLeg.shouldNotBeNull()
+        revealLeg.additionalCostInfo!!.validRevealTargets shouldBe listOf(kindredElf)
+
+        d.submitSuccess(
+            CastSpell(
+                playerId = d.player1,
+                cardId = vanquisher,
+                additionalCostPayment = AdditionalCostPayment(revealedCards = listOf(kindredElf)),
+            )
+        )
+        repeat(4) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+        d.state.getZone(d.player1, Zone.BATTLEFIELD).contains(vanquisher).shouldBeTrue()
+    }
+
+    test("with no Elf in hand it costs {3}{1}{G}") {
+        val d = driver()
+        repeat(5) { d.putLandOnBattlefield(d.player1, "Forest") }
+        val vanquisher = d.putCardInHand(d.player1, "Wren's Run Vanquisher")
+
+        val casts = d.castsOf(vanquisher)
+        casts.size shouldBe 1
+        casts.single().additionalCostInfo?.costType shouldBe null
+
+        d.submitSuccess(casts.single().action)
+        repeat(4) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+        d.state.getZone(d.player1, Zone.BATTLEFIELD).contains(vanquisher).shouldBeTrue()
+    }
+
+    test("four Forests and no Elf is not enough — the spell isn't castable") {
+        val d = driver()
+        repeat(4) { d.putLandOnBattlefield(d.player1, "Forest") }
+        val vanquisher = d.putCardInHand(d.player1, "Wren's Run Vanquisher")
+
+        withClue("the pay path needs five mana; the reveal path has nothing to reveal") {
+            d.castsOf(vanquisher).isEmpty().shouldBeTrue()
+        }
+    }
+})

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WrensRunVanquisherReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WrensRunVanquisherReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wren's Run Vanquisher reprint in JMP. Canonical CardDefinition lives in its earliest set (LRW).
+ */
+val WrensRunVanquisherReprint = Printing(
+    oracleId = "fe9cdd15-a390-4a1e-bae9-474ce8d355b8",
+    name = "Wren's Run Vanquisher",
+    setCode = "JMP",
+    collectorNumber = "447",
+    scryfallId = "f61eae36-9c4a-4d72-9431-6cac34dbb527",
+    artist = "Paolo Parente",
+    imageUri = "https://cards.scryfall.io/normal/front/f/6/f61eae36-9c4a-4d72-9431-6cac34dbb527.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/SilvergillAdeptReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/SilvergillAdeptReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Silvergill Adept reprint in RIX. Canonical CardDefinition lives in its earliest set (LRW).
+ */
+val SilvergillAdeptReprint = Printing(
+    oracleId = "cb66c5ec-e7a4-4bd2-b825-6c9b846ba40d",
+    name = "Silvergill Adept",
+    setCode = "RIX",
+    collectorNumber = "53",
+    scryfallId = "45ea8ca1-612d-4984-8572-06710d38bfa6",
+    artist = "Magali Villeneuve",
+    imageUri = "https://cards.scryfall.io/normal/front/4/5/45ea8ca1-612d-4984-8572-06710d38bfa6.jpg",
+    releaseDate = "2018-01-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -4996,6 +4996,42 @@
     ]
 }
 
+// Flamekin Bladewhirl
+{
+    "name": "Flamekin Bladewhirl",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Elemental Warrior",
+    "oracleText": "As an additional cost to cast this spell, reveal an Elemental card from your hand or pay {3}.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "additionalCosts": [
+            {
+                "type": "OrPay",
+                "cost": {
+                    "type": "AdditionalAtom",
+                    "atom": {
+                        "type": "AtomRevealFromHand",
+                        "filter": "Elemental"
+                    }
+                },
+                "alternativeManaCost": "{3}"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Zug",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b6ea1c8-ca58-4240-adb7-71cd49664414.jpg?1783942876"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Flamekin Brawler
 {
     "name": "Flamekin Brawler",
@@ -6308,6 +6344,42 @@
         "artist": "Steve Prescott",
         "flavorText": "\"It's a proven fact that sling-stones from the dawn side of the riverbank sail the farthest and truest.\"\n—Deagan, cenn of Burrenton",
         "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6a7508c-2815-40eb-92f7-3e66dfb28484.jpg?1783942915"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Goldmeadow Stalwart
+{
+    "name": "Goldmeadow Stalwart",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Kithkin Soldier",
+    "oracleText": "As an additional cost to cast this spell, reveal a Kithkin card from your hand or pay {3}.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "additionalCosts": [
+            {
+                "type": "OrPay",
+                "cost": {
+                    "type": "AdditionalAtom",
+                    "atom": {
+                        "type": "AtomRevealFromHand",
+                        "filter": "Kithkin"
+                    }
+                },
+                "alternativeManaCost": "{3}"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "rarity": "UNCOMMON",
+        "artist": "Wayne Reynolds",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6a7a9110-6aea-460b-91fa-5f8a507160e7.jpg?1783942915"
     },
     "colorIdentityOverride": [
         "WHITE"
@@ -13411,6 +13483,59 @@
     ]
 }
 
+// Silvergill Adept
+{
+    "name": "Silvergill Adept",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "As an additional cost to cast this spell, reveal a Merfolk card from your hand or pay {3}.\nWhen this creature enters, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "When this creature enters, draw a card."
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "OrPay",
+                "cost": {
+                    "type": "AdditionalAtom",
+                    "atom": {
+                        "type": "AtomRevealFromHand",
+                        "filter": "Merfolk"
+                    }
+                },
+                "alternativeManaCost": "{3}"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Cavotta",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9e07a38a-2d88-4b01-9634-f24cbc8d96d6.jpg?1783942897"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Silvergill Douser
 {
     "name": "Silvergill Douser",
@@ -14271,6 +14396,45 @@
         "imageUri": "https://cards.scryfall.io/normal/front/f/a/fa8b09d0-fbd2-4441-9d87-02450412e0db.jpg?1562375414"
     },
     "colorIdentityOverride": []
+}
+
+// Squeaking Pie Sneak
+{
+    "name": "Squeaking Pie Sneak",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Goblin Rogue",
+    "oracleText": "As an additional cost to cast this spell, reveal a Goblin card from your hand or pay {3}.\nFear (This creature can't be blocked except by artifact creatures and/or black creatures.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FEAR"
+    ],
+    "script": {
+        "additionalCosts": [
+            {
+                "type": "OrPay",
+                "cost": {
+                    "type": "AdditionalAtom",
+                    "atom": {
+                        "type": "AtomRevealFromHand",
+                        "filter": "Goblin"
+                    }
+                },
+                "alternativeManaCost": "{3}"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "rarity": "UNCOMMON",
+        "artist": "Jeff Miracola",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/7/b7184715-3ed3-4f56-9bf3-ff431cca86be.jpg?1783942883"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
 }
 
 // Stinkdrinker Daredevil
@@ -17027,6 +17191,45 @@
     "colorIdentityOverride": [
         "BLACK",
         "RED"
+    ]
+}
+
+// Wren's Run Vanquisher
+{
+    "name": "Wren's Run Vanquisher",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "As an additional cost to cast this spell, reveal an Elf card from your hand or pay {3}.\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "additionalCosts": [
+            {
+                "type": "OrPay",
+                "cost": {
+                    "type": "AdditionalAtom",
+                    "atom": {
+                        "type": "AtomRevealFromHand",
+                        "filter": "Elf"
+                    }
+                },
+                "alternativeManaCost": "{3}"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "245",
+        "rarity": "UNCOMMON",
+        "artist": "Paolo Parente",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f9c411a0-b8dd-4394-852a-a29dbcec953b.jpg?1783942854"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -315,6 +315,14 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // keeps additional-cost shapes at SCAFFOLD (the cast-time extra-cost area it declines to render).
     supported("AdditionalCastingCost", "cost: additional cost to cast (Costs.additional.*)")
     supported("ExileNumberGraveyardCards", "cost: exile N cards from your graveyard (Costs.additional.ExileFromGraveyardOrPay() / exile-from-graveyard)")
+    // "As an additional cost to cast this spell, reveal an Elf card from your hand or pay {3}" —
+    // Lorwyn's tribal cycle (Wren's Run Vanquisher, Silvergill Adept, Goldmeadow Stalwart, Squeaking
+    // Pie Sneak, Flamekin Bladewhirl), whose IR is
+    // `AdditionalCastingCost(Or(RevealACardOfTypeFromHand, PayMana))`. The engine models it via
+    // Costs.additional.RevealFromHandOrPay(); the bare reveal is Costs.additional.RevealFromHand().
+    // Capability-only, like every other additional-cost leg: the emitter keeps cast-time extra costs
+    // at SCAFFOLD rather than rendering them.
+    supported("RevealACardOfTypeFromHand", "cost: reveal a filtered card from your hand (Costs.additional.RevealFromHand() / RevealFromHandOrPay())")
     // Waterbend {N} (Avatar: The Last Airbender, CR) — a generic-mana cost where each generic may be
     // paid by tapping an untapped artifact/creature you control. On activated abilities this maps to
     // `activatedAbility { cost = Costs.Mana("{N}"); hasWaterbend = true }`. The emitter renders the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -1352,11 +1352,18 @@ class CostHandler {
                 // since the atom's default is `excludeSelf = true`.
                 is CostAtom.VariablePermanents ->
                     com.wingedsheep.engine.mechanics.cost.VariablePermanentsCost.canPay(state, controllerId, atom)
-                // Mana / return-to-hand / reveal / put-counters-on-self / mill are not produced as
+                // "As an additional cost to cast this spell, reveal an Elf card from your hand"
+                // (Wren's Run Vanquisher). Payable while the hand holds enough matching cards; the
+                // cards stay there (CR 701.20b), so paying it takes nothing away.
+                is CostAtom.RevealFromHand ->
+                    findMatchingCardsUnified(
+                        state, state.getZone(ZoneKey(controllerId, Zone.HAND)), atom.filter, controllerId
+                    ).size >= atom.count
+                // Mana / return-to-hand / put-counters-on-self / mill are not produced as
                 // spell additional costs today (put-counters-on-self and reveal-the-noted-type are
                 // inherently ability-scoped — a spell on the stack has no permanent to put the
                 // counters on, nor one carrying a secret note).
-                is CostAtom.Mana, is CostAtom.ReturnToHand, is CostAtom.RevealFromHand,
+                is CostAtom.Mana, is CostAtom.ReturnToHand,
                 is CostAtom.PutCountersOnPermanent,
                 is CostAtom.PutCountersOnSelf, is CostAtom.Mill,
                 is CostAtom.RevealNotedCreatureType,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1780,6 +1780,7 @@ class CastSpellHandler(
                 is CostAtom.TapPermanents -> p.tappedPermanents.isNotEmpty()
                 is CostAtom.ReturnToHand -> p.bouncedPermanents.isNotEmpty()
                 is CostAtom.VariablePermanents -> p.variableCostPermanents.isNotEmpty()
+                is CostAtom.RevealFromHand -> p.revealedCards.isNotEmpty()
                 // Never offered as a spell's additional cost (see CostHandler.canPayAdditionalCost),
                 // so no payment can satisfy it here.
                 is CostAtom.ExileFromGraveyardForTotal -> false
@@ -1987,11 +1988,33 @@ class CastSpellHandler(
                             }
                         }
                     }
-                    // Mana / reveal are not produced as spell additional costs today;
+                    // "Reveal an Elf card from your hand" — the chosen cards must be in the
+                    // caster's hand and match the filter. They stay there (CR 701.20b), so this
+                    // validates a selection rather than a zone change.
+                    is CostAtom.RevealFromHand -> {
+                        val revealed = action.additionalCostPayment?.revealedCards ?: emptyList()
+                        val filterDesc = atom.filter.description
+                        if (revealed.size < atom.count) {
+                            return "You must reveal ${atom.count} $filterDesc from your hand to cast this spell"
+                        }
+                        val hand = state.getZone(ZoneKey(action.playerId, Zone.HAND))
+                        val revealContext = PredicateContext(controllerId = action.playerId)
+                        for (revealedId in revealed) {
+                            val card = state.getEntity(revealedId)?.get<CardComponent>()
+                                ?: return "Revealed card not found: $revealedId"
+                            if (revealedId !in hand) {
+                                return "${card.name} is not in your hand"
+                            }
+                            if (!predicateEvaluator.matches(state, projected, revealedId, atom.filter, revealContext)) {
+                                return "${card.name} doesn't match the required filter: $filterDesc"
+                            }
+                        }
+                    }
+                    // Mana is not produced as a spell additional cost today;
                     // put-counters-on-self is ability-scoped (no permanent to accrue them on);
                     // Mill and ExileFromGraveyardForTotal are activated-ability-only costs, never
                     // spell additional costs (canPayAdditionalCost already reports both unpayable).
-                    is CostAtom.Mana, is CostAtom.RevealFromHand,
+                    is CostAtom.Mana,
                     is CostAtom.PutCountersOnPermanent,
                     is CostAtom.PutCountersOnSelf,
                     is CostAtom.RevealNotedCreatureType,
@@ -2861,15 +2884,33 @@ class CastSpellHandler(
                                 }
                             }
                         }
-                        // PayLife is auto-paid in the loop above; mana / reveal aren't spell additional
-                        // costs; put-counters-on-self is ability-scoped (a spell on the stack has no
+                        // Revealing publishes the cards and moves nothing (CR 701.20b), so paying
+                        // is the event alone — the cards stay in hand and are still castable later.
+                        is CostAtom.RevealFromHand -> {
+                            val revealed = action.additionalCostPayment.revealedCards
+                            if (revealed.isNotEmpty()) {
+                                events.add(
+                                    com.wingedsheep.engine.core.CardsRevealedEvent(
+                                        revealingPlayerId = action.playerId,
+                                        cardIds = revealed,
+                                        cardNames = revealed.map {
+                                            currentState.getEntity(it)?.get<CardComponent>()?.name ?: "Unknown"
+                                        },
+                                        source = currentState.getEntity(action.cardId)
+                                            ?.get<CardComponent>()?.name,
+                                    )
+                                )
+                            }
+                        }
+                        // PayLife is auto-paid in the loop above; mana isn't a spell additional
+                        // cost; put-counters-on-self is ability-scoped (a spell on the stack has no
                         // permanent to accrue them on); Mill is an activated-ability-only cost, never a
                         // spell additional cost (and canPayAdditionalCost reports Mill unpayable, so
                         // this is unreachable).
                         // ExileFromGraveyardForTotal is an activated-ability cost only: it is never
                         // offered as a spell's additional cost (canPayAdditionalCost reports it
                         // unpayable), so this branch is unreachable for the same reason Mill's is.
-                        is CostAtom.PayLife, is CostAtom.Mana, is CostAtom.RevealFromHand,
+                        is CostAtom.PayLife, is CostAtom.Mana,
                         is CostAtom.PutCountersOnPermanent,
                         is CostAtom.PutCountersOnSelf,
                         is CostAtom.RevealNotedCreatureType,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
@@ -467,6 +467,14 @@ data class AdditionalCostData(
     val exileWeightPerTarget: Map<EntityId, Int> = emptyMap(),
     val validBeholdTargets: List<EntityId> = emptyList(),
     val beholdCount: Int = 0,
+    /**
+     * Cards in the caster's hand that could pay a [com.wingedsheep.sdk.scripting.costs.CostAtom.RevealFromHand]
+     * additional cost, and how many of them to pick. Its own pool rather than
+     * [validBeholdTargets] because behold also offers battlefield permanents (CR 701.4a) and a
+     * reveal never does; the client submits the picks as `additionalCostPayment.revealedCards`.
+     */
+    val validRevealTargets: List<EntityId> = emptyList(),
+    val revealCount: Int = 0,
     val counterRemovalCreatures: List<CounterRemovalCreatureData> = emptyList(),
     val validBlightTargets: List<EntityId> = emptyList(),
     val blightAmount: Int = 0,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -225,6 +225,8 @@ class CastSpellEnumerator : ActionEnumerator {
             var tapCount = 0
             var beholdTargets = emptyList<EntityId>()
             var beholdCount = 0
+            var revealTargets = emptyList<EntityId>()
+            var revealCount = 0
             var blightOrPayCost: AdditionalCost.BlightOrPay? = null
             var blightCreatures = emptyList<EntityId>()
             var blightVariableCost: AdditionalCost.BlightVariable? = null
@@ -327,7 +329,27 @@ class CastSpellEnumerator : ActionEnumerator {
                             tapTargets = validTapTargets
                             tapCount = atom.count
                         }
-                        // Mana / reveal aren't produced as spell additional costs today.
+                        // "As an additional cost to cast this spell, reveal an Elf card from your
+                        // hand." The cards stay in hand (CR 701.20b) — the caster picks which to
+                        // publish, and nothing moves. The spell itself is on its way to the stack,
+                        // so it is excluded from its own candidate pool.
+                        is CostAtom.RevealFromHand -> {
+                            val predicateContext = PredicateContext(controllerId = playerId)
+                            val validReveals = state.getZone(ZoneKey(playerId, Zone.HAND))
+                                .filter { it != cardId }
+                                .filter {
+                                    atom.filter == com.wingedsheep.sdk.scripting.GameObjectFilter.Any ||
+                                        context.predicateEvaluator.matches(
+                                            state, state.projectedState, it, atom.filter, predicateContext
+                                        )
+                                }
+                            if (validReveals.size < atom.count) {
+                                canPayAdditionalCosts = false
+                            }
+                            revealTargets = validReveals
+                            revealCount = atom.count
+                        }
+                        // Mana isn't produced as a spell additional cost today.
                         else -> {}
                     }
                     is AdditionalCost.SacrificeCreaturesForCostReduction -> {
@@ -707,6 +729,7 @@ class CastSpellEnumerator : ActionEnumerator {
                 bounceTargets, bounceCount,
                 tapTargets, tapCount,
                 beholdTargets, beholdCount,
+                revealTargets, revealCount,
                 blightVariableCost, blightVariableCreatures, blightVariableMaxX,
                 payXLifeCost, payXLifeMaxX,
                 collectEvidenceCost, evidenceTargetWeights,
@@ -2703,6 +2726,8 @@ class CastSpellEnumerator : ActionEnumerator {
         tapCount: Int = 0,
         beholdTargets: List<EntityId> = emptyList(),
         beholdCount: Int = 0,
+        revealTargets: List<EntityId> = emptyList(),
+        revealCount: Int = 0,
         blightVariableCost: AdditionalCost.BlightVariable? = null,
         blightVariableCreatures: List<EntityId> = emptyList(),
         blightVariableMaxX: Int = 0,
@@ -2807,6 +2832,17 @@ class CastSpellEnumerator : ActionEnumerator {
                 costType = "TapPermanents",
                 validTapTargets = tapTargets,
                 tapCount = tapCount
+            )
+        } else if (revealTargets.isNotEmpty()) {
+            val revealCostAtom = additionalCosts.firstNotNullOfOrNull {
+                (it as? AdditionalCost.Atom)?.atom as? CostAtom.RevealFromHand
+            }
+            AdditionalCostData(
+                description = revealCostAtom?.description?.replaceFirstChar { it.uppercase() }
+                    ?: "Reveal a card from your hand",
+                costType = "RevealCard",
+                validRevealTargets = revealTargets,
+                revealCount = revealCount
             )
         } else if (beholdTargets.isNotEmpty()) {
             val flatCosts = additionalCosts.flatMap { if (it is AdditionalCost.Composite) it.steps else listOf(it) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/SelectionCostPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/SelectionCostPresentation.kt
@@ -185,6 +185,15 @@ object SelectionCostPresentation {
                         exileMaxCount = atom.count,
                     )
                 }
+                // The cards stay in hand (CR 701.20b), so the picker publishes a selection and
+                // moves nothing. Its own pool/count fields rather than behold's: behold also
+                // offers battlefield permanents (CR 701.4a), which can never pay this.
+                is CostAtom.RevealFromHand -> "Reveal" to AdditionalCostData(
+                    description = description,
+                    costType = "RevealCard",
+                    validRevealTargets = candidates,
+                    revealCount = atom.count,
+                )
                 is CostAtom.TapPermanents -> "Tap" to AdditionalCostData(
                     description = description,
                     costType = "TapPermanents",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
@@ -284,6 +284,8 @@ class LegalActionEnricher(
         exileWeightPerTarget = exileWeightPerTarget,
         validBeholdTargets = validBeholdTargets,
         beholdCount = beholdCount,
+        validRevealTargets = validRevealTargets,
+        revealCount = revealCount,
         counterRemovalCreatures = counterRemovalCreatures.map { it.toDto() },
         validBlightTargets = validBlightTargets,
         blightAmount = blightAmount,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
@@ -302,6 +302,9 @@ data class AdditionalCostInfo(
     val exileWeightPerTarget: Map<EntityId, Int> = emptyMap(),
     val validBeholdTargets: List<EntityId> = emptyList(),
     val beholdCount: Int = 0,
+    /** Hand cards that could pay a reveal-from-hand additional cost, and how many to pick. */
+    val validRevealTargets: List<EntityId> = emptyList(),
+    val revealCount: Int = 0,
     val counterRemovalCreatures: List<CounterRemovalCreatureInfo> = emptyList(),
     val validBlightTargets: List<EntityId> = emptyList(),
     val blightAmount: Int = 0,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RevealFromHandAdditionalCostTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RevealFromHandAdditionalCostTest.kt
@@ -1,0 +1,308 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsRevealedEvent
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import io.kotest.assertions.withClue
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain as stringShouldContain
+
+/**
+ * The reveal-from-hand additional cost — `CostAtom.RevealFromHand` as an
+ * [com.wingedsheep.sdk.scripting.AdditionalCost.Atom], on its own and as the non-mana leg of
+ * [com.wingedsheep.sdk.scripting.AdditionalCost.OrPay].
+ *
+ * The mechanic behind Lorwyn's tribal cycle ("reveal an Elf card from your hand or pay {3}" —
+ * Wren's Run Vanquisher, Silvergill Adept, Goldmeadow Stalwart, Squeaking Pie Sneak, Flamekin
+ * Bladewhirl). Two rules do the work and both are pinned here:
+ *
+ *  - **CR 701.20b** — revealing a card doesn't cause it to leave the zone it's in. Paying moves
+ *    nothing; the revealed card is still in hand and still castable afterwards.
+ *  - **CR 701.4a** — "behold a [quality]" is "reveal a [quality] card from your hand **or** choose
+ *    a [quality] permanent you control". Behold is the strictly *wider* action, which is why this
+ *    cost has its own [AdditionalCostPayment.revealedCards] channel rather than sharing behold's:
+ *    a battlefield permanent can never pay a hand-only reveal, and on the OrPay leg the payment
+ *    field is the only thing telling the engine which leg the caster took.
+ */
+class RevealFromHandAdditionalCostTest : ScenarioTestBase() {
+
+    init {
+        // "Reveal an Elf card from your hand or pay {3}" — the printed Lorwyn shape.
+        val revealOrPay = card("Elf Herald") {
+            manaCost = "{1}{G}"
+            colorIdentity = "G"
+            typeLine = "Creature — Elf Warrior"
+            power = 3
+            toughness = 3
+            oracleText = "As an additional cost to cast this spell, reveal an Elf card from your hand or pay {3}."
+            additionalCost(
+                Costs.additional.RevealFromHandOrPay(
+                    filter = GameObjectFilter.Any.withSubtype(Subtype.ELF),
+                    alternativeManaCost = "{3}"
+                )
+            )
+        }
+        // The same cost without the mana escape hatch: a mandatory reveal.
+        val mandatoryReveal = card("Elf Crier") {
+            manaCost = "{G}"
+            colorIdentity = "G"
+            typeLine = "Creature — Elf Scout"
+            power = 1
+            toughness = 1
+            oracleText = "As an additional cost to cast this spell, reveal an Elf card from your hand."
+            additionalCost(
+                Costs.additional.RevealFromHand(
+                    filter = GameObjectFilter.Any.withSubtype(Subtype.ELF)
+                )
+            )
+        }
+        // A Kindred *noncreature* Elf: an "Elf card" for the filter, but never a creature — the
+        // shape that separates "an Elf card" from "an Elf creature card".
+        val kindredElf = card("Elf Rite") {
+            manaCost = "{G}"
+            colorIdentity = "G"
+            typeLine = "Kindred Instant — Elf"
+            oracleText = "Draw a card."
+            spell {
+                effect = com.wingedsheep.sdk.dsl.Effects.DrawCards(1)
+            }
+        }
+        // A permanent Elf, to prove a *battlefield* Elf can't pay a hand-only reveal (CR 701.4a).
+        val elfOnBoard = card("Elf Sentry") {
+            manaCost = "{G}"
+            colorIdentity = "G"
+            typeLine = "Creature — Elf Soldier"
+            power = 1
+            toughness = 1
+        }
+        val nonElf = card("Plain Bear") {
+            manaCost = "{1}{G}"
+            colorIdentity = "G"
+            typeLine = "Creature — Bear"
+            power = 2
+            toughness = 2
+        }
+        listOf(revealOrPay, mandatoryReveal, kindredElf, elfOnBoard, nonElf).forEach { cardRegistry.register(it) }
+
+        fun TestGame.handCardNamed(name: String): EntityId =
+            state.getHand(player1Id).first { state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+        fun TestGame.tappedForests(): Int = state.getBattlefield(player1Id).count { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name == "Forest" &&
+                state.getEntity(id)?.has<TappedComponent>() == true
+        }
+
+        fun board(
+            forests: Int,
+            handExtras: List<String>,
+            elfOnBattlefield: Boolean = false,
+        ): TestGame {
+            var builder = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardInHand(1, "Elf Herald")
+                .withLandsOnBattlefield(1, "Forest", forests)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            handExtras.forEach { builder = builder.withCardInHand(1, it) }
+            if (elfOnBattlefield) builder = builder.withCardOnBattlefield(1, "Elf Sentry")
+            repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+            return builder.build()
+        }
+
+        context("the OrPay leg") {
+
+            test("both the reveal path and the pay path are enumerated when the hand has an Elf and mana for either") {
+                // Five Forests: enough for the base {1}{G} (2) and for {1}{G} + {3} (5).
+                val game = board(forests = 5, handExtras = listOf("Elf Sentry"))
+                val herald = game.handCardNamed("Elf Herald")
+
+                val casts = game.getLegalActions(1).filter { (it.action as? CastSpell)?.cardId == herald }
+                withClue("one action per leg: reveal (base cost) and pay (base + {3})") {
+                    casts.size shouldBe 2
+                }
+                val revealLeg = casts.firstOrNull { it.additionalCostInfo?.costType == "RevealCard" }
+                revealLeg.shouldNotBeNull()
+                withClue("the reveal picker's pool is the Elf in hand, not the spell being cast") {
+                    revealLeg.additionalCostInfo!!.validRevealTargets shouldBe
+                        listOf(game.handCardNamed("Elf Sentry"))
+                    revealLeg.additionalCostInfo!!.revealCount shouldBe 1
+                }
+            }
+
+            test("CR 701.20b — the revealed Elf stays in hand and can still be cast afterwards") {
+                val game = board(forests = 3, handExtras = listOf("Elf Sentry"))
+                val herald = game.handCardNamed("Elf Herald")
+                val elf = game.handCardNamed("Elf Sentry")
+
+                val result = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = herald,
+                        additionalCostPayment = AdditionalCostPayment(revealedCards = listOf(elf)),
+                    )
+                )
+                result.error shouldBe null
+                withClue("the reveal is published as an event so the opponent sees it") {
+                    val revealed = result.events.filterIsInstance<CardsRevealedEvent>().firstOrNull()
+                    revealed.shouldNotBeNull()
+                    revealed.cardIds shouldContain elf
+                    revealed.cardNames shouldContain "Elf Sentry"
+                }
+                withClue("revealing moves nothing — the Elf is still in hand") {
+                    game.state.getZone(game.player1Id, Zone.HAND) shouldContain elf
+                }
+                withClue("only the base {1}{G} was charged, not {1}{G} + {3}") {
+                    game.tappedForests() shouldBe 2
+                }
+                game.resolveStack()
+                game.findPermanent("Elf Herald") shouldNotBe null
+                withClue("the revealed Elf is untouched and still castable") {
+                    game.castSpell(1, "Elf Sentry").error shouldBe null
+                }
+            }
+
+            test("the pay path costs {3} more and reveals nothing") {
+                val game = board(forests = 5, handExtras = listOf("Elf Sentry"))
+                val herald = game.handCardNamed("Elf Herald")
+
+                val result = game.execute(CastSpell(playerId = game.player1Id, cardId = herald))
+                result.error shouldBe null
+                withClue("no reveal happened on the pay path") {
+                    result.events.filterIsInstance<CardsRevealedEvent>().isEmpty().shouldBeTrue()
+                }
+                withClue("{1}{G} + {3} taps five Forests") {
+                    game.tappedForests() shouldBe 5
+                }
+            }
+
+            test("with no Elf in hand only the pay path is offered, and the spell is still castable") {
+                val game = board(forests = 5, handExtras = listOf("Plain Bear"))
+                val herald = game.handCardNamed("Elf Herald")
+
+                val casts = game.getLegalActions(1).filter { (it.action as? CastSpell)?.cardId == herald }
+                withClue("nothing to reveal, so the leg path is declined and only the pay path remains") {
+                    casts.size shouldBe 1
+                    casts.single().additionalCostInfo?.costType shouldNotBe "RevealCard"
+                }
+                game.execute(casts.single().action).error shouldBe null
+                game.tappedForests() shouldBe 5
+            }
+
+            test("CR 701.4a — an Elf on the battlefield is not an Elf card in hand and cannot pay the reveal") {
+                // Behold would accept this permanent; a reveal-from-hand must not.
+                val game = board(forests = 5, handExtras = listOf("Plain Bear"), elfOnBattlefield = true)
+                val herald = game.handCardNamed("Elf Herald")
+                val elfPermanent = game.findPermanent("Elf Sentry")
+                elfPermanent.shouldNotBeNull()
+
+                val casts = game.getLegalActions(1).filter { (it.action as? CastSpell)?.cardId == herald }
+                withClue("the battlefield Elf never enters the reveal pool") {
+                    casts.none { it.additionalCostInfo?.costType == "RevealCard" }.shouldBeTrue()
+                }
+                val result = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = herald,
+                        additionalCostPayment = AdditionalCostPayment(revealedCards = listOf(elfPermanent)),
+                    )
+                )
+                withClue("submitting it anyway is rejected") {
+                    result.error.shouldNotBeNull()
+                    result.error!! stringShouldContain "not in your hand"
+                }
+            }
+
+            test("a Kindred noncreature Elf card pays it — the filter is 'an Elf card', not 'an Elf creature card'") {
+                val game = board(forests = 3, handExtras = listOf("Elf Rite"))
+                val herald = game.handCardNamed("Elf Herald")
+                val rite = game.handCardNamed("Elf Rite")
+
+                val result = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = herald,
+                        additionalCostPayment = AdditionalCostPayment(revealedCards = listOf(rite)),
+                    )
+                )
+                result.error shouldBe null
+                game.tappedForests() shouldBe 2
+            }
+
+            test("a non-Elf card in hand is rejected as the reveal") {
+                val game = board(forests = 5, handExtras = listOf("Plain Bear"))
+                val herald = game.handCardNamed("Elf Herald")
+                val bear = game.handCardNamed("Plain Bear")
+
+                val result = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = herald,
+                        additionalCostPayment = AdditionalCostPayment(revealedCards = listOf(bear)),
+                    )
+                )
+                withClue("the filter is enforced at validation, not just in the picker's pool") {
+                    result.error.shouldNotBeNull()
+                    result.error!! stringShouldContain "doesn't match"
+                }
+            }
+        }
+
+        context("the bare cost, with no mana alternative") {
+
+            fun crierBoard(handExtras: List<String>): TestGame {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Elf Crier")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                handExtras.forEach { builder = builder.withCardInHand(1, it) }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                return builder.build()
+            }
+
+            test("the cost is offered with its own picker when the hand holds a matching card") {
+                val game = crierBoard(listOf("Elf Sentry"))
+                val crier = game.handCardNamed("Elf Crier")
+
+                val cast = game.getLegalActions(1).firstOrNull { (it.action as? CastSpell)?.cardId == crier }
+                cast.shouldNotBeNull()
+                cast.additionalCostInfo?.costType shouldBe "RevealCard"
+                cast.additionalCostInfo!!.validRevealTargets shouldBe listOf(game.handCardNamed("Elf Sentry"))
+            }
+
+            test("the spell is uncastable with nothing to reveal — a mandatory cost fails closed") {
+                val game = crierBoard(listOf("Plain Bear"))
+                val crier = game.handCardNamed("Elf Crier")
+
+                withClue("no Elf card in hand means the cost cannot be paid at all (CR 601.2f-h)") {
+                    game.getLegalActions(1).none { (it.action as? CastSpell)?.cardId == crier }.shouldBeTrue()
+                }
+            }
+
+            test("the spell can't pay the cost with itself") {
+                // Elf Crier is itself an Elf card, but it is on its way to the stack — CR 601.2a
+                // moves it there before costs are paid, so it is never in its own candidate pool.
+                val game = crierBoard(emptyList())
+                val crier = game.handCardNamed("Elf Crier")
+
+                game.getLegalActions(1).none { (it.action as? CastSpell)?.cardId == crier }.shouldBeTrue()
+            }
+        }
+    }
+}

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -509,11 +509,13 @@ export function mergeResult(
                     costType === 'CollectEvidence' ||
                     costType === 'ExileForTotal'
                   ? { exiledCards: selectedTargets }
-                  : costType === 'Behold' || costType === 'ChooseEntity'
-                    ? { beheldCards: selectedTargets }
-                    : costType === 'Blight' || costType === 'BlightVariable'
-                      ? { blightTargets: selectedTargets }
-                      : { sacrificedPermanents: selectedTargets }
+                  : costType === 'RevealCard'
+                    ? { revealedCards: selectedTargets }
+                    : costType === 'Behold' || costType === 'ChooseEntity'
+                      ? { beheldCards: selectedTargets }
+                      : costType === 'Blight' || costType === 'BlightVariable'
+                        ? { blightTargets: selectedTargets }
+                        : { sacrificedPermanents: selectedTargets }
         // Spread the existing additionalCostPayment so prior phases' fields
         // (e.g. `blightAmount` from a preceding BlightVariable phase) survive.
         const additionalCostPayment = {
@@ -1020,9 +1022,9 @@ export function enterPhase(
           flags.isSacrificeSelection = true
           break
         case 'RevealCard':
-          validTargets = [...(costInfo.validDiscardTargets ?? [])]
-          minTargets = costInfo.discardCount ?? 1
-          maxTargets = costInfo.discardCount ?? 1
+          validTargets = [...(costInfo.validRevealTargets ?? [])]
+          minTargets = costInfo.revealCount ?? 1
+          maxTargets = costInfo.revealCount ?? 1
           flags.isSacrificeSelection = true
           flags.isRevealSelection = true
           break

--- a/web-client/src/types/actions.ts
+++ b/web-client/src/types/actions.ts
@@ -59,6 +59,12 @@ export interface AdditionalCostPayment {
   readonly lifePaid?: number
   readonly exiledCards?: readonly EntityId[]
   readonly beheldCards?: readonly EntityId[]
+  /**
+   * Cards revealed from hand for a reveal-from-hand additional cost. They stay in hand
+   * (CR 701.20b); its own field rather than `beheldCards` because behold also accepts a
+   * battlefield permanent (CR 701.4a) and a reveal never does.
+   */
+  readonly revealedCards?: readonly EntityId[]
   readonly tappedPermanents?: readonly EntityId[]
   readonly bouncedPermanents?: readonly EntityId[]
   readonly counterRemovals?: Readonly<Record<EntityId, number>>

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1126,6 +1126,14 @@ export interface AdditionalCostInfo {
   readonly tapBatchMaxActivations?: number
   readonly validDiscardTargets?: readonly EntityId[]
   readonly discardCount?: number
+  /**
+   * Cards in your hand that could pay a reveal-from-hand additional cost ("reveal an Elf card from
+   * your hand or pay {3}"), and how many to pick. Distinct from `validBeholdTargets` because
+   * behold also offers battlefield permanents (CR 701.4a); a reveal never does. Picks are
+   * submitted as `additionalCostPayment.revealedCards` — the cards stay in hand (CR 701.20b).
+   */
+  readonly validRevealTargets?: readonly EntityId[]
+  readonly revealCount?: number
   readonly validBounceTargets?: readonly EntityId[]
   readonly bounceCount?: number
   readonly validExileTargets?: readonly EntityId[]


### PR DESCRIPTION
Lorwyn **261 → 266 / 286**.

Every one of Lorwyn's 25 remaining cards is blocked on missing engine vocabulary, so this PR ships the smallest gap that unlocks the most of them — the reveal-from-hand additional cost — and the five cards it frees.

## The gap

`CostAtom.RevealFromHand` already existed as an *ability* cost (KTK's megamorph reveals). The cast rail declined it in five separate places, each with the same comment: *"Mana / reveal are not produced as spell additional costs today."* So `AdditionalCost.OrPay` had no reveal leg to carry, and *"as an additional cost to cast this spell, reveal an Elf card from your hand or pay {3}"* had no spelling at all.

**Not `BeholdOrPay`.** CR 701.4a defines *"behold a [quality]"* as *"reveal a [quality] card from your hand **or** choose a [quality] permanent you control on the battlefield"* — behold is strictly wider, and substituting it would let a battlefield permanent pay a hand-only reveal. That width is also why the reveal gets its own `AdditionalCostPayment.revealedCards` channel rather than sharing `beheldCards`: on an `OrPay` leg, *which payment field the client populated* is the only thing telling the engine which leg the caster took.

**Paying moves nothing** — CR 701.20b: revealing a card doesn't cause it to leave the zone it's in. The payment is a `CardsRevealedEvent` and nothing else; the revealed card is still in hand and still castable that same turn. As a *mandatory* cost it fails closed: with no matching card in hand the spell isn't castable.

## What changed

**SDK** — `Costs.additional.RevealFromHand(filter, count)` and `.RevealFromHandOrPay(filter, alternativeManaCost, count)`, plus the `revealedCards` payment field.

**Engine** — payability in `CostHandler`; the mandatory-cost branch and its `AdditionalCostData` in `CastSpellEnumerator`; the OrPay leg's picker payload in `SelectionCostPresentation`; validation, leg disambiguation and payment in `CastSpellHandler`. `validRevealTargets` + `revealCount` ride the legal-action DTO out to the client.

**Client** — the `RevealCard` cost phase was already listed in `costTypesNeedingSelection` but had no server producer; it read the *discard* pool and fell through to `sacrificedPermanents`. It now reads its own pool and submits into `revealedCards`.

## Cards

| Card | Cost |
|---|---|
| Silvergill Adept | reveal a **Merfolk** card or pay {3}; ETB draw |
| Goldmeadow Stalwart | reveal a **Kithkin** card or pay {3} |
| Squeaking Pie Sneak | reveal a **Goblin** card or pay {3}; fear |
| Flamekin Bladewhirl | reveal an **Elemental** card or pay {3} |
| Wren's Run Vanquisher | reveal an **Elf** card or pay {3}; deathtouch |

Each filters on the tribal ***card***, not the tribal creature card, so Lorwyn's Kindred noncreature tribals (Eyeblight's Ending, Merrow Commerce, Tarfire) pay them — pinned in the Vanquisher's test. Reprint rows added for RIX (Silvergill Adept) and JMP (Wren's Run Vanquisher); the other three are LRW-only.

## Tests

`RevealFromHandAdditionalCostTest` (rules-engine, 10 tests) is the mechanic's spec:
- both legs enumerate, and the reveal leg charges the base cost while the pay leg charges base + {3}
- **CR 701.20b** — the revealed card is still in hand afterwards and can still be cast
- **CR 701.4a** — a battlefield Elf never enters the reveal pool, and submitting one is rejected
- a Kindred noncreature Elf card pays it; a non-Elf card is rejected at validation, not just filtered out of the picker
- the bare (no-mana-alternative) form fails closed with nothing to reveal, and a spell can't pay the cost with itself

Plus one scenario test per card (14 more) pinning its own filter, both prices, and its body text.

## Gates

`just build`, `just test-rules`, `just check`, `npm run typecheck` — all green. `just assay-gate --limit 2000` clean (0 ambiguous / 0 print mismatch / 0 non-invertible); no Assay band is owed, since this adds new vocabulary rather than reshaping an existing type. `just rebless-cards` moved only the five new cards in `LRW.json`. `just check-card-printing` green for all five.

The mtgish bridge gains the `RevealACardOfTypeFromHand` cost tag — the IR for all five is `AdditionalCastingCost(Or(RevealACardOfTypeFromHand, PayMana))` — registered capability-only, like every other additional-cost leg (the emitter keeps cast-time extra costs at SCAFFOLD).

## What's still blocked in Lorwyn

The remaining 20 need their own features: champion (9), the Incarnations' put-into-a-graveyard-from-anywhere trigger (5), clash-won inside `WheneverYouClash` (2 — `ClashedEvent.won` exists but `TriggerContext` drops it), a filtered `AnyTarget` (Needle Drop), X-valued loyalty (Chandra Nalaar), keyword-by-graveyard-contents (Cairn Wanderer), and Twinning Glass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYF4tXDreErFzrrbEWbmGn
