### PR TITLE
Add Belltower Sphinx, and fix the mill it exposed in Mesmeric Orb

### DIFF
--- a/backlog/sets/ravnica-city-of-guilds/cards.md
+++ b/backlog/sets/ravnica-city-of-guilds/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards
 **Release Date:** October 7, 2005
-**Implemented:** 265 / 291
+**Implemented:** 266 / 291
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 37    | 33   |
@@ -58,7 +58,7 @@
 - [x] Wojek Siren
 
 ### Blue
-- [ ] Belltower Sphinx
+- [x] Belltower Sphinx
 - [x] Cerulean Sphinx
 - [x] Compulsive Research
 - [x] Convolute

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3749,6 +3749,19 @@ A resolving nonpermanent spell retains its stack instance through serialized eff
   target of a spell or ability, that spell or ability's controller gains control of that creature")
   = `GiveControlToTargetPlayerEffect(permanent = EffectTarget.TriggeringEntity, newController =
   EffectTarget.PlayerRef(Player.ControllerOfTargetingSource))`.
+- `Player.ControllerOfTriggeringEntity` — the controller of the **triggering entity**: the `Player`
+  half of `EffectTarget.ControllerOfTriggeringEntity`, for the places keyed by `Player` rather than
+  `EffectTarget`. The zone pipelines are exactly those places — `CardSource.TopOfLibrary` and
+  `CardDestination.ToZone` take a `Player`, so `Patterns.Library.mill` / `.exileTop` cannot name the
+  triggering object's controller without it. Not `Player.TriggeringPlayer`, which reads the trigger
+  context's *player* slot and is null whenever the thing that triggered the ability was an object.
+  Resolves through the same ladder as the `EffectTarget` form (projected controller → controller
+  component → last-known controller → owner, CR 608.2h), so a burn spell that has left the stack by
+  the time the trigger resolves still names its caster. Belltower Sphinx ("whenever a source deals
+  damage to this creature, that source's controller mills that many cards") =
+  `Patterns.Library.mill(DynamicAmount.ContextProperty(TRIGGER_DAMAGE_AMOUNT),
+  EffectTarget.ControllerOfTriggeringEntity)`; Mesmeric Orb is the same shape on
+  `Triggers.becomesUntapped`.
 - `Player.ContextPlayer(i)` / `Player.Candidate` / `Player.Any` — positional target, CR 115
   candidate during target-restriction evaluation, and "a player" matching.
 - `EffectTarget.ContextProperty(key)` — value plumbed into `EffectContext` (damage amount, life gained, blight

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
@@ -801,13 +801,7 @@ object LibraryPatterns {
         mill(DynamicAmount.Fixed(count), target)
 
     fun mill(count: DynamicAmount, target: EffectTarget = EffectTarget.Controller): CompositeEffect {
-        val player = when (target) {
-            EffectTarget.Controller -> Player.You
-            is EffectTarget.ContextTarget -> Player.ContextPlayer(target.index)
-            is EffectTarget.BoundVariable -> Player.ContextPlayer(0)
-            is EffectTarget.PlayerRef -> target.player
-            else -> Player.You
-        }
+        val player = effectTargetToPlayer(target)
         return CompositeEffect(
             listOf(
                 GatherCardsEffect(
@@ -833,13 +827,7 @@ object LibraryPatterns {
         exileTop(DynamicAmount.Fixed(count), target)
 
     fun exileTop(count: DynamicAmount, target: EffectTarget = EffectTarget.Controller): CompositeEffect {
-        val player = when (target) {
-            EffectTarget.Controller -> Player.You
-            is EffectTarget.ContextTarget -> Player.ContextPlayer(target.index)
-            is EffectTarget.BoundVariable -> Player.ContextPlayer(0)
-            is EffectTarget.PlayerRef -> target.player
-            else -> Player.You
-        }
+        val player = effectTargetToPlayer(target)
         return CompositeEffect(
             listOf(
                 GatherCardsEffect(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/PatternUtils.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/PatternUtils.kt
@@ -6,13 +6,28 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
  * Translate an [EffectTarget] to a [Player] reference for use in pipeline effects.
+ *
+ * Deliberately **not** total: an unmapped [EffectTarget] throws rather than falling back to
+ * [Player.You]. The fallback this replaced was a silent one, and it shipped a wrong card —
+ * Mesmeric Orb passed [EffectTarget.ControllerOfTriggeringEntity] and milled the Orb's own
+ * controller on every untap instead of the untapping permanent's. A pipeline keyed to the wrong
+ * player looks identical to a correct one in the golden snapshot, so nothing downstream can catch
+ * it; failing here, at card-construction time, is the only place it *is* catchable.
+ *
+ * Every caller passes a compile-time-known target, so this throws during `CardDiscovery`/snapshot
+ * construction — never mid-game.
  */
 internal fun effectTargetToPlayer(target: EffectTarget): Player = when (target) {
     EffectTarget.Controller -> Player.You
     is EffectTarget.ContextTarget -> Player.ContextPlayer(target.index)
     is EffectTarget.BoundVariable -> Player.ContextPlayer(0)
     is EffectTarget.PlayerRef -> target.player
-    else -> Player.You
+    EffectTarget.ControllerOfTriggeringEntity -> Player.ControllerOfTriggeringEntity
+    else -> error(
+        "No Player reference for EffectTarget $target. Pipeline effects (mill, exileTop, the " +
+            "Hand patterns) are keyed by Player, so a target with no mapping would silently " +
+            "become 'you'. Add the mapping here rather than letting it default."
+    )
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
@@ -277,6 +277,29 @@ sealed interface Player {
     }
 
     /**
+     * The controller of the **triggering entity** — the player half of
+     * [com.wingedsheep.sdk.scripting.targets.EffectTarget.ControllerOfTriggeringEntity], for the
+     * places that take a [Player] reference rather than an `EffectTarget`.
+     *
+     * The zone pipelines are exactly those places: `CardSource.TopOfLibrary` and
+     * `CardDestination.ToZone` are keyed by [Player], so "that source's controller **mills** that
+     * many cards" (Belltower Sphinx) and "**that player** exiles the top card" have no way to name
+     * the triggering object's controller without this. [TriggeringPlayer] is not that player: it
+     * reads the trigger context's *player* slot (the player who was dealt damage, who cast the
+     * spell), which is null whenever the thing that triggered the ability was an object.
+     *
+     * Resolution walks the same ladder as the `EffectTarget` form — projected controller, then
+     * `ControllerComponent`, then last-known controller, then owner (CR 608.2h) — so a source that
+     * has already left the stack or battlefield by the time the trigger resolves (a burn spell that
+     * damaged the creature, then finished resolving) still names the right player.
+     */
+    @SerialName("ControllerOfTriggeringEntity")
+    @Serializable
+    data object ControllerOfTriggeringEntity : Player {
+        override val description: String = "that source's controller"
+    }
+
+    /**
      * The controller of the spell or ability that **targeted** the source — the other end of a
      * "becomes the target of a spell or ability" trigger.
      *
@@ -330,5 +353,6 @@ sealed interface Player {
             ControllerOfSource -> "your"
             OwnersOfLinkedExile -> "the exiled card's owner's"
             ControllerOfTargetingSource -> "that spell or ability's controller's"
+            ControllerOfTriggeringEntity -> "that source's controller's"
         }
 }

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BelltowerSphinx.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BelltowerSphinx.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Belltower Sphinx — Ravnica: City of Guilds #38
+ * {4}{U} · Creature — Sphinx · 2/5
+ *
+ * Flying
+ * Whenever a source deals damage to this creature, that source's controller mills that many cards.
+ *
+ * A 2/5 flying wall that taxes every answer: block it, burn it, or fight it, and you mill yourself
+ * for the trouble. Both halves are ordinary vocabulary, but the join between them was the gap —
+ * "**that source's** controller" needs the *damage source*, and a SELF-bound
+ * [Triggers.TakesDamage] used to bind the creature that was *dealt* the damage instead. The
+ * detector now binds `event.sourceId`, matching what the two neighbouring damage paths already did
+ * (`detectDamagedBySourceTriggers` for the `SourceFilter.Creature`/`Spell` variants, and
+ * `TriggerContext.fromEvent`'s `DamagePreventedEvent` branch), so
+ * `Player.ControllerOfTriggeringEntity` names the right player here.
+ *
+ * **"That many" is per damage event, not per turn.** The engine emits one `DamageDealtEvent` per
+ * source/recipient pair, so being blocked by two 2/2s is two separate 2-damage instances and mills
+ * each blocker's controller 2 — not one controller 4. That is how the printed card behaves.
+ *
+ * **Lethal damage still mills.** State-based actions bury the Sphinx before the ability resolves,
+ * but the trigger was already detected off the damage event (CR 603.10), and
+ * `DamageTriggerDetector.detectDamageReceivedTriggers` deliberately looks the creature up after it
+ * has left the battlefield for exactly this case.
+ *
+ * **A burn spell mills its caster even though it is gone by then.** The damage source for a
+ * Lightning Bolt finishes resolving and leaves the stack before this trigger does, so
+ * `Player.ControllerOfTriggeringEntity` falls through `TargetResolutionUtils.controllerOf`'s ladder
+ * to the spell's last-known controller and finally its owner (CR 608.2h).
+ *
+ * Canonical printing note: Scryfall lists a `psal` (Salvat 2005) printing seven weeks before RAV,
+ * but that is a regional box product rather than a real expansion, so the canonical definition
+ * stays here. `SelesnyaSanctuary` and `SeedSpark` document the same call for this set.
+ */
+val BelltowerSphinx = card("Belltower Sphinx") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sphinx"
+    power = 2
+    toughness = 5
+    oracleText = "Flying\nWhenever a source deals damage to this creature, that source's " +
+        "controller mills that many cards."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.TakesDamage
+        effect = Patterns.Library.mill(
+            DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT),
+            EffectTarget.ControllerOfTriggeringEntity,
+        )
+        description = "Whenever a source deals damage to this creature, that source's controller " +
+            "mills that many cards."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "38"
+        artist = "Jim Nelson"
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/452a23a0-62de-4561-b361-9c0de9151129.jpg?1783943691"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BelltowerSphinxScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BelltowerSphinxScenarioTest.kt
@@ -1,0 +1,181 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.lea.cards.HillGiant
+import com.wingedsheep.mtg.sets.definitions.rav.cards.BelltowerSphinx
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Belltower Sphinx (RAV) — "Whenever a source deals damage to this creature, that source's
+ * controller mills that many cards."
+ *
+ * Every assertion here is about **whose** library shrinks. That is the whole card, and it is the
+ * half that used to be wrong in two independent ways: the trigger bound the damaged creature
+ * rather than the damage source, and `Patterns.Library.mill` silently mapped any target it didn't
+ * recognise to `Player.You`. Either bug alone mills the Sphinx's own controller — which looks
+ * perfectly normal in a golden snapshot — so every test checks *both* libraries, never just that
+ * someone milled.
+ */
+class BelltowerSphinxScenarioTest : ScenarioTestBase() {
+
+    private val bolt = card("Bolt Test") {
+        manaCost = "{0}"
+        typeLine = "Instant"
+        oracleText = "Bolt Test deals 3 damage to target creature."
+        spell {
+            val t = target("target creature", TargetCreature())
+            effect = Effects.DealDamage(3, t)
+        }
+    }
+
+    /** 7 damage kills the 2/5 outright — the last-known-information case. */
+    private val quake = card("Quake Test") {
+        manaCost = "{0}"
+        typeLine = "Instant"
+        oracleText = "Quake Test deals 7 damage to target creature."
+        spell {
+            val t = target("target creature", TargetCreature())
+            effect = Effects.DealDamage(7, t)
+        }
+    }
+
+    /**
+     * The Sphinx belongs to player 1; the burner takes their own turn so they hold priority
+     * without a handoff. Libraries are deep enough that no mill here empties one — losing to a
+     * draw from an empty library would end the game before the assertions run.
+     */
+    private fun burnGame(burner: Int, vararg spells: String): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Belltower Sphinx", summoningSickness = false)
+            .withActivePlayer(burner)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        repeat(12) {
+            builder.withCardInLibrary(1, "Island")
+            builder.withCardInLibrary(2, "Island")
+        }
+        spells.forEach { builder.withCardInHand(burner, it) }
+        return builder.build()
+    }
+
+    init {
+        cardRegistry.register(BelltowerSphinx)
+        cardRegistry.register(HillGiant)
+        cardRegistry.register(bolt)
+        cardRegistry.register(quake)
+
+        context("Belltower Sphinx") {
+
+            test("a burn spell mills its own caster, not the Sphinx's controller") {
+                val game = burnGame(2, "Bolt Test")
+                val sphinx = game.findPermanent("Belltower Sphinx")!!
+
+                game.castSpell(2, "Bolt Test", targetId = sphinx).error shouldBe null
+                game.resolveStack()
+
+                withClue("the opponent cast the damage source, so the opponent mills 3") {
+                    game.librarySize(2) shouldBe 12 - 3
+                }
+                withClue("the Sphinx's controller is untouched — the bug this card exposes") {
+                    game.librarySize(1) shouldBe 12
+                    game.graveyardSize(1) shouldBe 0
+                }
+                withClue("a 2/5 survives 3 damage") {
+                    game.isOnBattlefield("Belltower Sphinx") shouldBe true
+                }
+            }
+
+            test("the Sphinx's own controller mills when they are the one dealing the damage") {
+                val game = burnGame(1, "Bolt Test")
+                val sphinx = game.findPermanent("Belltower Sphinx")!!
+
+                game.castSpell(1, "Bolt Test", targetId = sphinx).error shouldBe null
+                game.resolveStack()
+
+                withClue("'that source's controller' is the caster — here that really is player 1") {
+                    game.librarySize(1) shouldBe 12 - 3
+                }
+                withClue("the opponent dealt nothing and mills nothing") {
+                    game.librarySize(2) shouldBe 12
+                }
+            }
+
+            test("lethal damage still mills — the trigger is detected off the damage event") {
+                val game = burnGame(2, "Quake Test")
+                val sphinx = game.findPermanent("Belltower Sphinx")!!
+
+                game.castSpell(2, "Quake Test", targetId = sphinx).error shouldBe null
+                game.resolveStack()
+
+                withClue("state-based actions killed the Sphinx before the trigger resolved") {
+                    game.isOnBattlefield("Belltower Sphinx") shouldBe false
+                }
+                withClue("CR 603.10 — the trigger fired anyway, and for the full 7") {
+                    game.librarySize(2) shouldBe 12 - 7
+                }
+                withClue("still not the Sphinx's controller") {
+                    game.librarySize(1) shouldBe 12
+                }
+            }
+
+            test("two damage instances mill separately, each for its own amount") {
+                val game = burnGame(2, "Bolt Test", "Bolt Test")
+                val sphinx = game.findPermanent("Belltower Sphinx")!!
+
+                game.castSpell(2, "Bolt Test", targetId = sphinx).error shouldBe null
+                game.resolveStack()
+                withClue("first instance: 3") { game.librarySize(2) shouldBe 12 - 3 }
+
+                // Resolving the mill trigger leaves priority with whoever answered last, so the
+                // caster has to be handed it back before the second Bolt is legal.
+                if (game.state.priorityPlayerId != game.player2Id) game.passPriority()
+
+                // The Sphinx is a 2/5 carrying 3 damage; the second Bolt is lethal, but its
+                // trigger still fires (see the lethal case above).
+                game.castSpell(2, "Bolt Test", targetId = sphinx).error shouldBe null
+                game.resolveStack()
+
+                withClue("each DamageDealtEvent mills its own amount — 3 then 3, never 6 at once") {
+                    game.librarySize(2) shouldBe 12 - 6
+                }
+                withClue("the Sphinx's controller never milled across either instance") {
+                    game.librarySize(1) shouldBe 12
+                }
+            }
+
+            test("blocking mills the attacker's controller for the attacker's power") {
+                val builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Belltower Sphinx", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(12) {
+                    builder.withCardInLibrary(1, "Island")
+                    builder.withCardInLibrary(2, "Island")
+                }
+                val game = builder.build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Hill Giant" to 1)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Belltower Sphinx" to listOf("Hill Giant")))
+                    .error shouldBe null
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("the 3/3 attacker dealt the damage, so its controller mills 3") {
+                    game.librarySize(2) shouldBe 12 - 3
+                }
+                withClue("the blocking Sphinx's controller mills nothing") {
+                    game.librarySize(1) shouldBe 12
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MesmericOrbScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MesmericOrbScenarioTest.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.lea.cards.GrizzlyBears
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.MesmericOrb
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mesmeric Orb (MRD) — "Whenever a permanent becomes untapped, that permanent's controller mills a
+ * card."
+ *
+ * A regression test for a bug this card shipped with. The definition always read
+ * `Patterns.Library.mill(1, EffectTarget.ControllerOfTriggeringEntity)` — the right thing — but
+ * `mill` mapped every target it did not explicitly recognise to `Player.You`, and
+ * `ControllerOfTriggeringEntity` was not among the four it recognised. So the Orb's *own*
+ * controller milled on every untap, whoever the permanent belonged to. Nothing caught it: the
+ * golden snapshot serialises the intended `EffectTarget`, the card still milled exactly one card
+ * per untap, and there was no scenario test.
+ *
+ * "That permanent's controller" is the entire card, so the assertions are about which library
+ * shrinks — and always about both, since milling the wrong player is invisible if you only check
+ * that a mill happened.
+ */
+class MesmericOrbScenarioTest : ScenarioTestBase() {
+
+    private val unwind = card("Unwind Test") {
+        manaCost = "{0}"
+        typeLine = "Instant"
+        oracleText = "Untap target permanent."
+        spell {
+            val t = target("target permanent", TargetPermanent())
+            effect = Effects.Untap(t)
+        }
+    }
+
+    /** The Orb belongs to player 1 throughout; only the untapping permanent's owner varies. */
+    private fun game(untapperOwner: Int, tappedPermanentOwner: Int): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Mesmeric Orb")
+            .withCardOnBattlefield(tappedPermanentOwner, "Grizzly Bears", tapped = true)
+            .withCardInHand(untapperOwner, "Unwind Test")
+            .withActivePlayer(untapperOwner)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        repeat(12) {
+            builder.withCardInLibrary(1, "Island")
+            builder.withCardInLibrary(2, "Island")
+        }
+        return builder.build()
+    }
+
+    init {
+        cardRegistry.register(MesmericOrb)
+        cardRegistry.register(GrizzlyBears)
+        cardRegistry.register(unwind)
+
+        context("Mesmeric Orb") {
+
+            test("an opponent's permanent untapping mills the opponent, not the Orb's controller") {
+                val game = game(untapperOwner = 2, tappedPermanentOwner = 2)
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(2, "Unwind Test", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("the untapped permanent is the opponent's, so the opponent mills 1") {
+                    game.librarySize(2) shouldBe 12 - 1
+                }
+                withClue("the Orb's controller mills nothing — the shipped bug milled here instead") {
+                    game.librarySize(1) shouldBe 12
+                    game.graveyardSize(1) shouldBe 0
+                }
+            }
+
+            test("the Orb's controller mills when it is their own permanent untapping") {
+                val game = game(untapperOwner = 1, tappedPermanentOwner = 1)
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Unwind Test", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("their own permanent untapped, so they really do mill 1") {
+                    game.librarySize(1) shouldBe 12 - 1
+                }
+                withClue("the opponent is untouched") {
+                    game.librarySize(2) shouldBe 12
+                }
+            }
+
+            test("the untapping permanent's controller mills even when an opponent untaps it") {
+                // Player 2 casts the untap on player 1's permanent: the *permanent's* controller
+                // mills, not the caster's. This is the case that distinguishes
+                // ControllerOfTriggeringEntity from every "whoever did it" reading.
+                val game = game(untapperOwner = 2, tappedPermanentOwner = 1)
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(2, "Unwind Test", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("player 1 controls the untapped permanent, so player 1 mills") {
+                    game.librarySize(1) shouldBe 12 - 1
+                }
+                withClue("the caster is irrelevant to the card's text") {
+                    game.librarySize(2) shouldBe 12
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/BelltowerSphinxReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/BelltowerSphinxReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Belltower Sphinx reprint in M12. Canonical CardDefinition lives in its earliest set (RAV).
+ */
+val BelltowerSphinxM12Reprint = Printing(
+    oracleId = "b9ed0081-7eda-4ff9-ac2d-bcdc29a22d9f",
+    name = "Belltower Sphinx",
+    setCode = "M12",
+    collectorNumber = "46",
+    scryfallId = "d6829959-dae1-4ddf-8a75-33a77e6b4612",
+    artist = "Jim Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/d/6/d6829959-dae1-4ddf-8a75-33a77e6b4612.jpg?1783941095",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BelltowerSphinxReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BelltowerSphinxReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Belltower Sphinx reprint in JMP. Canonical CardDefinition lives in its earliest set (RAV).
+ */
+val BelltowerSphinxJmpReprint = Printing(
+    oracleId = "b9ed0081-7eda-4ff9-ac2d-bcdc29a22d9f",
+    name = "Belltower Sphinx",
+    setCode = "JMP",
+    collectorNumber = "141",
+    scryfallId = "ef04340d-284c-4e7b-afd7-444d21a6b382",
+    artist = "Jim Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/e/f/ef04340d-284c-4e7b-afd7-444d21a6b382.jpg?1783930459",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -7685,6 +7685,7 @@
                                     "type": "Fixed",
                                     "amount": 1
                                 },
+                                "player": "ControllerOfTriggeringEntity",
                                 "isMill": true
                             },
                             "storeAs": "milled"
@@ -7694,7 +7695,8 @@
                             "from": "milled",
                             "destination": {
                                 "type": "ToZone",
-                                "zone": "Graveyard"
+                                "zone": "Graveyard",
+                                "player": "ControllerOfTriggeringEntity"
                             }
                         }
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -250,6 +250,66 @@
     ]
 }
 
+// Belltower Sphinx
+{
+    "name": "Belltower Sphinx",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Sphinx",
+    "oracleText": "Flying\nWhenever a source deals damage to this creature, that source's controller mills that many cards.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DamageReceivedEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "ContextProperty",
+                                    "key": "TRIGGER_DAMAGE_AMOUNT"
+                                },
+                                "player": "ControllerOfTriggeringEntity",
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": "ControllerOfTriggeringEntity"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever a source deals damage to this creature, that source's controller mills that many cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "rarity": "UNCOMMON",
+        "artist": "Jim Nelson",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/452a23a0-62de-4561-b361-9c0de9151129.jpg?1783943691"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Benevolent Ancestor
 {
     "name": "Benevolent Ancestor",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DamageTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DamageTriggerDetector.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.EventPattern
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
 import com.wingedsheep.sdk.scripting.events.DamageType
 import com.wingedsheep.sdk.scripting.events.RecipientFilter
 import com.wingedsheep.sdk.scripting.events.SourceFilter
@@ -22,6 +23,39 @@ class DamageTriggerDetector(
     private val abilityResolver: TriggerAbilityResolver,
     private val matcher: TriggerMatcher
 ) {
+
+    companion object {
+        /**
+         * Whether [ability] is the SELF-bound "whenever a source deals damage to this creature"
+         * shape ([SourceFilter.Any]) — the one whose triggering entity is the **damage source**
+         * rather than the creature that was dealt the damage.
+         *
+         * "That source's controller mills that many cards" (Belltower Sphinx) has nothing to name
+         * otherwise: the damaged creature is the trigger's own `sourceId`, and its controller is
+         * already `controllerId`, so binding it carried no information. This matches what the
+         * source-filtered variants have always done (`detectDamagedBySourceTriggers`) and what
+         * `TriggerContext.fromEvent` does for `DamagePreventedEvent`.
+         *
+         * Shared because this trigger is detected in **two** places — the main battlefield scan in
+         * `TriggerDetector` while the creature is still alive, and
+         * [detectDamageReceivedTriggers] once it has died to that same damage. They must agree, or
+         * a card would behave differently depending on whether the damage happened to be lethal.
+         */
+        fun bindsDamageSource(ability: TriggeredAbility): Boolean {
+            val trigger = ability.trigger
+            return ability.binding == TriggerBinding.SELF &&
+                trigger is EventPattern.DamageReceivedEvent &&
+                trigger.source == SourceFilter.Any
+        }
+
+        /** The trigger context for [bindsDamageSource] abilities, built off the damage event. */
+        fun damageReceivedContext(event: DamageDealtEvent): TriggerContext = TriggerContext(
+            triggeringEntityId = event.sourceId,
+            damageAmount = event.amount,
+            excessDamageAmount = event.excessAmount.takeIf { it > 0 },
+            recipientToughnessAtDamage = event.targetToughnessAtDamage
+        )
+    }
 
     /**
      * Detect "whenever this creature is dealt damage" triggers on creatures that
@@ -54,19 +88,18 @@ class DamageTriggerDetector(
             val trigger = ability.trigger
             // Only match generic (source=Any) DamageReceivedEvent triggers here.
             // Source-filtered triggers (DamagedByCreature, DamagedBySpell) are handled
-            // exclusively by detectDamagedBySourceTriggers to avoid firing with a wrong
-            // triggeringEntityId (fromEvent uses targetId, not sourceId).
-            if (trigger is EventPattern.DamageReceivedEvent &&
-                ability.binding == TriggerBinding.SELF &&
-                trigger.source == SourceFilter.Any
-            ) {
+            // exclusively by detectDamagedBySourceTriggers.
+            if (trigger is EventPattern.DamageReceivedEvent && bindsDamageSource(ability)) {
                 triggers.add(
                     PendingTrigger(
                         ability = ability,
                         sourceId = entityId,
                         sourceName = cardComponent.name,
                         controllerId = controllerId,
-                        triggerContext = TriggerContext.fromEvent(event)
+                        // Binds the damage *source*, not the creature that was dealt the damage —
+                        // see [bindsDamageSource]. The main battlefield scan in TriggerDetector
+                        // applies the same rule for the case where the creature survived.
+                        triggerContext = damageReceivedContext(event)
                     )
                 )
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1535,7 +1535,16 @@ class TriggerDetector(
                                         enchantedCreatureLastKnownPower = enchantedPower,
                                         // Never clobber a capture the event itself carries
                                         // (manifest dread's graveyard cards).
-                                        capturedEntityIds = capturedTargets ?: ctx.capturedEntityIds
+                                        capturedEntityIds = capturedTargets ?: ctx.capturedEntityIds,
+                                        // "Whenever a source deals damage to this creature" binds
+                                        // the damage *source*, so "that source's controller …"
+                                        // (Belltower Sphinx) resolves. DamageTriggerDetector owns
+                                        // the same rule for the case where the creature died to
+                                        // that damage; both paths must agree.
+                                        triggeringEntityId =
+                                            if (event is DamageDealtEvent &&
+                                                DamageTriggerDetector.bindsDamageSource(ability)
+                                            ) event.sourceId else ctx.triggeringEntityId
                                     )
                                 }
                             )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -1210,7 +1210,8 @@ class DynamicAmountEvaluator(
             // controller controls" work (Skulking Killer's "if that opponent controls no other
             // creatures" = AggregateBattlefield(ControllerOf("target"), Creature) == 1).
             is Player.ControllerOf, is Player.OwnerOf, is Player.OwnerOfSource,
-            is Player.ControllerOfSource, is Player.ControllerOfTargetingSource -> listOfNotNull(
+            is Player.ControllerOfSource, is Player.ControllerOfTargetingSource,
+            is Player.ControllerOfTriggeringEntity -> listOfNotNull(
                 TargetResolutionUtils.resolvePlayerRef(player, context, state)
             )
             is Player.TriggeringPlayer -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -221,6 +221,14 @@ object TargetResolutionUtils {
             // stack, and [controllerOf] supplies last-known information once it has left.
             Player.ControllerOfTargetingSource -> context.targetingSourceEntityId
                 ?.let { stackObjectController(state, it) ?: controllerOf(state, it) }
+            // "That source's controller", for the pipelines that are keyed by Player rather than
+            // EffectTarget (Belltower Sphinx's mill). Same entity the EffectTarget form reads, and
+            // [controllerOf]'s ladder ends in last-known controller then owner — which is what
+            // makes it work for a burn spell that has already left the stack by resolution
+            // (CR 608.2h). Distinct from [Player.TriggeringPlayer], which reads the context's
+            // *player* slot and is null when the thing that triggered the ability was an object.
+            Player.ControllerOfTriggeringEntity -> context.triggeringEntityId
+                ?.let { controllerOf(state, it) }
             // Multi-player / list-only references have no single resolution here.
             // OwnersOfLinkedExile is resolved by ForEachExecutor.resolvePlayers (a player loop);
             // EachTargetedPlayer by DynamicAmountEvaluator.resolveUnifiedPlayerIds. Collapsing


### PR DESCRIPTION
**Belltower Sphinx** (RAV #38) — "Flying. Whenever a source deals damage to this creature, that source's controller mills that many cards." One card rather than a handful, because RAV's tail has no plain `add-card` left in it (see below).

It needed one piece of vocabulary, and finding it turned up a live bug in a shipped card.

## The gap

`Patterns.Library.mill` / `.exileTop` are keyed by `Player`, and there was no `Player` reference meaning "that source's / that permanent's controller". So a triggered ability could not mill anyone but its own controller.

- **`Player.ControllerOfTriggeringEntity`** — the missing sibling of `ControllerOfSource` / `ControllerOfIterationEntity` / `ControllerOfTargetingSource`, resolved through the existing `controllerOf` ladder so a burn spell that has already left the stack still names its caster (CR 608.2h). Distinct from `Player.TriggeringPlayer`, which reads the context's *player* slot and is null whenever the thing that triggered the ability was an object.

- **A SELF-bound "whenever a source deals damage to this creature" trigger now binds the damage *source*** as the triggering entity, not the creature that was dealt the damage. The damaged creature is already the trigger's own `sourceId` and its controller is already `controllerId`, so the old binding carried no information. This is what the source-filtered variants (`detectDamagedBySourceTriggers`) and `TriggerContext.fromEvent`'s `DamagePreventedEvent` branch have always done. The trigger is detected in **two** places — the main battlefield scan while the creature is alive, and `DamageTriggerDetector` once it has died to that same damage — so the rule is shared between them via `DamageTriggerDetector.bindsDamageSource`; they must agree, or a card would behave differently depending on whether the damage happened to be lethal. None of the 16 cards on this trigger read the triggering entity today.

## The shipped bug this uncovered

`effectTargetToPlayer` mapped anything it didn't recognise to `Player.You`. **Mesmeric Orb** (MRD) passed `EffectTarget.ControllerOfTriggeringEntity` — the right thing — and silently milled *the Orb's own controller* on every untap, whoever the permanent belonged to.

Nothing could have caught it: the golden snapshot serialises the intended `EffectTarget`, the card still milled exactly one card per untap, and there was no scenario test. The snapshot diff in this PR shows it plainly — `player` was simply *absent* from both the gather and the move, defaulting to `You`:

```diff
   "type": "Fixed", "amount": 1
 },
+"player": "ControllerOfTriggeringEntity",
 "isMill": true
```

That fallthrough now throws at card-construction time, which is the only place it is catchable. `mill`/`exileTop` had inlined copies of the same `when`; they call the shared helper instead. `MesmericOrbScenarioTest` is the regression, covering the three cases that distinguish the readings: an opponent's permanent untapping, the controller's own, and an opponent untapping the controller's permanent.

## Card

Canonical stays in RAV — Scryfall lists a `psal` (Salvat 2005) printing seven weeks earlier, but that is a regional box product rather than a real expansion, the same call `SelesnyaSanctuary` and `SeedSpark` already document for this set. `Printing` rows added for the M12 and JMP reprints.

Five scenarios, every one of them about *whose* library shrinks, since milling the wrong player is invisible if you only assert that a mill happened: an opponent's burn spell, the controller's own burn spell, lethal damage (CR 603.10), two instances milling separately rather than summing, and combat damage from a blocked attacker.

RAV backlog: **265 → 266 / 291**.

## Why one card

The other 25 remaining RAV cards are each blocked on named engine vocabulary — `just assay-ready RAV` reports `0 Assay-ready, 26 declined`. I re-probed the six shallowest rather than trusting the existing triage, and all six held:

| Card | Gap (re-verified today) |
|---|---|
| Auratouched Mage | No "Aura card that could enchant it" predicate; `PredicateEvaluator` has no `CardRegistry`, so a library card's own `auraTarget` is unreachable |
| Dream Leash | `auraTarget` is one field feeding both cast-time legality and the perpetual `UnattachedAurasCheck` SBA — a cast-time-only restriction would rip the Aura off when the host untaps |
| Gaze of the Gorgon | `blockingOrBlockedBySource` is source-relative with no `EntityReference` axis, and delayed triggers don't carry the creating spell's targets |
| Quickchange | `chosenColor` is a single `Color` everywhere, down to a single-select client component; needs a multi-select colour decision across SDK, engine and client |
| Mausoleum Turnkey | `TargetChooser.Opponent` is honoured only on the activated path; `TriggerProcessor.resolveTargetChooser` routes it back to the controller and `CardLinter` rejects it on a trigger |
| Spawnbroker | `EntityReference.Target(i)` resolves at resolution but is `null` during target *enumeration*, so requirement 2 can't be filtered against requirement 1's pick |

Belltower Sphinx was the one whose gap was a missing *axis* on an existing type rather than a missing type. Two others are worth flagging as good next PRs: **Molten Sentry** is pure composition after all (`OnEnterRunEffect` + `FlipCoinEffect`, the accepted Frankenstein's Monster divergence), and **Mausoleum Turnkey** is a contained widening of the trigger path to match the activated one.

## Verification

- `just build` and `just test` — full suite green (8m 59s)
- `just test-class BelltowerSphinxScenarioTest` 5/5, `MesmericOrbScenarioTest` 3/3
- `just rebless-cards` — RAV is pure addition; MRD moved **only** Mesmeric Orb, and that diff is the bug fix
- `just check-card-printing "Belltower Sphinx"` — canonical + both reprint rows ok
- `just assay-differential --set RAV` — 103 compared, 0 divergent (Assay declines this card's text, so it is not independently verified here)
- `just check-backlog` — all 15 headers in sync
- Scryfall re-verified field by field; image URI returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvLRhVP3UzWZrq3NWeSqWu
