### PR TITLE
Add Molten Sentry and Grifter's Blade to Ravnica

### DIFF
--- a/backlog/sets/ravnica-city-of-guilds/cards.md
+++ b/backlog/sets/ravnica-city-of-guilds/cards.md
@@ -2,16 +2,16 @@
 
 **Set Size:** 291 cards
 **Release Date:** October 7, 2005
-**Implemented:** 266 / 291
+**Implemented:** 268 / 291
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 37    | 33   |
-| Blue       | 39    | 34   |
+| Blue       | 39    | 35   |
 | Black      | 37    | 35   |
-| Red        | 39    | 37   |
+| Red        | 39    | 38   |
 | Green      | 37    | 37   |
-| Multicolor | 64    | 54   |
-| Artifact   | 21    | 16   |
+| Multicolor | 64    | 56   |
+| Artifact   | 21    | 17   |
 | Land       | 17    | 17   |
 
 > Verify status anytime with `scripts/card-status --set RAV` (and `--list`). That command's count is authoritative — keep this file's `Implemented:` line in sync (`just fix-backlog`) as boxes are checked. The set's mechanics are catalogued in [`mechanics.md`](mechanics.md).
@@ -160,7 +160,7 @@
 - [x] Indentured Oaf
 - [x] Instill Furor
 - [x] Mindmoil
-- [ ] Molten Sentry
+- [x] Molten Sentry
 - [x] Ordruun Commando
 - [x] Rain of Embers
 - [x] Reroute
@@ -293,7 +293,7 @@
 - [x] Dimir Signet
 - [x] Glass Golem
 - [x] Golgari Signet
-- [ ] Grifter's Blade
+- [x] Grifter's Blade
 - [x] Junktroller
 - [ ] Leashling
 - [x] Nullstone Gargoyle

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GriftersBlade.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GriftersBlade.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.OnEnterRunEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Grifter's Blade
+ * {3}
+ * Artifact — Equipment
+ * Flash
+ * As this Equipment enters, choose a creature you control it could be attached to. If you do, it
+ * enters attached to that creature.
+ * Equipped creature gets +1/+1.
+ * Equip {1}
+ *
+ * The entry clause is two existing replacements standing in a row rather than a new "enters
+ * attached" primitive: [EntersWithChoice] with [ChoiceType.CREATURE_ON_BATTLEFIELD] records the
+ * host on the Blade before it enters (its candidate pool is already "creature you control,
+ * excluding the entering object", and an empty pool skips the choice — which is precisely the
+ * card's "If you do" and its second ruling), and [OnEnterRunEffect] then attaches to
+ * [EffectTarget.ChosenCreature] inline with entry.
+ *
+ * "A creature you control **it could be attached to**" is, for an Equipment with no printed equip
+ * restriction, every creature you control; the pool is exact today. A future Equipment that
+ * *does* restrict its host would need the choice pool to take a filter.
+ *
+ * Not a "when this Equipment enters" trigger: a trigger uses the stack, so the Blade would sit
+ * unattached while opponents responded and the attach could be answered — the card enters already
+ * attached, with nothing to respond to.
+ */
+val GriftersBlade = card("Grifter's Blade") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Flash\n" +
+        "As this Equipment enters, choose a creature you control it could be attached to. If you " +
+        "do, it enters attached to that creature.\n" +
+        "Equipped creature gets +1/+1.\n" +
+        "Equip {1}"
+
+    keywords(Keyword.FLASH)
+
+    replacementEffect(EntersWithChoice(ChoiceType.CREATURE_ON_BATTLEFIELD))
+    replacementEffect(OnEnterRunEffect(Effects.AttachEquipment(EffectTarget.ChosenCreature)))
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "263"
+        artist = "Alan Pollack"
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c411784-fe96-42c0-baaa-36616d2be0b3.jpg?1783943598"
+
+        ruling("2005-10-01", "Grifter's Blade must enter attached to a creature you control, if possible.")
+        ruling(
+            "2005-10-01",
+            "If you don't control a creature Grifter's Blade could be attached to, it simply " +
+                "enters unattached."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/MoltenSentry.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/MoltenSentry.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.OnEnterRunEffect
+import com.wingedsheep.sdk.scripting.effects.FlipCoinEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Molten Sentry
+ * {3}{R}
+ * Creature — Elemental
+ * &#42;/&#42;
+ * As this creature enters, flip a coin. If the coin comes up heads, this creature enters as a 5/2
+ * creature with haste. If it comes up tails, this creature enters as a 2/5 creature with defender.
+ *
+ * There is no "enters as an X/Y with keyword" entry replacement, and there shouldn't be: a coin
+ * flip is not a *choice*, so [com.wingedsheep.sdk.scripting.EntersWithChoice] is the wrong shape,
+ * and the two outcomes are just a base-P/T set plus a keyword grant that already exist. So the
+ * card is [OnEnterRunEffect] wrapping a [FlipCoinEffect] whose two branches each compose
+ * `SetBasePowerAndToughness` + `GrantKeyword` at [Duration.Permanent] — nothing here expires, and
+ * neither branch is undone if the Sentry later stops being the thing it entered as.
+ *
+ * The printed P/T is `*`/`*`: without the entry replacement the Sentry has no defined size, which
+ * is 0/0. It never reaches state-based actions at that size, because `OnEnterRunEffect` runs
+ * inline with the entry — after placement, before SBAs — exactly as Frankenstein's Monster relies
+ * on to survive as an 0/1 until its counters land.
+ *
+ * **Known divergence, shared with Frankenstein's Monster and Nameless Race.** "As this creature
+ * enters" is a true entry replacement, but `OnEnterRunEffect` runs just *after* the permanent is
+ * on the battlefield. The permanent is momentarily a 0/0 Elemental with no keywords, so an ETB
+ * trigger elsewhere that reads its power sees 0 rather than 5 or 2. Closing that needs a
+ * pre-entry replacement hook, which is engine work rather than card work.
+ */
+val MoltenSentry = card("Molten Sentry") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 0
+    toughness = 0
+    oracleText = "As this creature enters, flip a coin. If the coin comes up heads, this creature " +
+        "enters as a 5/2 creature with haste. If it comes up tails, this creature enters as a 2/5 " +
+        "creature with defender."
+
+    replacementEffect(
+        OnEnterRunEffect(
+            FlipCoinEffect(
+                wonEffect = Effects.Composite(
+                    Effects.SetBasePowerAndToughness(5, 2, EffectTarget.Self, Duration.Permanent),
+                    Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self, Duration.Permanent),
+                ),
+                lostEffect = Effects.Composite(
+                    Effects.SetBasePowerAndToughness(2, 5, EffectTarget.Self, Duration.Permanent),
+                    Effects.GrantKeyword(Keyword.DEFENDER, EffectTarget.Self, Duration.Permanent),
+                ),
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "136"
+        artist = "Kev Walker"
+        flavorText = "Some take after their father, Stone, some after their mother, Fire."
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a9eb6c92-b385-4ef4-83ac-65a1a23e3d22.jpg?1783943649"
+
+        ruling(
+            "2005-10-01",
+            "If a creature enters copying Molten Sentry, that creature's controller flips a coin " +
+                "to see what the copy will be."
+        )
+        ruling(
+            "2005-10-01",
+            "If a creature that's already on the battlefield copies Molten Sentry, it becomes a " +
+                "copy of whatever Molten Sentry already is (either a 5/2 creature with haste or a " +
+                "2/5 creature with defender)."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GriftersBladeScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GriftersBladeScenarioTest.kt
@@ -1,0 +1,159 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.rav.cards.GriftersBlade
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Grifter's Blade (RAV) — "As this Equipment enters, choose a creature you control it could be
+ * attached to. If you do, it enters attached to that creature."
+ *
+ * The card is two entry replacements standing in a row: `EntersWithChoice` records the host before
+ * the Blade enters, then `OnEnterRunEffect` attaches to it inline with entry. Those two had never
+ * met before — the `EntersWithChoice` resume path completed the permanent's entry itself and never
+ * ran the `OnEnterRunEffect`, so the Blade would have made its choice and then entered unattached
+ * anyway. The first test is the regression for that; it fails on `main` with the choice prompted
+ * and nothing attached.
+ *
+ * The second test is the card's own second ruling — no creature, no choice, no attachment — which
+ * also proves the pipeline does not error out when the choice is skipped.
+ */
+class GriftersBladeScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    private fun TestGame.drainMana() {
+        var guard = 0
+        while (guard++ < 15 && getPendingDecision() is SelectManaSourcesDecision) {
+            submitManaSourcesAutoPay()
+        }
+    }
+
+    private fun TestGame.attachedHost(blade: EntityId): EntityId? =
+        state.getEntity(blade)?.get<AttachedToComponent>()?.targetId
+
+    private fun bladeGame(vararg creatures: String) = scenario()
+        .withPlayers("Alice", "Bob")
+        .withCardInHand(1, "Grifter's Blade")
+        .withLandsOnBattlefield(1, "Plains", 3)
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .also { builder -> creatures.forEach { builder.withCardOnBattlefield(1, it, summoningSickness = false) } }
+        .build()
+
+    init {
+        cardRegistry.register(GriftersBlade)
+
+        context("Grifter's Blade") {
+
+            test("enters attached to the chosen creature, and equips it") {
+                val game = bladeGame("Grizzly Bears")
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("a plain 2/2 before the Blade arrives") {
+                    val before = stateProjector.project(game.state)
+                    before.getPower(bears) shouldBe 2
+                    before.getToughness(bears) shouldBe 2
+                }
+
+                game.castSpell(1, "Grifter's Blade").error shouldBe null
+                game.drainMana()
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                withClue("the host is chosen as the Blade enters, on the battlefield") {
+                    (decision as? SelectCardsDecision)?.options shouldBe listOf(bears)
+                }
+                withClue("the Blade is not a creature, so the prompt must not say 'another'") {
+                    decision!!.prompt shouldBe "Choose a creature you control"
+                }
+
+                game.selectCards(listOf(bears)).error shouldBe null
+
+                val blade = game.findPermanent("Grifter's Blade")!!
+                withClue("it enters ALREADY attached — the regression: the choice was made and then dropped") {
+                    game.attachedHost(blade) shouldBe bears
+                }
+                withClue("and the equipped creature gets the +1/+1") {
+                    val after = stateProjector.project(game.state)
+                    after.getPower(bears) shouldBe 3
+                    after.getToughness(bears) shouldBe 3
+                }
+            }
+
+            test("with no creature to attach to, it simply enters unattached") {
+                val game = bladeGame()
+
+                game.castSpell(1, "Grifter's Blade").error shouldBe null
+                game.drainMana()
+                game.resolveStack()
+
+                withClue("nothing to choose between, so no prompt is raised at all") {
+                    game.getPendingDecision() shouldBe null
+                }
+                val blade = game.findPermanent("Grifter's Blade")
+                withClue("the Blade still enters — the clause is 'if you do', not a failed entry") {
+                    blade shouldNotBe null
+                }
+                withClue("its second ruling: unattached") {
+                    game.attachedHost(blade!!) shouldBe null
+                }
+            }
+
+            test("the chosen host is the one the player picked, not merely the first candidate") {
+                val game = bladeGame("Grizzly Bears", "Hill Giant")
+                val giant = game.findPermanent("Hill Giant")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Grifter's Blade").error shouldBe null
+                game.drainMana()
+                game.resolveStack()
+
+                game.selectCards(listOf(giant)).error shouldBe null
+
+                val blade = game.findPermanent("Grifter's Blade")!!
+                withClue("the Giant was chosen") { game.attachedHost(blade) shouldBe giant }
+
+                val after = stateProjector.project(game.state)
+                withClue("3/3 Giant becomes 4/4") {
+                    after.getPower(giant) shouldBe 4
+                    after.getToughness(giant) shouldBe 4
+                }
+                withClue("the creature that wasn't chosen is untouched") {
+                    after.getPower(bears) shouldBe 2
+                    after.getToughness(bears) shouldBe 2
+                }
+            }
+
+            test("an opponent's creature is never offered as a host") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Grifter's Blade")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Grifter's Blade").error shouldBe null
+                game.drainMana()
+                game.resolveStack()
+
+                withClue("'a creature YOU control' — the opponent's Bears is not a candidate") {
+                    game.getPendingDecision() shouldBe null
+                }
+                val blade = game.findPermanent("Grifter's Blade")!!
+                game.attachedHost(blade) shouldBe null
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MoltenSentryScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MoltenSentryScenarioTest.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CoinFlipEvent
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.rav.cards.MoltenSentry
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Molten Sentry (RAV) — "As this creature enters, flip a coin. If the coin comes up heads, this
+ * creature enters as a 5/2 creature with haste. If it comes up tails, this creature enters as a
+ * 2/5 creature with defender."
+ *
+ * The card is printed `*`/`*`, so the *only* thing that gives the Sentry a size is the entry
+ * replacement. Every assertion therefore reads the **projected** stats and keywords and pairs them
+ * with the coin flip that actually happened, rather than seeding a particular outcome: a seed→face
+ * mapping is an implementation detail of the RNG, while "whatever the coin said, the body matches
+ * it" is the card.
+ *
+ * The last test runs the entry many times over and insists on seeing both faces — that is what
+ * catches a branch that silently never fires (an `OnEnterRunEffect` dropped on some entry path, or
+ * a `lostEffect` that never runs), which a single-outcome test cannot.
+ */
+class MoltenSentryScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    /** Heads = the flip was won. Recorded off the emitted [CoinFlipEvent], not guessed. */
+    private data class Entry(val heads: Boolean, val power: Int?, val toughness: Int?, val keywords: Set<String>)
+
+    private fun playSentry(seed: Long): Entry {
+        val game = scenario()
+            .withPlayers("Alice", "Bob")
+            .withCardInHand(1, "Molten Sentry")
+            .withLandsOnBattlefield(1, "Mountain", 4)
+            .withActivePlayer(1)
+            .withRngSeed(seed)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+
+        val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
+        events += game.castSpell(1, "Molten Sentry").also { it.error shouldBe null }.events
+
+        var guard = 0
+        while (guard++ < 15) {
+            when (game.getPendingDecision()) {
+                is SelectManaSourcesDecision -> events += game.submitManaSourcesAutoPay().events
+                null -> if (game.state.stack.isNotEmpty()) {
+                    events += game.resolveStack().flatMap { it.events }
+                } else break
+                else -> error("unexpected decision ${game.getPendingDecision()}")
+            }
+        }
+
+        val sentry = game.findPermanent("Molten Sentry")
+            ?: error("Molten Sentry never reached the battlefield")
+        val projected = stateProjector.project(game.state)
+        val flips = events.filterIsInstance<CoinFlipEvent>()
+        withClue("exactly one coin is flipped, and it is flipped once — not once per branch") {
+            flips.size shouldBe 1
+        }
+        return Entry(
+            heads = flips.single().won,
+            power = projected.getPower(sentry),
+            toughness = projected.getToughness(sentry),
+            keywords = projected.getKeywords(sentry),
+        )
+    }
+
+    init {
+        cardRegistry.register(MoltenSentry)
+
+        context("Molten Sentry") {
+
+            test("the body always matches the coin that was flipped") {
+                val entry = playSentry(seed = 7L)
+
+                if (entry.heads) {
+                    withClue("heads: a 5/2 with haste") {
+                        entry.power shouldBe 5
+                        entry.toughness shouldBe 2
+                        entry.keywords shouldContain Keyword.HASTE.name
+                    }
+                    withClue("heads must not also pick up the tails rider") {
+                        entry.keywords.contains(Keyword.DEFENDER.name) shouldBe false
+                    }
+                } else {
+                    withClue("tails: a 2/5 with defender") {
+                        entry.power shouldBe 2
+                        entry.toughness shouldBe 5
+                        entry.keywords shouldContain Keyword.DEFENDER.name
+                    }
+                    withClue("tails must not also pick up the heads rider") {
+                        entry.keywords.contains(Keyword.HASTE.name) shouldBe false
+                    }
+                }
+            }
+
+            test("a printed */* Sentry is never left at 0/0 — it survives its own entry") {
+                val entry = playSentry(seed = 99L)
+
+                withClue("the entry replacement runs inline with the entry, before SBAs see an 0/0") {
+                    (entry.toughness ?: 0) shouldBe if (entry.heads) 2 else 5
+                }
+            }
+
+            test("both faces actually occur across repeated entries, each internally consistent") {
+                val seen = mutableSetOf<Boolean>()
+                for (seed in 1L..40L) {
+                    val entry = playSentry(seed)
+                    seen += entry.heads
+                    withClue("seed $seed: stats must agree with the flip every single time") {
+                        entry.power to entry.toughness shouldBe if (entry.heads) 5 to 2 else 2 to 5
+                    }
+                    if (seen.size == 2) break
+                }
+                withClue("a branch that never fires is the failure this card is prone to") {
+                    seen shouldBe setOf(true, false)
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -6658,6 +6658,87 @@
     ]
 }
 
+// Grifter's Blade
+{
+    "name": "Grifter's Blade",
+    "manaCost": "{3}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Flash\nAs this Equipment enters, choose a creature you control it could be attached to. If you do, it enters attached to that creature.\nEquipped creature gets +1/+1.\nEquip {1}",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "CREATURE_ON_BATTLEFIELD"
+            },
+            {
+                "type": "OnEnterRunEffect",
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": "ChosenCreature"
+                }
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "263",
+        "rarity": "UNCOMMON",
+        "artist": "Alan Pollack",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c411784-fe96-42c0-baaa-36616d2be0b3.jpg?1783943598",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "Grifter's Blade must enter attached to a creature you control, if possible."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "If you don't control a creature Grifter's Blade could be attached to, it simply enters unattached."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Grozoth
 {
     "name": "Grozoth",
@@ -8742,6 +8823,94 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Molten Sentry
+{
+    "name": "Molten Sentry",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "As this creature enters, flip a coin. If the coin comes up heads, this creature enters as a 5/2 creature with haste. If it comes up tails, this creature enters as a 2/5 creature with defender.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "OnEnterRunEffect",
+                "effect": {
+                    "type": "FlipCoin",
+                    "wonEffect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SetBaseStats",
+                                "target": "Self",
+                                "power": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                },
+                                "toughness": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": "Self",
+                                "duration": "Permanent"
+                            }
+                        ]
+                    },
+                    "lostEffect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SetBaseStats",
+                                "target": "Self",
+                                "power": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "toughness": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "DEFENDER",
+                                "target": "Self",
+                                "duration": "Permanent"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "RARE",
+        "artist": "Kev Walker",
+        "flavorText": "Some take after their father, Stone, some after their mother, Fire.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a9eb6c92-b385-4ef4-83ac-65a1a23e3d22.jpg?1783943649",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "If a creature enters copying Molten Sentry, that creature's controller flips a coin to see what the copy will be."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "If a creature that's already on the battlefield copies Molten Sentry, it becomes a copy of whatever Molten Sentry already is (either a 5/2 creature with haste or a 2/5 creature with defender)."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -680,6 +680,34 @@ class ModalAndCloneContinuationResumer(
         val events = mutableListOf<GameEvent>()
         events.addAll(syntheticRiotEvents)
         events.addAll(enterEvents)
+
+        // The generic "as this permanent enters, …" replacement ([OnEnterRunEffect]) — the same
+        // call `StackResolver.resolvePermanentSpell` makes just after `enterPermanentOnBattlefield`.
+        // It lives at both call sites because `enterPermanentOnBattlefield` returns a
+        // `(GameState, events)` pair and this replacement may *pause*, which that signature can't
+        // express. Without it here, a card carrying an `EntersWithChoice` **and** an
+        // `OnEnterRunEffect` silently loses the second one: the choice pauses before the permanent
+        // enters, and this resume path is where entry is completed (Grifter's Blade — "choose a
+        // creature you control it could be attached to. If you do, it enters attached to that
+        // creature", which is the CREATURE_ON_BATTLEFIELD choice plus an attach).
+        val onEnterResult = com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
+            .runOnEnterRunEffect(
+                newState, spellId, controllerId, services.cardRegistry,
+                { s, e, ctx -> services.effectExecutorRegistry.execute(s, e, ctx) },
+                xValue = spellComponent.xValue,
+            )
+        if (onEnterResult != null) {
+            // A pause carries the entry events with it so the ETB triggers are deferred to the
+            // resume path rather than lost — exactly as the spell path documents.
+            if (onEnterResult.isPaused) {
+                return ExecutionResult.propagatePause(
+                    onEnterResult.state, events + onEnterResult.events
+                )
+            }
+            newState = onEnterResult.state
+            events.addAll(onEnterResult.events)
+        }
+
         events.add(ResolvedEvent(spellId, cardComponent.name))
 
         return checkForMore(newState, events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
@@ -59,6 +59,13 @@ import com.wingedsheep.sdk.scripting.references.Player
  *    just after `enterPermanentOnBattlefield`. [runOnEnterRunEffect] only. Added for Nameless
  *    Race; until then [OnEnterRunEffect] was silently inert on every cast permanent, which went
  *    unnoticed because its only two users were lands (played, not cast).
+ *  - [com.wingedsheep.engine.handlers.continuations.ModalAndCloneContinuationResumer]'s
+ *    `resumeEntersWithChoiceSpell` — the same cast-as-a-spell entry, finished on the *other* side
+ *    of an [EntersWithChoice] pause. [runOnEnterRunEffect] only, and it has to be repeated there
+ *    because that resumer calls `enterPermanentOnBattlefield` itself: a card carrying both
+ *    replacements (Grifter's Blade) otherwise made its choice and then lost the effect that reads
+ *    it. `enterPermanentOnBattlefield` can't own the call — it returns a `(GameState, events)`
+ *    pair, and this replacement may pause.
  *
  * Those omissions are real gaps, not deliberate exclusions. The next one worth closing is
  * [EntersWithChoice] on the move path: a reanimated Shapeshifter or Sorcerous Spyglass currently
@@ -409,7 +416,13 @@ object PermanentEntryReplacements {
                     { id -> SelectCardsDecision(
                         id = id,
                         playerId = controllerId,
-                        prompt = "Choose another creature you control",
+                        // Same wording rule as the spell path: "another" only when the entering
+                        // permanent is itself a creature.
+                        prompt = if (cardComponent.isCreature) {
+                            "Choose another creature you control"
+                        } else {
+                            "Choose a creature you control"
+                        },
                         context = context(),
                         options = creatures,
                         minSelections = 1,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -3943,7 +3943,15 @@ class StackResolver(
                         SelectCardsDecision(
                             id = decisionId,
                             playerId = controllerId,
-                            prompt = "Choose another creature you control",
+                            // "Another" only reads right when the entering permanent is itself a
+                            // creature (Dauntless Bodyguard). The pool already excludes the
+                            // entering object either way, so an Equipment or enchantment making
+                            // this choice (Grifter's Blade) just says "a creature you control".
+                            prompt = if (cardComponent.isCreature) {
+                                "Choose another creature you control"
+                            } else {
+                                "Choose a creature you control"
+                            },
                             context = DecisionContext(
                                 sourceId = spellId,
                                 sourceName = cardComponent.name,


### PR DESCRIPTION
Two Ravnica: City of Guilds cards — **RAV 266/291 → 268/291** — plus the engine
fix the second one needed.

Two, not five. `just assay-ready RAV` still returns `0 Assay-ready, 26 declined`,
and a fresh probe of the shallowest remaining tail cards found them genuinely
blocked on engine work rather than stale triage (details below), so this is what
the set had left that composes.

## Cards

- **Molten Sentry** ({3}{R}, Creature — Elemental, `*`/`*`) — "As this creature
  enters, flip a coin. If the coin comes up heads, this creature enters as a 5/2
  creature with haste. If it comes up tails, this creature enters as a 2/5
  creature with defender." `OnEnterRunEffect` wrapping a `FlipCoinEffect` whose
  two branches are each `SetBasePowerAndToughness` + `GrantKeyword` at
  `Duration.Permanent`. No new vocabulary: the old triage said "there is no
  enters-as-an-X/Y-with-keyword replacement", which is true but not the answer —
  a coin flip is not a *choice*, so `EntersWithChoice` was never the right shape,
  and the two outcomes are a base-P/T set plus a keyword grant that both exist.

- **Grifter's Blade** ({3}, Artifact — Equipment) — flash; "As this Equipment
  enters, choose a creature you control it could be attached to. If you do, it
  enters attached to that creature."; equipped creature gets +1/+1; equip {1}.
  Two entry replacements in a row: `EntersWithChoice(CREATURE_ON_BATTLEFIELD)`
  records the host before the Blade enters, then `OnEnterRunEffect` attaches to
  `EffectTarget.ChosenCreature` inline with entry. The choice pool is already
  "creature you control, excluding the entering object", and an empty pool skips
  the choice — which is precisely the card's "If you do" and its second ruling
  ("If you don't control a creature Grifter's Blade could be attached to, it
  simply enters unattached"). Not modelled as a "when this enters" trigger: a
  trigger uses the stack, so the Blade would sit unattached while opponents
  responded to an attach that the card gives them no window for.

## The engine fix Grifter's Blade needed

`EntersWithChoice` and `OnEnterRunEffect` had never appeared on the same card,
and they did not compose. On the cast-as-a-spell path the choice pauses *before*
the permanent enters; the resumer
(`ModalAndCloneContinuationResumer.resumeEntersWithChoiceSpell`) then completes
the entry by calling `enterPermanentOnBattlefield` itself, skipping the
`runOnEnterRunEffect` call that `StackResolver.resolvePermanentSpell` makes right
after its own call to that same function. A card carrying both replacements made
its choice and then silently lost the effect that reads it — the dispatch
fallthrough shape, one function shared by two callers where only one runs the
tail.

The call is repeated at both sites rather than moved into
`enterPermanentOnBattlefield`, because that function returns a
`(GameState, events)` pair and this replacement may pause; the pause carries the
entry events so ETB triggers are deferred to the resume path rather than lost,
exactly as the spell path already documents. `PermanentEntryReplacements`' class
KDoc — which already enumerates which entry path runs which replacement, and says
plainly that the omissions are real gaps — gains the new row.

**Proven as a regression, not asserted:** reverting only that hunk fails two of
the four Grifter's Blade scenario tests, with the host prompt raised, the choice
answered, and nothing attached.

Also fixed while there: `CREATURE_ON_BATTLEFIELD` hardcoded the prompt "Choose
another creature you control", which only reads right when the entering permanent
is itself a creature (Dauntless Bodyguard). The candidate pool excludes the
entering object either way, so a non-creature source now says "a creature you
control". Both copies of that prompt — the spell path and the
already-on-battlefield path — move together.

## Tests

Seven scenario tests, one file per card.

`MoltenSentryScenarioTest` reads the emitted `CoinFlipEvent` and asserts the body
matches the face that actually came up, rather than pinning a seed to an outcome
(a seed→face mapping is an RNG implementation detail; "whatever the coin said,
the stats and the keyword agree with it" is the card). The last case repeats the
entry until both faces have been seen — that is what catches a branch that
silently never fires, which a single-outcome test cannot.

`GriftersBladeScenarioTest` covers the attach-on-entry regression, the
no-creature fallback (its second ruling, and proof the pipeline doesn't error
when the choice is skipped), choosing between two candidates so the host is the
one picked rather than the first offered, and an opponent's creature never being
offered.

## Tail cards re-probed and confirmed still blocked

Each wants `add-feature`, not `add-card`:

- **Leashling** — no "put a card from your hand on top of your library" cost
  atom; `CostAtom` has no such member, and per an earlier finding a new atom also
  has to be wired into `PayOrSufferExecutor` separately from `CostPaymentService`.
- **Sunforger** — no unattach cost. `UnattachEquipmentEffect` exists as an
  *effect*, but `AbilityCost` has no unattach member.
- **Spectral Searchlight** — `AddManaOfChoiceEffect.recipient` exists (Radiant
  Lotus), but its doc-comment is explicit that the *colour* is still chosen by the
  ability's controller. The Searchlight's recipient chooses, so it needs a
  `chooser` axis plus the executor half.
- **Crown of Convergence** — no `EntityReference` for the top card of a library,
  so "creatures that share a color with that card" can't be spelled.

## Verification

- `just test-class GriftersBladeScenarioTest` — 4/4 pass; 2/4 fail with the
  engine hunk reverted (the regression check above).
- `just test-class MoltenSentryScenarioTest` — 3/3 pass.
- `just rebless-cards` — `mtg-sets/src/test/resources/snapshots/cards/RAV.json`
  gains exactly these two cards, 169 insertions, no existing entry moved.
- `just check-card-printing` — both canonical in RAV, their earliest real
  printing (Grifter's Blade's two earlier `psal` rows are a `box` set, not
  scaffoldable). Both `image_uris.normal` return HTTP 200.
- `just assay-differential --set RAV` — 103 compared, 0 divergent. Assay declines
  both new cards' text, so this is a no-regression check, not a pass for them.
- Backlog ticked and `just fix-backlog` run: **268 / 291**.
- `just test` — **every engine, SDK, card, server and Assay suite passed**,
  including all eight eras of scenarios and the snapshot tests. Six tests failed
  in `:ai`, `:gym-server` and `:gym-trainer`; the box was saturated (load
  averages 12.8 / 15.0 / 17.9 on 8 cores). Five are
  `TimeoutCancellationException`. The sixth, `ArenaHarnessTest > a v0 mirror is
  exactly 50%`, was a real assertion failure — it and both of its timed-out
  siblings **pass on an isolated re-run** (`just test-class ArenaHarnessTest`,
  7/7 green). Nothing in this change touches those modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYF4tXDreErFzrrbEWbmGn
