### PR TITLE
Add Ossification to Phyrexia: All Will Be One

### DIFF
--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/Ossification.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/Ossification.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Ossification
+ * {1}{W}
+ * Enchantment — Aura
+ * Enchant basic land you control
+ * When this Aura enters, exile target creature or planeswalker an opponent controls until this Aura
+ * leaves the battlefield.
+ *
+ * Enchants a *basic* land specifically — [GameObjectFilter.BasicLand] is the supertype check, not
+ * `LandWithBasicLandType`, so a shockland or Dryad Arbor is not a legal host.
+ *
+ * The single printed line is modelled the way [ExileUntilLeaves] pairs are modelled everywhere else
+ * (Sheltered by Ghosts, Oblivion Ring): the ETB exile plus a linked leaves-trigger return. That
+ * ordering is what the 2023-02-04 ruling describes — if the Aura is gone before the trigger resolves,
+ * nothing is exiled.
+ */
+val Ossification = card("Ossification") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant basic land you control\n" +
+        "When this Aura enters, exile target creature or planeswalker an opponent controls until this Aura leaves the battlefield."
+
+    auraTarget = TargetPermanent(filter = TargetFilter(GameObjectFilter.BasicLand.youControl()))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val victim = target(
+            "creature or planeswalker an opponent controls",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.CreatureOrPlaneswalker.opponentControls())),
+        )
+        effect = Effects.ExileUntilLeaves(victim)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "26"
+        artist = "Nino Vecia"
+        flavorText = "Only Elesh Norn's most loyal servants are granted the honor of becoming part of her throne."
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0da03224-c1af-438f-96c2-b0e41e1070b7.jpg?1783918077"
+        ruling("2023-02-04", "If Ossification leaves the battlefield before its triggered ability resolves, the target permanent won't be exiled.")
+        ruling("2023-02-04", "Auras attached to the exiled permanent will be put into their owners' graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist. When the card returns to the battlefield, it will be a new object with no connection to the card that was exiled.")
+        ruling("2023-02-04", "If a token is exiled this way, it will cease to exist and won't return to the battlefield.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ONE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONE.json
@@ -1045,6 +1045,95 @@
     ]
 }
 
+// Ossification
+{
+    "name": "Ossification",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant basic land you control\nWhen this Aura enters, exile target creature or planeswalker an opponent controls until this Aura leaves the battlefield.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ExileUntilLeaves",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature or planeswalker an opponent controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|planeswalker ctrl:opponent"
+                    },
+                    "id": "creature or planeswalker an opponent controls"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "basicland ctrl:you"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "rarity": "UNCOMMON",
+        "artist": "Nino Vecia",
+        "flavorText": "Only Elesh Norn's most loyal servants are granted the honor of becoming part of her throne.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0da03224-c1af-438f-96c2-b0e41e1070b7.jpg?1783918077",
+        "rulings": [
+            {
+                "date": "2023-02-04",
+                "text": "If Ossification leaves the battlefield before its triggered ability resolves, the target permanent won't be exiled."
+            },
+            {
+                "date": "2023-02-04",
+                "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist. When the card returns to the battlefield, it will be a new object with no connection to the card that was exiled."
+            },
+            {
+                "date": "2023-02-04",
+                "text": "If a token is exiled this way, it will cease to exist and won't return to the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ovika, Enigma Goliath
 {
     "name": "Ovika, Enigma Goliath",


### PR DESCRIPTION
{1}{W} Aura enchanting a basic land you control; its ETB exiles a creature or planeswalker an opponent controls until the Aura leaves, composed from Effects.ExileUntilLeaves plus the linked-exile return.