### PR TITLE
Add three Ravnica cards: linked-exile name predicate, unattach cost, opponent-chosen trigger target

### DIFF
--- a/backlog/sets/ravnica-city-of-guilds/cards.md
+++ b/backlog/sets/ravnica-city-of-guilds/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards
 **Release Date:** October 7, 2005
-**Implemented:** 268 / 291
+**Implemented:** 271 / 291
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 37    | 33   |
@@ -116,7 +116,7 @@
 - [x] Infectious Host
 - [x] Keening Banshee
 - [x] Last Gasp
-- [ ] Mausoleum Turnkey
+- [x] Mausoleum Turnkey
 - [x] Moonlight Bargain
 - [x] Mortipede
 - [x] Necromantic Thirst
@@ -227,7 +227,7 @@
 - [ ] Brightflame
 - [x] Centaur Safeguard
 - [ ] Chorus of the Conclave
-- [ ] Circu, Dimir Lobotomist
+- [x] Circu, Dimir Lobotomist
 - [x] Clutch of the Undercity
 - [x] Congregation at Dawn
 - [x] Consult the Necrosages
@@ -302,7 +302,7 @@
 - [x] Plague Boiler
 - [x] Selesnya Signet
 - [ ] Spectral Searchlight
-- [ ] Sunforger
+- [x] Sunforger
 - [x] Terrarion
 - [x] Voyager Staff
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -535,6 +535,17 @@ exist in the cost and charges the life through the shared life-payment service.
   it. A forage that was declined, or one no mode was feasible for, emits nothing: forage has no
   "even if you can't" clause.
 - `Costs.RevealNotedCreatureType` (ability cost) — "Reveal the creature type you chose" (MKM — A Killer Among Us). Publishes the secret creature type this permanent's controller noted with `Effects.SecretlyChooseCreatureType(...)` (§ effects) and hands it to the ability's own effect as `chosenValues["chosenCreatureType"]` — the key `CardPredicate.HasSubtypeFromVariable` reads, so "if target attacking creature token is the chosen type" is an ordinary `Conditions.TargetMatchesFilter(Filters.creature.withSubtypeFromVariable("chosenCreatureType"))` test rather than new vocabulary. Two rules make it more than a formality. **Only the player who made the note can pay it**: for anyone else the cost is unpayable, so a permanent whose control changed hands stops offering the ability at all (the card's own ruling; CR 702.106d's linkage). And the type is **captured at activation, not at resolution** (CR 113.7a) — the same cost usually sacrifices the source, so by the time the ability resolves the permanent and its note are gone. Activated-ability-only: a spell has no source permanent to carry a note, and every other cost context reports it unpayable rather than half-paying it.
+- `Costs.Unattach` (ability cost) — "**Unattach this Equipment**" (RAV — Sunforger). Detaches the
+  ability's source from the permanent it is attached to, without moving it between zones (CR 701.3d).
+  The cost twin of `Effects.UnattachEquipment` (§ effects): the *effect* has existed since Stolen
+  Uniform's rider, the *cost* had not, and it is not a lookalike of any other atom — a sacrifice moves
+  zones, a tap can be restored, this does neither. Its affordability gate is the card's own ruling
+  ("You can't pay the cost of unattaching Sunforger unless Sunforger is attached to a creature"), so
+  the ability is offered as unaffordable while the Equipment sits loose. Payment runs through the same
+  `ZoneMovementUtils.unattachEmittingEvent` chokepoint as the effect, so a `Triggers.becomesUnattached`
+  trigger cannot tell the two apart. Activated-ability-only: a spell on the stack is attached to
+  nothing, so every other cost context reports it unpayable rather than half-paying it. Sunforger is
+  `Costs.Composite(Costs.Mana("{R}{W}"), Costs.Unattach)`.
 - `Costs.CollectEvidence(n)` (ability cost) / `Costs.additional.CollectEvidence(n)` (mandatory
   additional cost) / `card { collectEvidence(n) }` (the optional **linked** cast cost) — Collect
   evidence N (CR 701.59a): "exile any number of cards from your graveyard with total mana value N or
@@ -4070,8 +4081,11 @@ Every `TargetRequirement` carries count semantics (defaults shown):
   object/player it is (the controller chooses *which* opponent in multiplayer per CR 601.6a/602.3a, and
   that pick follows the controller's own choices per CR 601.6b/602.3b). Orthogonal to legality: target-finding and
   validation ignore `chooser` (always relative to the controller); only the announcement layer reads it
-  to route the selection decision. `TargetChooser.Opponent` is honored for **activated abilities**; list
-  the opponent-chosen requirement after the controller-chosen ones. `Targets.AnyChosenByOpponent` is the
+  to route the selection decision. `TargetChooser.Opponent` is honored for **activated and triggered
+  abilities** (Mausoleum Turnkey: "When this creature enters, return target creature card of an
+  opponent's choice from your graveyard to your hand") — both announcement paths pin the deciding
+  opponent before raising the target decision, asking the controller which opponent decides when
+  there is more than one. List the opponent-chosen requirement after the controller-chosen ones. `Targets.AnyChosenByOpponent` is the
   ready-made "any target of an opponent's choice"; `TargetObject` (and so the `TargetCreature` factory)
   carries `chooser` too, for opponent-chosen *permanent* targets — Preacher's "gain control of target
   creature of an opponent's choice they control" is `TargetCreature(filter =
@@ -4096,8 +4110,8 @@ Every `TargetRequirement` carries count semantics (defaults shown):
   requirement list — no printed card splits one trigger's targets between two deciders.
 
   `CardLinter` (§21) fails any card that puts a chooser in a context the engine doesn't route:
-  `Opponent` outside an activated ability, `TriggeringPlayer` / `ControllerOfTriggeringEntity` outside a
-  triggered one. In the wrong context the *controller* would silently choose the target instead.
+  `Opponent` outside an activated *or* triggered ability, `TriggeringPlayer` /
+  `ControllerOfTriggeringEntity` outside a triggered one. In the wrong context the *controller* would silently choose the target instead.
 
 ### Player-target restrictions (`TargetPlayer.restriction` / `TargetOpponent.restriction`)
 
@@ -4314,6 +4328,17 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   `CastSpellTypesFromTopOfLibrary(GameObjectFilter.Any.sharingCardTypeWithLinkedExile(), maxCastsPerTurn = 1)`.
   The cost-side reading of the same pile is `CostReductionSource.SharedCardTypesWithLinkedExile`
   (Cemetery Prowler).
+- `.sharingNameWithLinkedExile()` — `CardPredicate.SharesNameWithLinkedExile`: **same name** as any card
+  still exiled with the filtering ability's source. The name axis of `.sharingCardTypeWithLinkedExile()`,
+  and pile-wide for the same reason: Circu, Dimir Lobotomist exiles on every blue *and* every black
+  spell you cast, so "a card exiled with Circu" is the whole pile and
+  `.sharingNameWith(EntityReference.LinkedExiledCard())` could only ever name one index of it. Printed
+  names on both sides — neither an exiled card nor a card in a hand or library has a battlefield
+  projection a Layer-3 rename could have touched. An empty pile matches nothing; no source in context
+  fails closed. Circu's third line is
+  `PlayersCantCastSpells(affected = Player.EachOpponent, spellFilter = GameObjectFilter.Any.sharingNameWithLinkedExile())`
+  — and note that a `PlayersCantCastSpells` filter is evaluated with the *granting permanent* as its
+  source, which is what makes any source-relative predicate usable there.
 - `.sharingColorWith(entity)` — `CardPredicate.SharesColorWith(entity)`: shares ≥1 (projected) color with
   a referenced entity (e.g. `EntityReference.Triggering`). Mirror of `.sharingCreatureTypeWith(entity)`.
   Colorless entities share no color (never match). Used by Spreading Plague ("destroy all other creatures

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -257,6 +257,13 @@ object Costs {
      */
     val RevealNotedCreatureType: AbilityCost = AbilityCost.Atom(CostAtom.RevealNotedCreatureType)
 
+    /**
+     * "Unattach this Equipment" (Sunforger) — detach the source from the permanent it is attached
+     * to, without moving zones (CR 701.3d). Only payable while it *is* attached, which is the whole
+     * of Sunforger's first ruling. See [CostAtom.Unattach].
+     */
+    val Unattach: AbilityCost = AbilityCost.Atom(CostAtom.Unattach)
+
     // =========================================================================
     // Exile Costs
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
@@ -648,6 +648,27 @@ sealed interface CostAtom : TextReplaceable<CostAtom> {
         override val description: String get() = "reveal the creature type you chose"
     }
 
+    /**
+     * Unattach the ability's source from the permanent it is attached to (CR 701.3d) — "Unattach
+     * this Equipment" (Sunforger). The cost twin of
+     * [com.wingedsheep.sdk.scripting.effects.UnattachEquipmentEffect]: the *effect* has existed for
+     * a while (Stolen Uniform's rider), the *cost* had not.
+     *
+     * Payable only while the source is actually attached to something, per Sunforger's own ruling
+     * ("You can't pay the cost of unattaching Sunforger unless Sunforger is attached to a
+     * creature") — which is what makes this a real cost rather than a free rider. It moves nothing
+     * between zones, so unlike sacrifice there is no last-known-information question, and unlike a
+     * tap cost there is nothing to restore.
+     *
+     * Ability-scoped: a spell on the stack is not attached to anything, so this is never a spell
+     * additional cost or a "unless you …" [com.wingedsheep.sdk.scripting.PayCost].
+     */
+    @SerialName("AtomUnattach")
+    @Serializable
+    data object Unattach : CostAtom {
+        override val description: String get() = "unattach this Equipment"
+    }
+
     /** Reveal [count] cards matching [filter] from your hand (the cards stay in hand). */
     @SerialName("AtomRevealFromHand")
     @Serializable

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtoms.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtoms.kt
@@ -55,6 +55,8 @@ fun CostAtom.repeated(times: Int): CostAtom {
         is CostAtom.RevealNotedCreatureType -> this
         // Emptying an already-empty hand is a cost of nothing, so paying it N times is one payment.
         is CostAtom.DiscardHand -> this
+        // Once unattached there is nothing left to detach, so N unattachments are one payment.
+        is CostAtom.Unattach -> this
         // Collecting evidence N twice is collecting evidence 2N: CR 601.2f folds the repeated cost
         // into one payment, and one exile of total mana value 2N satisfies that just as two
         // separate exiles of N would. (No printed card repeats it — escalate is the only caller —

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -706,6 +706,15 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.SharesCardTypeWithLinkedExile
     )
 
+    /**
+     * Must share a **name** with any card exiled with the filtering ability's source — "spells with
+     * the same name as a card exiled with Circu" (Circu, Dimir Lobotomist). The name axis of
+     * [sharingCardTypeWithLinkedExile]; see [CardPredicate.SharesNameWithLinkedExile].
+     */
+    fun sharingNameWithLinkedExile() = copy(
+        cardPredicates = cardPredicates + CardPredicate.SharesNameWithLinkedExile
+    )
+
     fun sharingCardTypeWith(entity: EntityReference) = copy(
         cardPredicates = cardPredicates + CardPredicate.SharesCardTypeWith(entity)
     )

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -983,6 +983,27 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         override val description: String = "that shares a card type with a card exiled with this permanent"
     }
 
+    /**
+     * Matches objects whose **name** equals that of **any** card exiled with the asking ability's
+     * source — "spells with the same name as a card exiled with Circu" (Circu, Dimir Lobotomist).
+     *
+     * The name axis of [SharesCardTypeWithLinkedExile], and the pile-wide form of
+     * [SharesNameWith]`(EntityReference.LinkedExiledCard())`, which reads one index. Circu exiles on
+     * every blue *and* every black spell you cast, so its pile grows without bound and "a card
+     * exiled with Circu" means any of them — an index can't say that.
+     *
+     * Printed names on both sides: a card in exile and a card in a hand/library have no battlefield
+     * projection whose name a Layer-3 effect could have changed, so this is a plain name comparison
+     * (the same reading [SharesCardTypeWithLinkedExile] takes for type lines). An empty pile — or
+     * one whose cards have all since left exile — matches nothing. Fails closed with no source in
+     * context.
+     */
+    @SerialName("SharesNameWithLinkedExile")
+    @Serializable
+    data object SharesNameWithLinkedExile : CardPredicate {
+        override val description: String = "with the same name as a card exiled with this permanent"
+    }
+
     /** Matches objects that share a color with the referenced entity */
     @SerialName("SharesColorWith")
     @Serializable

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
@@ -82,9 +82,9 @@ sealed interface TargetRequirement : TextReplaceable<TargetRequirement> {
     /**
      * Who selects this requirement's target(s). Defaults to [TargetChooser.Controller]; set to
      * [TargetChooser.Opponent] for "… of an opponent's choice" wording. See [TargetChooser].
-     * Currently honored at announcement for activated abilities (the only printed use, Cuombajj
-     * Witches); a requirement whose chooser is an opponent should appear after the
-     * controller-chosen requirements in a script.
+     * Honored at announcement by the activated-ability path (Cuombajj Witches) and the
+     * triggered-ability path (Mausoleum Turnkey); a requirement whose chooser is an opponent should
+     * appear after the controller-chosen requirements in a script.
      */
     val chooser: TargetChooser get() = TargetChooser.Controller
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -460,8 +460,9 @@ object CardLinter {
      * path, and in the wrong context the controller would silently choose the target instead — so
      * catch it at card load rather than mis-resolve:
      *
-     * - `Opponent` ("… of an opponent's choice") — activated abilities only, because routing it
-     *   needs the controller to first pick *which* opponent decides.
+     * - `Opponent` ("… of an opponent's choice") — activated *or* triggered abilities. Both
+     *   announcement paths pin the deciding opponent before raising the target decision (with more
+     *   than one opponent, the controller picks which); nothing else does.
      * - `TriggeringPlayer` / `ControllerOfTriggeringEntity` — triggered abilities only, because
      *   both are read off a trigger context that nothing else has.
      *
@@ -486,13 +487,14 @@ object CardLinter {
                 val chooser = (element["chooser"] as? JsonPrimitive)?.contentOrNull
                 if (type in CHOOSER_BEARING_TARGET_TYPES) {
                     val misplaced = when (chooser) {
-                        "Opponent" -> !withinActivatedAbility
+                        "Opponent" -> !withinActivatedAbility && !withinTriggeredAbility
                         "TriggeringPlayer", "ControllerOfTriggeringEntity" -> !withinTriggeredAbility
                         else -> false
                     }
                     if (misplaced) {
                         val expected =
-                            if (chooser == "Opponent") "an activated ability" else "a triggered ability"
+                            if (chooser == "Opponent") "an activated or triggered ability"
+                            else "a triggered ability"
                         // Name the printed wording, not just the enum: that is what lets an author
                         // recognise the clause they were modelling.
                         val wording = when (chooser) {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
@@ -310,10 +310,11 @@ sealed interface CardValidationError {
 
     /**
      * A `TargetChooser` target requirement in a context that doesn't route the selection to the
-     * named player. Each chooser is honored by exactly one announcement path — `Opponent` by
-     * activated abilities, `TriggeringPlayer` and `ControllerOfTriggeringEntity` by triggered ones
-     * — and anywhere else (a spell, a kicker target, a saga chapter) the controller would silently
-     * pick the target instead. Fail at card load rather than mis-resolve.
+     * named player. `Opponent` is honored by the activated- and triggered-ability announcement
+     * paths (both pin the deciding opponent before raising the decision); `TriggeringPlayer` and
+     * `ControllerOfTriggeringEntity` by triggered ones only. Anywhere else (a spell, a kicker
+     * target, a saga chapter) the controller would silently pick the target instead. Fail at card
+     * load rather than mis-resolve.
      */
     data class UnsupportedOpponentChooser(
         override val cardName: String,

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardLinterTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardLinterTest.kt
@@ -349,7 +349,10 @@ class CardLinterTest : DescribeSpec({
                 .message shouldContain "opponent's choice"
         }
 
-        it("flags a TargetChooser.Opponent target on a triggered ability") {
+        // Mausoleum Turnkey ("return target creature card of an opponent's choice from your
+        // graveyard to your hand") is the printed triggered use, and the trigger announcement path
+        // now pins the deciding opponent exactly as the activated one does.
+        it("accepts a TargetChooser.Opponent target on a triggered ability (Mausoleum Turnkey)") {
             val card = instant(
                 "Triggered Opponent-Chosen",
                 CardScript(
@@ -363,8 +366,8 @@ class CardLinterTest : DescribeSpec({
                     ),
                 ),
             )
-            val findings = CardLinter.lint(card)
-            findings.filterIsInstance<CardValidationError.UnsupportedOpponentChooser>().shouldHaveSize(1)
+            CardLinter.lint(card).filterIsInstance<CardValidationError.UnsupportedOpponentChooser>()
+                .shouldBeEmpty()
         }
 
         it("accepts a TargetChooser.Opponent target on an activated ability (Cuombajj Witches)") {

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CostAtomSerializationTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CostAtomSerializationTest.kt
@@ -51,6 +51,7 @@ class CostAtomSerializationTest : FunSpec({
         CostAtom.CollectEvidence(CostAtom.CollectEvidence.TARGET_SUM),
         CostAtom.RevealNotedCreatureType,
         CostAtom.DiscardHand,
+        CostAtom.Unattach,
         CostAtom.ExileFromGraveyardForTotal(
             filter = GameObjectFilter.Any.withColor(Color.BLACK),
             measure = CardMeasure.ColoredManaSymbols(listOf(Color.BLACK)),

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/CircuDimirLobotomist.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/CircuDimirLobotomist.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PlayersCantCastSpells
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Circu, Dimir Lobotomist — Ravnica: City of Guilds #196
+ * {2}{U}{B} · Legendary Creature — Human Wizard · Rare · 2/3
+ *
+ * Whenever you cast a blue spell, exile the top card of target player's library.
+ * Whenever you cast a black spell, exile the top card of target player's library.
+ * Your opponents can't cast spells with the same name as a card exiled with Circu.
+ *
+ * Modelling notes:
+ * - **Two separate triggered abilities, not one with an "or" filter.** A blue *and* black spell
+ *   fires both (the 2005-10-01 ruling), and each picks its own target — a filter reading
+ *   "blue or black" would fire once and exile one card. Writing them as two abilities is what
+ *   makes "you can target two different players or target the same player twice" fall out.
+ * - The exile is a **linked** one (CR 607): `linkToSource = true` files each card against this
+ *   permanent so the static below can read the whole pile. That is also why a replacement Circu
+ *   does not inherit the old one's exiles.
+ * - The prohibition is the reused [PlayersCantCastSpells] static scoped to `EachOpponent` — the
+ *   card is not symmetric, per its own ruling that the last ability applies to all of its
+ *   controller's opponents rather than to the owner of the exiled card.
+ * - **New SDK vocabulary:** `CardPredicate.SharesNameWithLinkedExile`, reached here through
+ *   `GameObjectFilter.Any.sharingNameWithLinkedExile()`. It is the *name* axis of the existing
+ *   `SharesCardTypeWithLinkedExile` (Cemetery Illuminator) and, like it, has to be pile-wide:
+ *   `sharingNameWith(EntityReference.LinkedExiledCard())` reads exactly one index, and Circu's
+ *   pile grows on every blue and every black spell you cast, so no index names "a card exiled
+ *   with Circu". Comparing printed names is correct on both sides — neither an exiled card nor a
+ *   card in a hand or library has a battlefield projection a Layer-3 rename could have touched.
+ * - Split cards: the ruling says exiling one half locks out both. Our `CardComponent.name` for a
+ *   split card is the full "A // B" string, so a split card exiled this way blocks casting either
+ *   half only insofar as the halves share that name — an approximation the corpus can't currently
+ *   improve on, and one no RAV-era card exercises (no split cards are legal alongside it in
+ *   Standard-era play).
+ */
+val CircuDimirLobotomist = card("Circu, Dimir Lobotomist") {
+    manaCost = "{2}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Human Wizard"
+    oracleText = "Whenever you cast a blue spell, exile the top card of target player's library.\n" +
+        "Whenever you cast a black spell, exile the top card of target player's library.\n" +
+        "Your opponents can't cast spells with the same name as a card exiled with Circu."
+    power = 2
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(Color.BLUE))
+        target("target player", TargetPlayer())
+        effect = exileTopOfTargetPlayersLibrary("circuBlueExile")
+    }
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(Color.BLACK))
+        target("target player", TargetPlayer())
+        effect = exileTopOfTargetPlayersLibrary("circuBlackExile")
+    }
+
+    staticAbility {
+        ability = PlayersCantCastSpells(
+            affected = Player.EachOpponent,
+            spellFilter = GameObjectFilter.Any.sharingNameWithLinkedExile()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "196"
+        artist = "Cyril Van Der Haegen"
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0b19c0f3-68a5-4544-985a-677aa2c2b50b.jpg?1783943626"
+
+        ruling(
+            "2005-10-01",
+            "If you cast a blue and black spell, both of Circu's triggered abilities trigger. " +
+                "You can target two different players or target the same player twice."
+        )
+        ruling(
+            "2005-10-01",
+            "Circu's last ability applies to all of its controller's opponents, not just the " +
+                "owner of the exiled card."
+        )
+        ruling(
+            "2005-10-01",
+            "If a split card is exiled this way, opponents can't cast either half of the split card."
+        )
+    }
+}
+
+/**
+ * "Exile the top card of target player's library", filed against Circu so the cast prohibition can
+ * read it. A gather → move pair rather than a bespoke effect; an empty library gathers nothing and
+ * the move is a no-op, which is the card's own behaviour.
+ */
+private fun exileTopOfTargetPlayersLibrary(slot: String) = Effects.Composite(
+    GatherCardsEffect(
+        source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1), Player.TargetPlayer),
+        storeAs = slot
+    ),
+    MoveCollectionEffect(
+        from = slot,
+        destination = CardDestination.ToZone(Zone.EXILE),
+        linkToSource = true
+    )
+)

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/MausoleumTurnkey.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/MausoleumTurnkey.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetChooser
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Mausoleum Turnkey — Ravnica: City of Guilds #94
+ * {3}{B} · Creature — Ogre Rogue · Uncommon · 3/2
+ *
+ * When this creature enters, return target creature card of an opponent's choice from your
+ * graveyard to your hand.
+ *
+ * Modelling notes:
+ * - The whole card is one enters trigger over the existing `Effects.ReturnToHand`. The only new
+ *   thing is **who picks the target**: `TargetChooser.Opponent` existed and was honored on
+ *   *activated* abilities only (Cuombajj Witches), with `CardLinter` failing any card that put it
+ *   on a triggered one. This card is the printed triggered use, so the trigger path now pins the
+ *   deciding opponent the same way the activated path does.
+ * - The chooser is **orthogonal to legality** (see `TargetChooser`): the legal targets are still
+ *   found relative to *this* card's controller, so "from your graveyard" stays your graveyard. The
+ *   opponent only picks which of those cards comes back — which is the whole point of the card, and
+ *   why it can't be modelled as an opponent-controlled effect.
+ * - Mandatory, not "may": with a creature card in your graveyard the trigger goes on the stack and
+ *   an opponent must name one. With none, no legal target exists and the trigger is removed from
+ *   the stack (CR 603.3d) — nothing to decline.
+ * - With three or more opponents the controller first picks *which* opponent decides, then that
+ *   opponent picks the card. In a two-player game the engine skips straight to the only opponent.
+ */
+val MausoleumTurnkey = card("Mausoleum Turnkey") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Ogre Rogue"
+    oracleText = "When this creature enters, return target creature card of an opponent's choice " +
+        "from your graveyard to your hand."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "target creature card of an opponent's choice from your graveyard",
+            TargetObject(
+                filter = TargetFilter.CreatureInYourGraveyard,
+                chooser = TargetChooser.Opponent
+            )
+        )
+        effect = Effects.ReturnToHand(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "94"
+        artist = "Darrell Riche"
+        flavorText = "When he reaches for his key ring, you should be running for the exit."
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/51b6dc7d-fc8a-4842-bf30-3dc9fec708c4.jpg?1783943667"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Sunforger.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Sunforger.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sunforger — Ravnica: City of Guilds #272
+ * {3} · Artifact — Equipment · Rare
+ *
+ * Equipped creature gets +4/+0.
+ * {R}{W}, Unattach this Equipment: Search your library for a red or white instant card with mana
+ * value 4 or less and cast that card without paying its mana cost. Then shuffle.
+ * Equip {3}
+ *
+ * Modelling notes:
+ * - **New SDK vocabulary: `CostAtom.Unattach`** (`Costs.Unattach`). The *effect*
+ *   `UnattachEquipmentEffect` already existed for "unattach it" riders; the *cost* did not, and it
+ *   is not a lookalike of any existing atom — a sacrifice moves zones, a tap can be restored, and
+ *   this does neither. Its affordability gate is the card's own 2020-08-07 ruling: "You can't pay
+ *   the cost of unattaching Sunforger unless Sunforger is attached to a creature", so the ability
+ *   is not even offered while it sits unattached. Payment runs through the same
+ *   `ZoneMovementUtils.unattachEmittingEvent` chokepoint as the effect, so a "becomes unattached"
+ *   trigger cannot tell the two apart.
+ * - The activated ability is at **instant speed** — the whole point of the card, and what
+ *   `activatedAbility` gives by default. Unattaching mid-combat is legal and is how the card is
+ *   played; nothing about the cost implies the sorcery timing that `equipAbility` carries.
+ * - The search is the ordinary Gather → Select → cast pipeline rather than
+ *   `Patterns.Library.searchLibrary`, because that helper's `SearchDestination` vocabulary has no
+ *   "cast it" case — hand / battlefield / graveyard / top of library are all it can reach.
+ *   `ChooseUpTo(1)` rather than `ChooseExactly(1)` is the "search … and cast" reading every such
+ *   card gets: a search may always fail to find (CR 701.19c).
+ * - **Shuffle before the cast, not after.** The printed order is "cast that card … Then shuffle",
+ *   but the two are order-independent here: the found card is already held in a pipeline
+ *   collection, and `CastFromCollectionWithoutPayingCost` re-finds its current zone, so shuffling
+ *   with it still in the library and then pulling it out reaches the same state as the reverse.
+ *   Doing it in this order keeps the shuffle from having to survive the pause the cast opens for
+ *   the spell's own targets. `Patterns.Library.searchLibrary` takes the same liberty for its
+ *   top-of-library destination.
+ * - Casting "without paying its mana cost" carries the printed rulings for free: no alternative
+ *   costs, mandatory additional costs still owed, and X = 0 — all of them properties of
+ *   [CastFromCollectionWithoutPayingCostEffect] rather than of this card.
+ */
+val Sunforger = card("Sunforger") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +4/+0.\n" +
+        "{R}{W}, Unattach this Equipment: Search your library for a red or white instant card " +
+        "with mana value 4 or less and cast that card without paying its mana cost. Then shuffle.\n" +
+        "Equip {3}"
+
+    staticAbility {
+        ability = ModifyStats(4, 0)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}{W}"), Costs.Unattach)
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.FromZone(
+                    Zone.LIBRARY,
+                    Player.You,
+                    GameObjectFilter.Instant
+                        .withAnyColor(Color.RED, Color.WHITE)
+                        .manaValueAtMost(4)
+                ),
+                storeAs = "sunforgerSearch"
+            ),
+            SelectFromCollectionEffect(
+                from = "sunforgerSearch",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                storeSelected = "sunforgerFound",
+                prompt = "Search for a red or white instant card with mana value 4 or less to " +
+                    "cast without paying its mana cost"
+            ),
+            ShuffleLibraryEffect(),
+            CastFromCollectionWithoutPayingCostEffect(from = "sunforgerFound")
+        )
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "272"
+        artist = "Darrell Riche"
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c8d5e027-aa74-444b-a945-1bafa9bdec4c.jpg?1783943594"
+
+        ruling(
+            "2020-08-07",
+            "You can't pay the cost of unattaching Sunforger unless Sunforger is attached to a creature."
+        )
+        ruling(
+            "2020-08-07",
+            "If you cast a spell \"without paying its mana cost,\" you can't choose to cast it for " +
+                "any alternative costs. You can, however, pay additional costs. If the card has " +
+                "any mandatory additional costs, those must be paid to cast the spell."
+        )
+        ruling(
+            "2020-08-07",
+            "If a spell has {X} in its mana cost, you must choose 0 as the value of X when casting " +
+                "it without paying its mana cost."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CircuDimirLobotomistScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CircuDimirLobotomistScenarioTest.kt
@@ -1,0 +1,224 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.mtg.sets.definitions.rav.cards.CircuDimirLobotomist
+import com.wingedsheep.mtg.sets.definitions.rav.cards.DimirCutpurse
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Circu, Dimir Lobotomist (RAV #196) — two "whenever you cast a blue/black spell" triggers that
+ * exile the top card of target player's library, plus "Your opponents can't cast spells with the
+ * same name as a card exiled with Circu."
+ *
+ * The new vocabulary is `CardPredicate.SharesNameWithLinkedExile` — the *pile-wide* name predicate,
+ * the name axis of `SharesCardTypeWithLinkedExile` (Cemetery Illuminator). What these tests pin:
+ *
+ * - the pile is read **whole**, not at one index: a second exile has to lock out a second name
+ *   while the first stays locked (an `EntityReference.LinkedExiledCard()` index could only ever
+ *   name one of them);
+ * - the prohibition is **opponents-only**, per the card's own second ruling — the controller can
+ *   still cast a same-named card;
+ * - a blue *and* black spell fires **both** triggers, per the first ruling;
+ * - the lock is tied to *this* Circu: it lifts when the permanent leaves the battlefield.
+ *
+ * The last one is also the regression that matters for the engine change: the prohibition is read
+ * through `CastPermissionUtils.blockedByPlayersCantCastSpells`, which had been building its
+ * `PredicateContext` with no `sourceId` at all — so a source-relative spell filter in a
+ * `PlayersCantCastSpells` static could only ever fail closed.
+ */
+class CircuDimirLobotomistScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + CircuDimirLobotomist + DimirCutpurse)
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /**
+     * Casts [spellName] from [caster]'s hand and points Circu's resulting trigger at [victim],
+     * then drains the stack. The trigger's target is a player and there are two legal ones, so the
+     * decision is always raised rather than auto-selected.
+     */
+    fun GameTestDriver.castAndExileTopOf(caster: EntityId, spellName: String, victim: EntityId) {
+        val card = putCardInHand(caster, spellName)
+        giveMana(caster, Color.BLUE, 2)
+        giveMana(caster, Color.BLACK, 2)
+        giveMana(caster, Color.RED, 2)
+        giveColorlessMana(caster, 2)
+        castSpell(caster, card).error shouldBe null
+
+        var guard = 0
+        while (guard++ < 20) {
+            val decision = pendingDecision
+            if (decision is ChooseTargetsDecision) {
+                submitTargetSelection(decision.playerId, listOf(victim))
+                continue
+            }
+            if (decision != null) error("unexpected decision: $decision")
+            if (stackSize == 0) break
+            bothPass()
+        }
+    }
+
+    test("a card exiled with Circu can't be cast by an opponent, but can by its controller") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+
+        d.putPermanentOnBattlefield(me, "Circu, Dimir Lobotomist")
+        d.putCardOnTopOfLibrary(opp, "Lightning Bolt")
+
+        d.castAndExileTopOf(me, "Phantom Warrior", opp)
+
+        withClue("the opponent's top card was exiled") {
+            d.getExileCardNames(opp) shouldBe listOf("Lightning Bolt")
+        }
+
+        // The opponent holds their own copy of the exiled card. Lightning Bolt is an instant, so
+        // sorcery timing isn't what's stopping them — only the prohibition is.
+        val oppBolt = d.putCardInHand(opp, "Lightning Bolt")
+        val oppGrowth = d.putCardInHand(opp, "Giant Growth")
+        d.giveMana(opp, Color.RED, 3)
+        d.giveMana(opp, Color.GREEN, 3)
+
+        val blocked = d.submit(
+            CastSpell(
+                playerId = opp,
+                cardId = oppBolt,
+                targets = listOf(ChosenTarget.Player(me)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        withClue("an opponent can't cast a spell sharing a name with a card exiled with Circu") {
+            (blocked.error != null) shouldBe true
+        }
+
+        withClue("a differently-named spell is untouched") {
+            d.legalActions(opp).any { legal ->
+                val action = legal.action
+                action is CastSpell && action.cardId == oppGrowth
+            } shouldBe true
+        }
+        withClue("the blocked spell is not even offered") {
+            d.legalActions(opp).any { legal ->
+                val action = legal.action
+                action is CastSpell && action.cardId == oppBolt
+            } shouldBe false
+        }
+
+        // "…applies to all of its controller's opponents, not just the owner of the exiled card"
+        // — and, by the same token, not to the controller.
+        val myBolt = d.putCardInHand(me, "Lightning Bolt")
+        d.giveMana(me, Color.RED, 3)
+        withClue("the controller is not affected by their own Circu") {
+            d.castSpell(me, myBolt, listOf(opp)).error shouldBe null
+        }
+    }
+
+    test("the pile is read whole — a second exile locks a second name without unlocking the first") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+
+        d.putPermanentOnBattlefield(me, "Circu, Dimir Lobotomist")
+        d.putCardOnTopOfLibrary(opp, "Lightning Bolt")
+
+        d.castAndExileTopOf(me, "Phantom Warrior", opp)
+        // Second exile, a different name. An index-based "the card exiled with ~" would now name
+        // only one of the two.
+        d.putCardOnTopOfLibrary(opp, "Counterspell")
+        d.castAndExileTopOf(me, "Black Creature", opp)
+
+        withClue("both cards are in the linked pile") {
+            d.getExileCardNames(opp).toSet() shouldBe setOf("Lightning Bolt", "Counterspell")
+        }
+
+        val oppBolt = d.putCardInHand(opp, "Lightning Bolt")
+        val oppCounter = d.putCardInHand(opp, "Counterspell")
+        d.giveMana(opp, Color.RED, 3)
+        d.giveMana(opp, Color.BLUE, 3)
+
+        val offered = d.legalActions(opp)
+            .mapNotNull { (it.action as? CastSpell)?.cardId }
+        withClue("the first exiled name is still locked") { offered.contains(oppBolt) shouldBe false }
+        withClue("the second exiled name is locked too") { offered.contains(oppCounter) shouldBe false }
+    }
+
+    test("a blue and black spell fires both triggers, and each picks its own target") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+
+        d.putPermanentOnBattlefield(me, "Circu, Dimir Lobotomist")
+        d.putCardOnTopOfLibrary(opp, "Lightning Bolt")
+        d.putCardOnTopOfLibrary(me, "Giant Growth")
+
+        // Dimir Cutpurse is {1}{U}{B} — blue *and* black, so both triggers go on the stack. They
+        // are pointed at different players, which is the printed ruling's other half. (A second
+        // Circu would do the same job and then drag the legend rule into the test.)
+        val card = d.putCardInHand(me, "Dimir Cutpurse")
+        d.giveMana(me, Color.BLUE, 2)
+        d.giveMana(me, Color.BLACK, 2)
+        d.giveColorlessMana(me, 2)
+        d.castSpell(me, card).error shouldBe null
+
+        val victims = mutableListOf(opp, me)
+        var guard = 0
+        while (guard++ < 20) {
+            val decision = d.pendingDecision
+            if (decision is ChooseTargetsDecision) {
+                d.submitTargetSelection(decision.playerId, listOf(victims.removeAt(0)))
+                continue
+            }
+            if (decision != null) error("unexpected decision: $decision")
+            if (d.stackSize == 0) break
+            d.bothPass()
+        }
+
+        withClue("both triggers resolved — one exile in each library's owner's exile zone") {
+            d.getExileCardNames(opp) shouldBe listOf("Lightning Bolt")
+            d.getExileCardNames(me) shouldBe listOf("Giant Growth")
+        }
+    }
+
+    test("the lock lifts when Circu leaves the battlefield") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+
+        val circu = d.putPermanentOnBattlefield(me, "Circu, Dimir Lobotomist")
+        d.putCardOnTopOfLibrary(opp, "Lightning Bolt")
+        d.castAndExileTopOf(me, "Phantom Warrior", opp)
+
+        val oppBolt = d.putCardInHand(opp, "Lightning Bolt")
+        d.giveMana(opp, Color.RED, 3)
+        withClue("locked while Circu is out") {
+            d.legalActions(opp).any { legal ->
+                val action = legal.action
+                action is CastSpell && action.cardId == oppBolt
+            } shouldBe false
+        }
+
+        d.moveToGraveyard(circu)
+
+        withClue("the static is gone with the permanent that printed it") {
+            d.legalActions(opp).any { legal ->
+                val action = legal.action
+                action is CastSpell && action.cardId == oppBolt
+            } shouldBe true
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MausoleumTurnkeyScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MausoleumTurnkeyScenarioTest.kt
@@ -1,0 +1,160 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.MausoleumTurnkey
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Mausoleum Turnkey (RAV #94) — "When this creature enters, return target creature card of an
+ * opponent's choice from your graveyard to your hand."
+ *
+ * `TargetChooser.Opponent` already existed but was honored on *activated* abilities only (Cuombajj
+ * Witches); `CardLinter` failed any card that put it on a triggered one, and
+ * `TriggerProcessor.resolveTargetChooser` mapped it to the controller on purpose. This is the
+ * printed triggered use. What these tests pin:
+ *
+ * - the target decision is raised for the **opponent**, not the controller;
+ * - the chooser is **orthogonal to legality** — the legal pool is still *your* graveyard, and the
+ *   card comes back to *your* hand, so an opponent cannot fish out of their own graveyard;
+ * - a graveyard with no creature card leaves the trigger with no legal target, and it never reaches
+ *   the stack (CR 603.3d) — nobody is asked anything;
+ * - in multiplayer the controller first picks *which* opponent decides, mirroring the
+ *   activated-ability path.
+ */
+class MausoleumTurnkeyScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + MausoleumTurnkey)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    test("the enters trigger routes its target decision to the opponent") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+
+        val lions = d.putCardInGraveyard(me, "Savannah Lions")
+        val courser = d.putCardInGraveyard(me, "Centaur Courser")
+        val theirs = d.putCardInGraveyard(opp, "Phantom Warrior")
+
+        val card = d.putCardInHand(me, "Mausoleum Turnkey")
+        d.giveColorlessMana(me, 3)
+        d.giveMana(me, Color.BLACK, 1)
+        d.castSpell(me, card).error shouldBe null
+        var guard = 0
+        while (d.pendingDecision == null && d.stackSize > 0 && guard++ < 10) d.bothPass()
+
+        val decision = d.pendingDecision
+        withClue("a target decision was raised: $decision") {
+            (decision is ChooseTargetsDecision) shouldBe true
+        }
+        decision as ChooseTargetsDecision
+        withClue("…and the opponent is the one answering it") { decision.playerId shouldBe opp }
+        withClue("the pool is the controller's graveyard, not the chooser's") {
+            decision.legalTargets[0]?.toSet() shouldBe setOf(lions, courser)
+        }
+        withClue("the opponent's own creature card is not on offer") {
+            decision.legalTargets[0]?.contains(theirs) shouldBe false
+        }
+
+        // The opponent picks the weaker one, which is the whole point of the drawback.
+        d.submitDecision(
+            opp,
+            TargetsResponse(decision.id, mapOf(0 to listOf(lions)))
+        ).error shouldBe null
+        guard = 0
+        while (d.stackSize > 0 && guard++ < 10) d.bothPass()
+
+        withClue("it returns to the controller's hand, not the chooser's") {
+            d.findCardInHand(me, "Savannah Lions") shouldBe lions
+            d.findCardInHand(opp, "Savannah Lions") shouldBe null
+        }
+        withClue("the card the opponent declined stays in the graveyard") {
+            d.getGraveyardCardNames(me).contains("Centaur Courser") shouldBe true
+        }
+    }
+
+    test("an empty graveyard leaves no legal target, so nobody is asked") {
+        val d = driver()
+        val me = d.player1
+        // Only a non-creature card in the graveyard.
+        d.putCardInGraveyard(me, "Lightning Bolt")
+        d.putCardInGraveyard(d.player2, "Phantom Warrior")
+
+        val card = d.putCardInHand(me, "Mausoleum Turnkey")
+        d.giveColorlessMana(me, 3)
+        d.giveMana(me, Color.BLACK, 1)
+        d.castSpell(me, card).error shouldBe null
+        var guard = 0
+        while (d.stackSize > 0 && guard++ < 10) {
+            withClue("no decision should be raised at all") { d.pendingDecision shouldBe null }
+            d.bothPass()
+        }
+
+        withClue("the Turnkey still resolved as a creature") {
+            d.findPermanent(me, "Mausoleum Turnkey") shouldNotBe null
+        }
+    }
+
+    test("with two opponents the controller picks which one decides") {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + MausoleumTurnkey)
+        val players = d.initMultiplayer(
+            decks = List(3) { Deck.of("Swamp" to 40) },
+            skipMulligans = true,
+            startingPlayer = 0
+        )
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = players[0]
+        val second = players[2]
+
+        val lions = d.putCardInGraveyard(me, "Savannah Lions")
+        d.putCardInGraveyard(me, "Centaur Courser")
+
+        val card = d.putCardInHand(me, "Mausoleum Turnkey")
+        d.giveColorlessMana(me, 3)
+        d.giveMana(me, Color.BLACK, 1)
+        d.castSpell(me, card).error shouldBe null
+        var guard = 0
+        while (d.pendingDecision == null && d.stackSize > 0 && guard++ < 20) d.passPriority(d.state.priorityPlayerId!!)
+
+        val chooserPick = d.pendingDecision
+        withClue("the controller is asked which opponent decides: $chooserPick") {
+            (chooserPick is ChooseOptionDecision) shouldBe true
+            (chooserPick as ChooseOptionDecision).playerId shouldBe me
+            chooserPick.options.size shouldBe 2
+        }
+        // Pick the second opponent — proving the answer is honored rather than defaulted.
+        d.submitDecision(
+            me,
+            OptionChosenResponse((chooserPick as ChooseOptionDecision).id, 1)
+        ).error shouldBe null
+
+        val targets = d.pendingDecision
+        withClue("the chosen opponent now answers the target decision: $targets") {
+            (targets is ChooseTargetsDecision) shouldBe true
+            (targets as ChooseTargetsDecision).playerId shouldBe second
+        }
+        d.submitDecision(
+            second,
+            TargetsResponse(
+                (targets as ChooseTargetsDecision).id,
+                mapOf(0 to listOf(lions))
+            )
+        ).error shouldBe null
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SunforgerScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SunforgerScenarioTest.kt
@@ -1,0 +1,146 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.Sunforger
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sunforger (RAV #272) — "{R}{W}, Unattach this Equipment: Search your library for a red or white
+ * instant card with mana value 4 or less and cast that card without paying its mana cost. Then
+ * shuffle."
+ *
+ * The new vocabulary is `CostAtom.Unattach` (`Costs.Unattach`), and its whole point is that it is a
+ * *cost* with a real affordability gate rather than a free rider on the effect. What these tests
+ * pin:
+ *
+ * - "You can't pay the cost of unattaching Sunforger unless Sunforger is attached to a creature"
+ *   (the printed 2020-08-07 ruling) — the ability is not offered at all while it sits unattached,
+ *   even with the mana in hand;
+ * - paying it actually detaches, and the +4/+0 it was granting goes with it;
+ * - the search pool honours the card's filter (a red or white instant of mana value 4 or less, not
+ *   any instant and not a sorcery), and the found card is cast for free.
+ */
+class SunforgerScenarioTest : FunSpec({
+
+    val forgeAbility = Sunforger.activatedAbilities[0].id
+    val equipAbility = Sunforger.activatedAbilities[1].id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + Sunforger)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** Puts Sunforger and [creatureName] on player 1's battlefield and equips them. */
+    fun GameTestDriver.equipTo(creatureName: String): Pair<EntityId, EntityId> {
+        val forger = putPermanentOnBattlefield(player1, "Sunforger")
+        val creature = putCreatureOnBattlefield(player1, creatureName)
+        giveColorlessMana(player1, 3)
+        submit(
+            ActivateAbility(
+                playerId = player1,
+                sourceId = forger,
+                abilityId = equipAbility,
+                targets = listOf(ChosenTarget.Permanent(creature))
+            )
+        ).error shouldBe null
+        bothPass()
+        state.getEntity(forger)?.get<AttachedToComponent>()?.targetId shouldBe creature
+        return forger to creature
+    }
+
+    test("the ability isn't offered while Sunforger is unattached, even with the mana available") {
+        val d = driver()
+        val forger = d.putPermanentOnBattlefield(d.player1, "Sunforger")
+        d.giveMana(d.player1, Color.RED, 1)
+        d.giveMana(d.player1, Color.WHITE, 1)
+
+        withClue("nothing is attached, so the unattach cost can't be paid and the client greys it out") {
+            d.legalActions(d.player1).single { legal ->
+                val action = legal.action
+                action is ActivateAbility && action.abilityId == forgeAbility
+            }.affordable shouldBe false
+        }
+        withClue("and the engine refuses the activation outright") {
+            (d.submit(ActivateAbility(d.player1, forger, forgeAbility)).error != null) shouldBe true
+        }
+    }
+
+    test("paying the cost detaches Sunforger and casts the found instant for free") {
+        val d = driver()
+        val (forger, bear) = d.equipTo("Centaur Courser") // 3/3
+
+        withClue("+4/+0 while attached") {
+            d.state.projectedState.getPower(bear) shouldBe 7
+        }
+
+        // A legal find, plus two cards the filter must reject: a blue instant and a red sorcery.
+        d.putCardOnTopOfLibrary(d.player1, "Counterspell")
+        d.putCardOnTopOfLibrary(d.player1, "Doom Blade")
+        val bolt = d.putCardOnTopOfLibrary(d.player1, "Lightning Bolt")
+
+        d.giveMana(d.player1, Color.RED, 1)
+        d.giveMana(d.player1, Color.WHITE, 1)
+        d.submit(ActivateAbility(d.player1, forger, forgeAbility)).error shouldBe null
+        d.bothPass()
+
+        val search = d.pendingDecision
+        withClue("the search decision is raised: $search") { (search is SelectCardsDecision) shouldBe true }
+        withClue("only the red-or-white instant of mana value 4 or less is on offer") {
+            (search as SelectCardsDecision).options shouldBe listOf(bolt)
+        }
+        d.submitCardSelection(d.player1, listOf(bolt)).error shouldBe null
+
+        // Cast without paying its mana cost — the Bolt still needs a target.
+        d.submitTargetSelection(d.player1, listOf(d.player2)).error shouldBe null
+        var guard = 0
+        while (d.stackSize > 0 && guard++ < 10) d.bothPass()
+
+        withClue("the free Bolt resolved") { d.getLifeTotal(d.player2) shouldBe 17 }
+        withClue("the unattach cost was really paid") {
+            d.state.getEntity(forger)?.get<AttachedToComponent>()?.targetId shouldBe null
+        }
+        withClue("so the +4/+0 is gone with it") {
+            d.state.projectedState.getPower(bear) shouldBe 3
+        }
+        withClue("Sunforger itself never left the battlefield — unattaching moves no zones") {
+            d.findPermanent(d.player1, "Sunforger") shouldBe forger
+        }
+    }
+
+    test("a library with nothing the filter admits finds nothing and still unattaches") {
+        val d = driver()
+        val (forger, _) = d.equipTo("Centaur Courser")
+        d.putCardOnTopOfLibrary(d.player1, "Counterspell")
+
+        d.giveMana(d.player1, Color.RED, 1)
+        d.giveMana(d.player1, Color.WHITE, 1)
+        d.submit(ActivateAbility(d.player1, forger, forgeAbility)).error shouldBe null
+        d.bothPass()
+
+        var guard = 0
+        while (d.pendingDecision != null && guard++ < 5) {
+            d.submitCardSelection(d.player1, emptyList()).error shouldBe null
+        }
+
+        withClue("a search may always fail to find (CR 701.19c) — nothing was cast") {
+            d.getLifeTotal(d.player2) shouldBe 20
+        }
+        withClue("the cost was still paid: costs are paid before the effect does anything") {
+            d.state.getEntity(forger)?.get<AttachedToComponent>()?.targetId shouldBe null
+        }
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/SunforgerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/SunforgerReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunforger reprint in Commander 2016. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `rav` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SunforgerReprint = Printing(
+    oracleId = "d1421070-a3cc-4af3-bf91-0f97372f4161",
+    name = "Sunforger",
+    setCode = "C16",
+    collectorNumber = "275",
+    scryfallId = "0f9a9654-edf1-486f-a002-57418f03de8e",
+    artist = "Darrell Riche",
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0f9a9654-edf1-486f-a002-57418f03de8e.jpg?1783937033",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/SunforgerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/SunforgerReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunforger reprint in Commander Legends. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `rav` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SunforgerReprint = Printing(
+    oracleId = "d1421070-a3cc-4af3-bf91-0f97372f4161",
+    name = "Sunforger",
+    setCode = "CMR",
+    collectorNumber = "473",
+    scryfallId = "dd3e42ee-ab13-460b-90fd-86e677abce4f",
+    artist = "Darrell Riche",
+    imageUri = "https://cards.scryfall.io/normal/front/d/d/dd3e42ee-ab13-460b-90fd-86e677abce4f.jpg?1783928686",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MausoleumTurnkeyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MausoleumTurnkeyReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mausoleum Turnkey reprint in Jumpstart. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `rav` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val MausoleumTurnkeyReprint = Printing(
+    oracleId = "d4a61685-7149-4d14-bc17-85b060945687",
+    name = "Mausoleum Turnkey",
+    setCode = "JMP",
+    collectorNumber = "255",
+    scryfallId = "f7b6e993-1988-4b6d-970e-be71d95cf21a",
+    artist = "Darrell Riche",
+    imageUri = "https://cards.scryfall.io/normal/front/f/7/f7b6e993-1988-4b6d-970e-be71d95cf21a.jpg?1783930417",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -1772,6 +1772,146 @@
     ]
 }
 
+// Circu, Dimir Lobotomist
+{
+    "name": "Circu, Dimir Lobotomist",
+    "manaCost": "{2}{U}{B}",
+    "typeLine": "Legendary Creature — Human Wizard",
+    "oracleText": "Whenever you cast a blue spell, exile the top card of target player's library.\nWhenever you cast a black spell, exile the top card of target player's library.\nYour opponents can't cast spells with the same name as a card exiled with Circu.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "BLUE"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "player": "TargetPlayer"
+                            },
+                            "storeAs": "circuBlueExile"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "circuBlueExile",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "BLACK"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "player": "TargetPlayer"
+                            },
+                            "storeAs": "circuBlackExile"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "circuBlackExile",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "PlayersCantCastSpells",
+                "spellFilter": {
+                    "cardPredicates": [
+                        "SharesNameWithLinkedExile"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "196",
+        "rarity": "RARE",
+        "artist": "Cyril Van Der Haegen",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b19c0f3-68a5-4544-985a-677aa2c2b50b.jpg?1783943626",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "If you cast a blue and black spell, both of Circu's triggered abilities trigger. You can target two different players or target the same player twice."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "Circu's last ability applies to all of its controller's opponents, not just the owner of the exiled card."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "If a split card is exiled this way, opponents can't cast either half of the split card."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Civic Wayfinder
 {
     "name": "Civic Wayfinder",
@@ -8677,6 +8817,56 @@
     ]
 }
 
+// Mausoleum Turnkey
+{
+    "name": "Mausoleum Turnkey",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Ogre Rogue",
+    "oracleText": "When this creature enters, return target creature card of an opponent's choice from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card of an opponent's choice from your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card of an opponent's choice from your graveyard",
+                    "chooser": "Opponent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "rarity": "UNCOMMON",
+        "artist": "Darrell Riche",
+        "flavorText": "When he reaches for his key ring, you should be running for the exit.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/1/51b6dc7d-fc8a-4842-bf30-3dc9fec708c4.jpg?1783943667"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Mindmoil
 {
     "name": "Mindmoil",
@@ -13163,6 +13353,126 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Sunforger
+{
+    "name": "Sunforger",
+    "manaCost": "{3}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +4/+0.\n{R}{W}, Unattach this Equipment: Search your library for a red or white instant card with mana value 4 or less and cast that card without paying its mana cost. Then shuffle.\nEquip {3}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}{W}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomUnattach"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "instant red|white mv<=4"
+                            },
+                            "storeAs": "sunforgerSearch"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "sunforgerSearch",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "sunforgerFound",
+                            "prompt": "Search for a red or white instant card with mana value 4 or less to cast without paying its mana cost"
+                        },
+                        "ShuffleLibrary",
+                        {
+                            "type": "CastFromCollectionWithoutPayingCost",
+                            "from": "sunforgerFound"
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 4,
+                "toughnessBonus": 0
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "272",
+        "rarity": "RARE",
+        "artist": "Darrell Riche",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c8d5e027-aa74-444b-a945-1bafa9bdec4c.jpg?1783943594",
+        "rulings": [
+            {
+                "date": "2020-08-07",
+                "text": "You can't pay the cost of unattaching Sunforger unless Sunforger is attached to a creature."
+            },
+            {
+                "date": "2020-08-07",
+                "text": "If you cast a spell \"without paying its mana cost,\" you can't choose to cast it for any alternative costs. You can, however, pay additional costs. If the card has any mandatory additional costs, those must be paid to cast the spell."
+            },
+            {
+                "date": "2020-08-07",
+                "text": "If a spell has {X} in its mana cost, you must choose 0 as the value of X when casting it without paying its mana cost."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // Sunhome Enforcer

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -352,6 +352,30 @@ data class MayTriggerContinuation(
 ) : AnswerContinuation
 
 /**
+ * Resume a triggered ability after its controller picks *which* opponent chooses its
+ * "… of an opponent's choice" target (Mausoleum Turnkey: "return target creature card of an
+ * opponent's choice from your graveyard to your hand").
+ *
+ * The multiplayer-only half of the flow: with a single opponent `TriggerProcessor` pins the decider
+ * outright and never raises this frame, exactly as `ActivateAbilityHandler` does for the activated
+ * twin ([ActivateAbilityOpponentChooserContinuation]). The resumer pins the chosen opponent onto
+ * the trigger and re-enters target selection, so the target decision itself is raised by the one
+ * ordinary code path.
+ *
+ * @property trigger The pending trigger, still unpinned.
+ * @property targetRequirement The trigger's primary target requirement, as `processTargetedTrigger`
+ *   takes it.
+ * @property opponentIds The opponents offered, in the order their names were listed — the response
+ *   is an index into this list.
+ */
+@Serializable
+data class TriggerOpponentChooserContinuation(
+    val trigger: PendingTrigger,
+    val targetRequirement: TargetRequirement,
+    val opponentIds: List<EntityId>
+) : AnswerContinuation
+
+/**
  * Resume after the controller answers a [com.wingedsheep.engine.core.BatchYesNoDecision] raised on
  * behalf of a run of structurally identical optional ("you may … target …") triggers.
  *

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -336,6 +336,7 @@ val engineSerializersModule = SerializersModule {
         subclass(MayRevealCardFromHandContinuation::class)
         subclass(BeholdContinuation::class)
         subclass(MayTriggerContinuation::class)
+        subclass(TriggerOpponentChooserContinuation::class)
         subclass(BatchMayTriggerContinuation::class)
         subclass(FlipCoinsUntilLossContinuation::class)
         subclass(CoinFlipChoiceContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/PendingTrigger.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/PendingTrigger.kt
@@ -43,7 +43,21 @@ data class PendingTrigger(
      * reflexive ability, threaded onto [com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent]
      * when this pending trigger is placed on the stack. Null for ordinary triggered abilities.
      */
-    val carriedPipeline: com.wingedsheep.engine.handlers.PipelineState? = null
+    val carriedPipeline: com.wingedsheep.engine.handlers.PipelineState? = null,
+    /**
+     * Which opponent answers this trigger's target decision, when a requirement carries
+     * [com.wingedsheep.sdk.scripting.targets.TargetChooser.Opponent] ("target creature card of an
+     * opponent's choice" — Mausoleum Turnkey).
+     *
+     * Pinned by `TriggerProcessor` once the deciding opponent is known — immediately in a
+     * two-player game, and after the controller picks one in multiplayer — and read back by
+     * `resolveTargetChooser`. It has to live on the trigger rather than be recomputed, because the
+     * multiplayer pick is a decision of its own and the resumer re-enters target selection with
+     * nothing else to carry the answer.
+     *
+     * Null on every other trigger, which is every trigger without an opponent chooser.
+     */
+    val opponentTargetChooserId: EntityId? = null
 )
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -703,6 +703,13 @@ class TriggerProcessor(
             }
         }
 
+        // "… of an opponent's choice" (Mausoleum Turnkey): settle *which* opponent answers the
+        // decision below before raising it. Deliberately after the fizzle loop and the auto-select
+        // shortcut, so a trigger with no legal target or exactly one never bothers anybody with the
+        // question — the same order the activated-ability path takes.
+        pinOpponentTargetChooserOrPause(state, trigger, allRequirements, targetRequirement)
+            ?.let { return it }
+
         // Create target requirement infos for the decision.
         //
         // A slot's minimum is the *requirement's* — "up to one" allows zero, "target creature" does
@@ -1400,11 +1407,83 @@ class TriggerProcessor(
      *
      * Choosers are read from the *whole* requirement list and must agree — no printed card splits
      * one trigger's targets between two deciders, and honoring only the first requirement's chooser
-     * would silently hand the rest to the wrong player. [TargetChooser.Opponent] is deliberately
-     * not handled here: it needs the controller to first pick *which* opponent decides, which is
-     * the activated-ability path's `pauseForOpponentTargetChooser`, and `CardLinter` already
-     * refuses it on a triggered ability.
+     * would silently hand the rest to the wrong player.
+     *
+     * [TargetChooser.Opponent] reads the opponent [PendingTrigger.opponentTargetChooserId] pinned
+     * by [pinOpponentTargetChooserOrPause], which runs just before the target decision is raised.
+     * It cannot be resolved here, because with three or more players *which* opponent decides is
+     * itself a choice the controller makes (the same reading the activated-ability path's
+     * `pauseForOpponentTargetChooser` takes). An unpinned trigger falls back to the controller,
+     * which is what a trigger with no opponent at all gets.
      */
+    /**
+     * Settle which opponent answers a trigger's "… of an opponent's choice" target decision
+     * (Mausoleum Turnkey: "return target creature card of an opponent's choice from your graveyard
+     * to your hand").
+     *
+     * Returns null when there is nothing to settle — no requirement carries
+     * [TargetChooser.Opponent], the decider is already pinned, or the controller has no opponents
+     * left (in which case [resolveTargetChooser] falls back to the controller, since a target was
+     * already found legal and somebody has to pick it).
+     *
+     * Otherwise it re-enters [processTargetedTrigger] with the decider pinned onto the trigger.
+     * With exactly one opponent that is immediate; with two or more, *which* opponent decides is
+     * the controller's own choice — the same reading the activated-ability path takes in
+     * `ActivateAbilityHandler.pauseForOpponentTargetChooser` — so this pauses for a
+     * [com.wingedsheep.engine.core.ChooseOptionDecision] first and the resumer re-enters with the
+     * answer.
+     *
+     * Re-entering rather than threading a local decider is what keeps [resolveTargetChooser] the
+     * single place that answers "who picks": the pinned id rides on the trigger, so the resumed
+     * path and the direct path reach the decision through exactly the same code.
+     */
+    private fun pinOpponentTargetChooserOrPause(
+        state: GameState,
+        trigger: PendingTrigger,
+        allRequirements: List<TargetRequirement>,
+        targetRequirement: TargetRequirement
+    ): ExecutionResult? {
+        if (trigger.opponentTargetChooserId != null) return null
+        if (allRequirements.none { it.chooser == TargetChooser.Opponent }) return null
+
+        val opponentIds = state.getOpponents(trigger.controllerId).filter { state.hasEntity(it) }
+        if (opponentIds.isEmpty()) return null
+
+        if (opponentIds.size == 1) {
+            return processTargetedTrigger(
+                state,
+                trigger.copy(opponentTargetChooserId = opponentIds.single()),
+                targetRequirement
+            )
+        }
+
+        val opponentNames = opponentIds.map { opponentId ->
+            state.getEntity(opponentId)
+                ?.get<com.wingedsheep.engine.state.components.identity.PlayerComponent>()?.name
+                ?: "Player ${opponentId.value}"
+        }
+        return state.suspendForDecision(
+            question = { decisionId ->
+                com.wingedsheep.engine.core.ChooseOptionDecision(
+                    id = decisionId,
+                    playerId = trigger.controllerId,
+                    prompt = "Choose an opponent to choose a target for ${trigger.sourceName}",
+                    context = com.wingedsheep.engine.core.DecisionContext(
+                        sourceId = trigger.sourceId,
+                        sourceName = trigger.sourceName,
+                        phase = DecisionPhase.RESOLUTION
+                    ),
+                    options = opponentNames
+                )
+            },
+            answer = com.wingedsheep.engine.core.TriggerOpponentChooserContinuation(
+                trigger = trigger,
+                targetRequirement = targetRequirement,
+                opponentIds = opponentIds
+            )
+        )
+    }
+
     private fun resolveTargetChooser(
         state: GameState,
         trigger: PendingTrigger,
@@ -1414,7 +1493,10 @@ class TriggerProcessor(
         val choosers = requirements.map { it.chooser }.distinct()
         val chooser = choosers.singleOrNull() ?: return controller
         return when (chooser) {
-            TargetChooser.Controller, TargetChooser.Opponent -> controller
+            TargetChooser.Controller -> controller
+            // "… of an opponent's choice" (Mausoleum Turnkey). Pinned before the decision is
+            // raised; see the note above for why it cannot be computed from the trigger alone.
+            TargetChooser.Opponent -> trigger.opponentTargetChooserId ?: controller
             TargetChooser.TriggeringPlayer ->
                 trigger.triggerContext.triggeringPlayerId
                     ?: trigger.triggerContext.triggeringEntityId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -669,6 +669,13 @@ class CostHandler {
             state.getEntity(sourceId)
                 ?.get<com.wingedsheep.engine.state.components.battlefield.NotedCreatureTypesComponent>()
                 ?.let { it.secretTo == controllerId && it.types.isNotEmpty() } == true
+        // "You can't pay the cost of unattaching Sunforger unless Sunforger is attached to a
+        // creature" — its own 2020-08-07 ruling, and the reason this is a real affordability gate
+        // rather than a free rider.
+        is CostAtom.Unattach ->
+            state.getEntity(sourceId)
+                ?.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()
+                ?.targetId != null
         // Adding counters takes nothing away, so there is never a reason it can't be paid — this
         // is what keeps Mazemind Tome activatable on the very activation that exiles it.
         is CostAtom.PutCountersOnSelf -> true
@@ -829,6 +836,16 @@ class CostHandler {
             // is a no-op success kept for atom exhaustiveness (the PayCost reveal path emits the
             // CardsRevealedEvent through CostPaymentService).
             CostPaymentResult.success(state, manaPool)
+        is CostAtom.Unattach -> {
+            // The shared chokepoint clears both ends of the link and reports the
+            // PermanentUnattachedEvent, so a "becomes unattached" trigger sees this payment exactly
+            // as it sees the UnattachEquipmentEffect. It no-ops when nothing is attached; the gate
+            // above already established that something is, so that only happens if the host left
+            // between the two checks — in which case the cost is paid by there being nothing owed.
+            val (unattached, events) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+                .unattachEmittingEvent(state, sourceId)
+            CostPaymentResult.success(unattached, manaPool, events)
+        }
         is CostAtom.RevealNotedCreatureType -> {
             // Publishing the note is the whole payment: the types stay where they are and simply
             // stop being secret (CR 702.106c's "doing so will reveal the chosen name"). The
@@ -1367,6 +1384,8 @@ class CostHandler {
                 is CostAtom.PutCountersOnPermanent,
                 is CostAtom.PutCountersOnSelf, is CostAtom.Mill,
                 is CostAtom.RevealNotedCreatureType,
+                // A spell on the stack is attached to nothing, so unattaching is ability-only too.
+                is CostAtom.Unattach,
                 is CostAtom.ExileTopOfLibrary -> false
             }
             is AdditionalCost.PayLifePerTarget -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -900,6 +900,23 @@ class PredicateEvaluator {
                 entityTypes.any { it in exiledTypes }
             }
 
+            // "with the same name as a card exiled with this permanent" (Circu, Dimir Lobotomist).
+            // The name axis of the branch above, and pile-wide for the same reason: Circu keeps
+            // exiling on every blue and every black spell, so no single index names "a card exiled
+            // with Circu". Printed names on both sides — a card in exile and a card in a hand or
+            // library have no battlefield projection a Layer-3 rename could have touched. Fails
+            // closed with no source in context.
+            CardPredicate.SharesNameWithLinkedExile -> {
+                val sourceId = context?.sourceId ?: return false
+                val exiledNames = com.wingedsheep.engine.handlers.effects.linkedexile.LinkedExileLookup
+                    .exiledCards(state, sourceId)
+                    .mapNotNull { state.getEntity(it)?.get<CardComponent>()?.name?.takeIf { n -> n.isNotBlank() } }
+                    .toSet()
+                if (exiledNames.isEmpty()) return false
+                val entityName = projected.getName(entityId)?.takeIf { it.isNotBlank() } ?: card.name
+                entityName.isNotBlank() && entityName in exiledNames
+            }
+
             is CardPredicate.SharesNameWith -> {
                 val referenceId = resolveEntityReference(state, predicate.entity, context) ?: return false
                 // Projected first so a renamed permanent (Layer 3, CR 613.1c) compares under its
@@ -2149,6 +2166,7 @@ class PredicateEvaluator {
             is CardPredicate.SharesCreatureTypeWith,
             is CardPredicate.SharesCardTypeWith,
             CardPredicate.SharesCardTypeWithLinkedExile,
+            CardPredicate.SharesNameWithLinkedExile,
             is CardPredicate.SharesColorWith,
             is CardPredicate.SharesManaValueWith,
             is CardPredicate.SharesNameWith,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -2018,6 +2018,7 @@ class CastSpellHandler(
                     is CostAtom.PutCountersOnPermanent,
                     is CostAtom.PutCountersOnSelf,
                     is CostAtom.RevealNotedCreatureType,
+                    is CostAtom.Unattach,
                     is CostAtom.ExileFromGraveyardForTotal,
                     is CostAtom.ExileTopOfLibrary,
                     is CostAtom.Mill -> {}
@@ -2914,6 +2915,7 @@ class CastSpellHandler(
                         is CostAtom.PutCountersOnPermanent,
                         is CostAtom.PutCountersOnSelf,
                         is CostAtom.RevealNotedCreatureType,
+                        is CostAtom.Unattach,
                         is CostAtom.ExileFromGraveyardForTotal,
                         is CostAtom.ExileTopOfLibrary,
                         is CostAtom.Mill -> {}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -999,6 +999,18 @@ class CastZoneResolver(
                         card.typeLine.cardTypes.any { it in exiledTypes }
                     }
                 }
+                // "with the same name as a card exiled with this permanent" (Circu, Dimir
+                // Lobotomist). Judged here for the same reason as the card-type branch above: the
+                // pile hangs off the granting permanent, which every caller supplying a source has
+                // in hand. Printed names on both sides.
+                CardPredicate.SharesNameWithLinkedExile -> {
+                    val source = grantingSourceId
+                    if (state == null || source == null || card.name.isBlank()) false else {
+                        com.wingedsheep.engine.handlers.effects.linkedexile.LinkedExileLookup
+                            .exiledCards(state, source)
+                            .any { state.getEntity(it)?.get<CardComponent>()?.name == card.name }
+                    }
+                }
                 is CardPredicate.IsToken,
                 is CardPredicate.IsNontoken,
                 is CardPredicate.HasChosenColor,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
@@ -96,6 +96,10 @@ class CostPaymentContinuationResumer(
             // selection — never reaches a PayCost prompt.
             is CostAtom.RevealNotedCreatureType ->
                 resumeYesNo(state, continuation, cost, response, checkForMore)
+            // Ability-scoped only (it reads the source's own attachment), and it takes no
+            // selection — never reaches a PayCost prompt.
+            is CostAtom.Unattach ->
+                resumeYesNo(state, continuation, cost, response, checkForMore)
             // VariablePermanents is an activated-ability-only cost, never a PayCost — unreachable here.
             is CostAtom.VariablePermanents ->
                 ExecutionResult.error(state, "VariablePermanents is not a payable cost in this context")

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -37,6 +37,7 @@ class EffectAndTriggerContinuationResumer(
         resumer(MayRevealCardFromHandContinuation::class, ::resumeMayRevealCardFromHand),
         resumer(BeholdContinuation::class, ::resumeBehold),
         resumer(MayTriggerContinuation::class, ::resumeMayTrigger),
+        resumer(TriggerOpponentChooserContinuation::class, ::resumeTriggerOpponentChooser),
         resumer(BatchMayTriggerContinuation::class, ::resumeBatchMayTrigger)
     )
 
@@ -313,6 +314,42 @@ class EffectAndTriggerContinuationResumer(
         }
 
         return checkForMore(stackResult.newState, stackResult.events.toList())
+    }
+
+    /**
+     * Resume a trigger after its controller picked which opponent chooses its "… of an opponent's
+     * choice" target (Mausoleum Turnkey). Raised only with two or more opponents; with one, the
+     * processor pins the decider without asking.
+     *
+     * The answer is pinned onto the trigger and target selection is re-entered, so the target
+     * decision itself is built by the same `processTargetedTrigger` path a trigger with no chooser
+     * takes — the pin is the only difference. Cancelling drops the trigger rather than silently
+     * handing the choice back to the controller: nothing has been paid or moved, and the trigger
+     * has not yet reached the stack.
+     */
+    private fun resumeTriggerOpponentChooser(
+        state: GameState,
+        continuation: TriggerOpponentChooserContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response is CancelDecisionResponse) {
+            return checkForMore(state, emptyList())
+        }
+        if (response !is OptionChosenResponse) {
+            return ExecutionResult.error(state, "Expected option response for trigger opponent chooser")
+        }
+        val deciderId = continuation.opponentIds.getOrNull(response.optionIndex)
+            ?: return ExecutionResult.error(state, "Invalid opponent choice for trigger target")
+
+        val result = services.triggerProcessor.processTargetedTrigger(
+            state,
+            continuation.trigger.copy(opponentTargetChooserId = deciderId),
+            continuation.targetRequirement
+        )
+
+        if (result.isPaused || !result.isSuccess) return result
+        return checkForMore(result.newState, result.events.toList())
     }
 
     private fun resumeMayTrigger(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
@@ -119,6 +119,8 @@ class PayOrSufferExecutor(
                     handlePutCountersCost(state, effect, context, atom, sourceId, sourceCard.name, payingPlayerId)
                 is CostAtom.RevealNotedCreatureType ->
                     EffectResult.error(state, "RevealNotedCreatureType is an activated-ability cost, not a PayOrSuffer cost")
+                is CostAtom.Unattach ->
+                    EffectResult.error(state, "Unattach is an activated-ability cost, not a PayOrSuffer cost")
                 // Deep Spawn — "sacrifice this creature unless you mill two cards".
                 is CostAtom.Mill ->
                     handleMillCost(state, effect, context, atom, sourceId, sourceCard.name, payingPlayerId)
@@ -1014,6 +1016,7 @@ class PayOrSufferExecutor(
                 is CostAtom.PutCountersOnPermanent ->
                     findValidPermanentsOnBattlefield(state, playerId, atom.filter, null, sourceId).isNotEmpty()
                 is CostAtom.RevealNotedCreatureType -> false
+                is CostAtom.Unattach -> false
                 is CostAtom.VariablePermanents -> false
                 // CR 701.17b — a player can't pay a cost that includes milling more cards than
                 // their library holds, so a library shallower than the cost makes this unpayable

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -354,6 +354,15 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                         // Gated above, before this `when` — only the chooser is offered the
                         // ability at all — and it takes no enumeration-time selection.
                         is CostAtom.RevealNotedCreatureType -> {}
+                        // "Unattach this Equipment" (Sunforger). No selection — the source detaches
+                        // from whatever it is on — but a *real* affordability gate: the ability is
+                        // not offered while the Equipment is unattached (its own 2020-08-07 ruling).
+                        is CostAtom.Unattach -> {
+                            if (state.getEntity(entityId)
+                                    ?.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()
+                                    ?.targetId == null
+                            ) continue
+                        }
                         // CR 701.17b — a mill cost is unpayable when the library holds fewer cards.
                         // No selection: the milled cards are the top of the library.
                         is CostAtom.Mill -> {
@@ -581,6 +590,16 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                     is CostAtom.DiscardHand -> {}
                                     // See the top-level branch: gated before the `when`.
                                     is CostAtom.RevealNotedCreatureType -> {}
+                                    // See the top-level branch: unpayable while unattached.
+                                    is CostAtom.Unattach -> {
+                                        if (state.getEntity(entityId)
+                                                ?.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()
+                                                ?.targetId == null
+                                        ) {
+                                            costCanBePaid = false
+                                            break
+                                        }
+                                    }
                                     // CR 701.17b — a mill cost is unpayable when the library holds
                                     // fewer cards. No selection: the milled cards are the top.
                                     is CostAtom.Mill -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -348,9 +348,15 @@ class CastPermissionUtils(
                     if (!conditionEvaluator.evaluate(state, condition, ctx)) continue
                 }
                 // Match the spell filter against the card being cast (card predicates apply in any zone).
+                //
+                // `sourceId` is the *granting* permanent, not the spell: a source-relative predicate
+                // in a continuous cast prohibition can only mean "relative to the permanent printing
+                // it". Circu, Dimir Lobotomist's "spells with the same name as a card exiled with
+                // Circu" needs it — CardPredicate.SharesNameWithLinkedExile reads the pile hanging
+                // off this permanent and fails closed without a source.
                 if (predicateEvaluator.matches(
                         state, projected, spellCardId, sa.spellFilter,
-                        PredicateContext(controllerId = castingPlayerId)
+                        PredicateContext(controllerId = castingPlayerId, sourceId = permanentId)
                     )
                 ) {
                     return true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -207,6 +207,9 @@ class CostPaymentService(private val services: EngineServices) {
                 // Reading a secret note off the source permanent is activated-ability-only; as a
                 // PayCost there is no such source, so it fails closed like the two below.
                 is CostAtom.RevealNotedCreatureType -> PaymentResult.Unaffordable(state)
+                // Unattaching reads the source's own attachment; a PayCost has no such source, so
+                // it fails closed like its neighbours.
+                is CostAtom.Unattach -> PaymentResult.Unaffordable(state)
                 // VariablePermanents is an activated-ability-only cost, never a PayCost.
                 is CostAtom.VariablePermanents -> PaymentResult.Unaffordable(state)
                 // Likewise ExileFromGraveyardForTotal: canAfford reports it unaffordable as a
@@ -385,6 +388,8 @@ class CostPaymentService(private val services: EngineServices) {
             is CostAtom.RemoveCounters -> performRemoveCounters(state, payerId, atom, sourceId, selected)
             // Likewise activated-ability-only — see the prompt branch above.
             is CostAtom.RevealNotedCreatureType -> CostPaymentExecution(state, emptyList(), success = false)
+            // Likewise activated-ability-only — see the prompt branch above.
+            is CostAtom.Unattach -> CostPaymentExecution(state, emptyList(), success = false)
             // VariablePermanents is an activated-ability-only cost, never a PayCost.
             is CostAtom.VariablePermanents -> CostPaymentExecution(state, emptyList(), success = false)
             // Likewise ExileFromGraveyardForTotal — see the prompt branch above.
@@ -792,6 +797,8 @@ class CostPaymentService(private val services: EngineServices) {
                     is CostAtom.PutCountersOnPermanent -> domain(state, payerId, c, sourceId).isNotEmpty()
                     // Activated-ability cost only (it reads a note on the source permanent).
                     is CostAtom.RevealNotedCreatureType -> false
+                    // Activated-ability cost only (it reads the source's own attachment).
+                    is CostAtom.Unattach -> false
                     is CostAtom.RemoveCounters -> {
                         val needed = when (val c = atom.count) {
                             is com.wingedsheep.sdk.scripting.values.DynamicAmount.Fixed -> c.amount
@@ -878,7 +885,7 @@ class CostPaymentService(private val services: EngineServices) {
                 is CostAtom.Mana, is CostAtom.PayLife, is CostAtom.Mill,
                 is CostAtom.ExileTopOfLibrary,
                 is CostAtom.PutCountersOnSelf, is CostAtom.VariablePermanents,
-                is CostAtom.RevealNotedCreatureType,
+                is CostAtom.RevealNotedCreatureType, is CostAtom.Unattach,
                 is CostAtom.ExileFromGraveyardForTotal -> null
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -957,6 +957,7 @@ internal class AffectsFilterResolver {
         is CardPredicate.SharesCreatureTypeWith,
         is CardPredicate.SharesCardTypeWith,
         CardPredicate.SharesCardTypeWithLinkedExile,
+        CardPredicate.SharesNameWithLinkedExile,
         is CardPredicate.SharesColorWith,
         is CardPredicate.SharesManaValueWith,
         is CardPredicate.SharesNameWith,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -1368,6 +1368,7 @@ class CostCalculator(
             is CardPredicate.SharesCreatureTypeWith -> true
             is CardPredicate.SharesCardTypeWith -> true
             CardPredicate.SharesCardTypeWithLinkedExile -> true
+            CardPredicate.SharesNameWithLinkedExile -> true
             is CardPredicate.SharesColorWith -> true
             is CardPredicate.SharesManaValueWith -> true
             is CardPredicate.SharesNameWith -> true


### PR DESCRIPTION
Three Ravnica: City of Guilds cards, taking the set to **271/291**. Every card left in the RAV tail needs engine work — there are no purely-composable ones — so these are three *independent, small axis additions*, one per card, each with its own commit and its own scenario file. Nothing here is a new mechanic; each is a missing axis on a type that already existed.

## Circu, Dimir Lobotomist — a pile-wide linked-exile *name* predicate

Two "whenever you cast a blue/black spell" triggers that exile the top card of target player's library, plus "Your opponents can't cast spells with the same name as a card exiled with Circu."

- **`CardPredicate.SharesNameWithLinkedExile`** (`GameObjectFilter.sharingNameWithLinkedExile()`) — the *name* axis of the existing `SharesCardTypeWithLinkedExile` (Cemetery Illuminator), and pile-wide for the same reason: Circu exiles on every blue *and* every black spell you cast, so `sharingNameWith(EntityReference.LinkedExiledCard())` — which reads exactly one index — can never mean "a card exiled with Circu". Read sites mirror the card-type predicate one for one.
- **A fail-closed hole this exposed:** `CastPermissionUtils.blockedByPlayersCantCastSpells` built its `PredicateContext` with **no `sourceId` at all**, so *any* source-relative predicate in a `PlayersCantCastSpells` spell filter could only ever evaluate false. The granting permanent is the static's source, so it is now threaded in.
- Two separate triggered abilities rather than one "blue or black" filter — that is what makes the printed ruling ("both trigger; you can target two different players") fall out.

## Sunforger — an unattach ability cost

"{R}{W}, Unattach this Equipment: Search your library for a red or white instant card with mana value 4 or less and cast that card without paying its mana cost. Then shuffle."

- **`CostAtom.Unattach`** (`Costs.Unattach`) — the *effect* has existed since Stolen Uniform's rider; the *cost* had not, and no existing atom stands in: a sacrifice moves zones, a tap can be restored, this does neither. Its affordability gate is the card's own ruling ("You can't pay the cost of unattaching Sunforger unless Sunforger is attached to a creature"), so the ability reads unaffordable while the Equipment sits loose. Payment goes through the same `ZoneMovementUtils.unattachEmittingEvent` chokepoint as the effect, so a "becomes unattached" trigger cannot tell the two apart.
- The search is the plain Gather → Select → cast pipeline, because `Patterns.Library.searchLibrary`'s `SearchDestination` vocabulary has no "cast it" case. The shuffle runs *before* the cast — order-independent here, and it keeps the shuffle from having to survive the pause the cast opens for the found spell's own targets.
- Reprint rows for C16 and CMR.

## Mausoleum Turnkey — an opponent target chooser on a *triggered* ability

"When this creature enters, return target creature card of an opponent's choice from your graveyard to your hand."

- `TargetChooser.Opponent` existed but was routed only by the activated-ability path (Cuombajj Witches); `TriggerProcessor.resolveTargetChooser` mapped it to the controller on purpose and `CardLinter` failed any card that put it on a trigger. This is the printed triggered use.
- The trigger path now settles the deciding opponent before raising the target decision, mirroring `pauseForOpponentTargetChooser`: one opponent is pinned outright, two or more make the controller pick which one decides (a new `TriggerOpponentChooserContinuation`). The pinned id rides on `PendingTrigger`, so `resolveTargetChooser` stays the single place that answers "who picks" — the resumed and direct paths reach the decision through identical code. The pin runs *after* the no-legal-target check and the auto-select shortcut, so a fizzling or single-choice trigger asks nobody anything.
- The chooser stays orthogonal to legality: targets are still found relative to the ability's controller, so "from your graveyard" is *your* graveyard and the card returns to *your* hand. The opponent only picks which of your creature cards it is.
- Reprint row for JMP.

## Verification

- `just build`, `just test` (6m 03s) and `just check` all green.
- Ten new scenarios across three files, all passing: 4 Circu, 3 Sunforger, 3 Mausoleum Turnkey — including the multiplayer chooser-then-target pair.
- `just rebless-cards`: the RAV golden diff is **310 insertions, 0 deletions** — exactly the three new cards, no existing entry moved.
- `just check-card-printing` clean for all three (canonical in RAV; the three reprint rows added).
- `just assay-differential --set RAV`: 103 compared, **0 divergences**. Assay declines all three cards' full text, so it does not independently verify them.
- Backlog ticked and resynced: RAV 271/291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW9JHTLm8FLacG2yxTRAZu
