### PR TITLE
Add the Champion keyword and Lorwyn's nine champions

### DIFF
--- a/backlog/sets/lorwyn/cards.md
+++ b/backlog/sets/lorwyn/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 cards
 **Release Date:** October 12, 2007
-**Implemented:** 268 / 286
+**Implemented:** 277 / 286
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 49    | 43   |
@@ -27,7 +27,7 @@
 - [x] Brigid, Hero of Kinsbaile
 - [x] Burrenton Forge-Tender
 - [x] Cenn's Heir
-- [ ] Changeling Hero
+- [x] Changeling Hero
 - [x] Cloudgoat Ranger
 - [x] Crib Swap
 - [x] Dawnfluke
@@ -62,7 +62,7 @@
 - [x] Springjack Knight
 - [x] Summon the School
 - [x] Surge of Thoughtweft
-- [ ] Thoughtweft Trio
+- [x] Thoughtweft Trio
 - [x] Triclopean Sight
 - [x] Veteran of the Depths
 - [x] Wellgabber Apothecary
@@ -95,7 +95,7 @@
 - [x] Merrow Commerce
 - [x] Merrow Harbinger
 - [x] Merrow Reejerey
-- [ ] Mistbind Clique
+- [x] Mistbind Clique
 - [x] Mulldrifter
 - [x] Paperfin Rascal
 - [x] Pestermite
@@ -115,7 +115,7 @@
 - [x] Surgespanner
 - [x] Tideshaper Mystic
 - [x] Turtleshell Changeling
-- [ ] Wanderwine Prophets
+- [x] Wanderwine Prophets
 - [x] Whirlpool Whelm
 - [x] Wings of Velis Vel
 - [x] Zephyr Net
@@ -126,7 +126,7 @@
 - [x] Boggart Birth Rite
 - [x] Boggart Harbinger
 - [x] Boggart Loggers
-- [ ] Boggart Mob
+- [x] Boggart Mob
 - [ ] Cairn Wanderer
 - [x] Colfenor's Plans
 - [ ] Dread
@@ -184,7 +184,7 @@
 - [x] Caterwauling Boggart
 - [x] Ceaseless Searblades
 - [ ] Chandra Nalaar
-- [ ] Changeling Berserker
+- [x] Changeling Berserker
 - [x] Consuming Bonfire
 - [x] Crush Underfoot
 - [x] Faultgrinder
@@ -211,7 +211,7 @@
 - [x] Lowland Oaf
 - [x] Mudbutton Torchrunner
 - [ ] Needle Drop
-- [ ] Nova Chaser
+- [x] Nova Chaser
 - [x] Rebellion of the Flamekin
 - [x] Smokebraider
 - [x] Soulbright Flamekin
@@ -226,7 +226,7 @@
 - [x] Battlewand Oak
 - [x] Bog-Strider Ash
 - [x] Briarhorn
-- [ ] Changeling Titan
+- [x] Changeling Titan
 - [x] Cloudcrown Oak
 - [x] Cloudthresher
 - [x] Dauntless Dourbark
@@ -270,7 +270,7 @@
 - [x] Warren-Scourge Elf
 - [x] Woodland Changeling
 - [x] Woodland Guidance
-- [ ] Wren's Run Packmaster
+- [x] Wren's Run Packmaster
 - [x] Wren's Run Vanquisher
 
 ### Multicolor

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6320,6 +6320,15 @@ Dominant back faces that "stay" instead self-exile on their final chapter, dodgi
   is itself a Food counts its own sacrifice). Pick by the printed article — "one or more" → batch,
   "a" → `YouSacrificeA`, "another" → `YouSacrificeAnother`.
 - `Sacrificed` — source is sacrificed.
+- `EventPattern.ChampionedEvent` — "when a [quality] is championed with this creature" (CR 702.72c;
+  Mistbind Clique). Reach it through `Triggers.championedWith(binding)`. A parameterless pattern whose
+  subject is the **championing** permanent, selected by the ability's `TriggerBinding`: `SELF` is
+  "championed with **this** creature", `OTHER` is "with another permanent you control", `ANY` has no
+  restriction. Emitted by `EmitChampionedEventEffect`, the success branch of the champion ability's own
+  gate, so it fires once per permanent that actually reached exile and never when the choice was
+  declined. It carries no filter for the championed permanent's quality — a champion ability can only
+  exile something matching its own quality, so the printed "a Faerie is championed with this creature"
+  is already guaranteed by the champion clause. See the `Champion` keyword entry for full wiring.
 - `EventPattern.ExploitedEvent(player = Player.You, requireNontokenExploited = false)` — "whenever a creature you control
   exploits a creature" (CR 702.110b; the sacrifice half of the Exploit keyword). Fires once per exploited creature; the
   `exploit()` helper appends `EmitExploitedEventEffect` after the exploit sacrifice, so declining the optional sacrifice
@@ -8772,7 +8781,7 @@ Flying, Menace, Intimidate, Fear, Shadow, Horsemanship, all basic landwalks (Pla
 Strike, Trample, Deathtouch, Lifelink, Vigilance, Reach, Provoke, Defender, Indestructible, Hexproof, Shroud, Haste,
 Flash, Prowess, Flurry, Changeling, Devoid (**not** display-only — see the note above: the engine
 derives `CardDefinition.colors` from it), Convoke, Delve, Improvise, Affinity, Emerge, Storm, Flashback, Harmonize, Mayhem, Disturb, Evoke, Sneak, Ninjutsu, Web-slinging, Impending, Conspire, Casualty, Miracle, Hideaway, Cascade, Plot,
-Offspring, Persist, Undying, Enduring, Ascend, Storied, Start your engines!, Max speed, Wither, Toxic, Eerie, Vivid, Fateful Bite, Exploit, Soulbond, Daybound, Nightbound, … (display-only — engine effect lives in handlers or
+Offspring, Persist, Undying, Enduring, Ascend, Storied, Start your engines!, Max speed, Wither, Toxic, Eerie, Vivid, Fateful Bite, Exploit, Champion, Soulbond, Daybound, Nightbound, … (display-only — engine effect lives in handlers or
 composite abilities).
 
 **Parameterized `KeywordAbility.*`**
@@ -9158,6 +9167,43 @@ composite abilities).
   is a battlefield replacement scoped by its own `appliesTo` pattern — while one is on the battlefield (or the "damage
   can't be prevented this turn" one-shot is active) `DamageUtils.applyDamagePreventionShields` applies no prevention
   shields to the damage instances that pattern names (CR 615.12).
+- `Champion an [object]` — "Champion a Goblin (When this enters, sacrifice it unless you exile another
+  Goblin you control. When this leaves the battlefield, that card returns to the battlefield.)"
+  (CR 702.72, Lorwyn). Display-only keyword (`Keyword.CHAMPION`); wire the behavior with the
+  `card { champion(Subtype.GOBLIN) }` builder helper — or `champion(quality: GameObjectFilter,
+  qualityDescription: String)` for a non-tribal quality, of which `championCreature()` ("champion a
+  creature", the three Changelings) is the only printed one. It adds the keyword plus **two linked
+  triggered abilities** (CR 702.72b / 607.2k), both composed from existing primitives with no new
+  executor:
+  - **enters** — an `IfYouDoEffect` over a Gather → Select → Move pipeline. The quality is chosen,
+    **not targeted** (the printed text has no "target"): `CardSource.BattlefieldMatching(filter =
+    quality.notSourceItself(), player = Player.You)`, then `SelectionMode.ChooseUpTo(1)` with
+    `useTargetingUI = true`, then a move to exile carrying `linkToSource = true` and
+    `storeMovedAs = CHAMPIONED_CARDS`. `ChooseUpTo(1)` **is** the "unless": picking nothing is always
+    legal, and with no eligible permanent the selection resolves with no prompt at all. The gate's
+    criterion is `SuccessCriterion.CollectionNonEmpty(CHAMPIONED_CARDS)` — the cards that actually
+    reached exile, not merely the ones picked — with `otherwise = SacrificeSelfEffect` and
+    `then = EmitChampionedEventEffect()`.
+  - **leaves** — `Triggers.LeavesBattlefield` running `Effects.ReturnLinkedExileUnderOwnersControl()`,
+    which reads the linked-exile pile of the **originating battlefield visit**, so a champion that
+    blinks never returns the other visit's card and never sacrifices for the other visit's obligation.
+  - **the quality is a permanent filter.** "Champion a Goblin" is a bare tribal noun, so per CR 109.2
+    it means a Goblin *permanent* — a Kindred noncreature Goblin is a legal choice. The `Subtype`
+    overload builds `GameObjectFilter.Permanent.withSubtype(subtype)`; narrowing it to `Creature`
+    would silently drop those. `notSourceItself()` supplies "another" and is *visit-aware*.
+  - **two triggers, not an "exile until" replacement.** This is what CR 702.72a says, and it
+    reproduces the printed interaction Fiend Hunter documents: a champion removed before its enters
+    trigger resolves has already run its leaves trigger against an empty pile, and then exiles a
+    permanent that never comes back. The sacrifice is a genuine no-op when the champion is already
+    gone, exactly as the printed instruction behaves.
+  - **CR 702.72c payoff** — `Triggers.championedWith()` (`EventPattern.ChampionedEvent`) is
+    "when a [quality] is championed with this creature" (Mistbind Clique). It fires only when a
+    permanent actually reached exile, so declining the choice taps nothing. The quality is not
+    restated on the trigger: the champion clause above it can only ever exile a matching permanent.
+  Cards: Boggart Mob, Changeling Berserker/Hero/Titan, Mistbind Clique, Nova Chaser, Thoughtweft
+  Trio, Wanderwine Prophets, Wren's Run Packmaster. Pinned by `ChampionKeywordTest` (17 scenarios
+  covering accept/decline/no-candidate, "another", the tribal-vs-creature quality, projected types,
+  owner's-control return, linkage, tokens, trigger ordering, and blinking).
 - `Exploit` — "Exploit (When this creature enters, you may sacrifice a creature.)" (CR 702.110, Dragons of Tarkir;
   reprinted MH1/MH2/VOW/PIP/MH3). Display-only keyword; wire the behavior with the `card { exploit(onExploit, onExploitTargets) }`
   builder helper. It adds the keyword plus one `EntersBattlefield` triggered ability whose effect is a

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -586,6 +586,35 @@ enum class Keyword(val displayName: String) {
     EXPLOIT("Exploit"),
 
     /**
+     * Champion (CR 702.72, Lorwyn). "Champion an [object]" represents **two linked triggered
+     * abilities** (CR 702.72b, 607.2k): "When this permanent enters, sacrifice it unless you exile
+     * another [object] you control" and "When this permanent leaves the battlefield, return the
+     * exiled card to the battlefield under its owner's control." A permanent is *championed* by
+     * another permanent when the latter exiles it as the direct result of a champion ability
+     * (CR 702.72c).
+     *
+     * The keyword itself is display-only; the quality and the behavior are composed by the
+     * `champion(...)` DSL helper on [com.wingedsheep.sdk.dsl.CardBuilder]:
+     *
+     *  - the enters half is a Gather → Select → Move pipeline (choose, don't target — the printed
+     *    text says "exile another [object] you control", with no "target") whose move carries
+     *    `linkToSource`, wrapped in a [com.wingedsheep.sdk.scripting.effects.Gate.DoAction] whose
+     *    `otherwise` is [com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect] — the "unless";
+     *  - the leaves half is an ordinary leaves-the-battlefield trigger running
+     *    [com.wingedsheep.sdk.dsl.Effects.ReturnLinkedExileUnderOwnersControl], which reads the
+     *    linked-exile pile of the *originating battlefield visit*, so a source that leaves and
+     *    returns never returns the other visit's card;
+     *  - the `then` branch emits an observable
+     *    [com.wingedsheep.sdk.scripting.EventPattern.ChampionedEvent] so the "when a [quality] is
+     *    championed with this creature" payoff (Mistbind Clique) can react.
+     *
+     * The two halves are separate triggers, not an "exile until" replacement, which reproduces the
+     * printed interaction: a champion that leaves before its enters trigger resolves has already
+     * run its leaves trigger against an empty pile, and then exiles a permanent that never returns.
+     */
+    CHAMPION("Champion"),
+
+    /**
      * Training (CR 702.149, Innistrad: Midnight Hunt). A triggered attack ability:
      * "Whenever this creature and at least one other creature with power greater than this
      * creature's power attack, put a +1/+1 counter on this creature" (CR 702.149a). Multiple

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1555,6 +1555,23 @@ object Triggers {
         binding = binding
     )
 
+    /**
+     * "When a [quality] is championed with this creature" (CR 702.72c) — Mistbind Clique. Fires
+     * when a resolving champion ability on this permanent exiles a permanent; declining the choice
+     * champions nothing and fires nothing. Keyed on [EventPattern.ChampionedEvent], whose subject
+     * is the *championing* permanent, so [TriggerBinding.SELF] means "with **this** creature".
+     *
+     * The quality is not restated on the trigger: a champion ability can only ever exile something
+     * matching its own quality, so "a Faerie is championed with this creature" is already guaranteed
+     * by the `champion(Subtype.FAERIE)` clause above it. [TriggerBinding.OTHER] ("championed with
+     * another permanent you control") and [TriggerBinding.ANY] are supported for the next card; only
+     * the SELF form is printed.
+     */
+    fun championedWith(binding: TriggerBinding = TriggerBinding.SELF): TriggerSpec = TriggerSpec(
+        event = ChampionedEvent,
+        binding = binding
+    )
+
     // =========================================================================
     // Damage Received (incoming)
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/ChampionDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/ChampionDsl.kt
@@ -1,0 +1,162 @@
+package com.wingedsheep.sdk.dsl
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CHAMPIONED_CARDS
+import com.wingedsheep.sdk.scripting.effects.CHAMPION_CANDIDATES
+import com.wingedsheep.sdk.scripting.effects.CHAMPION_CHOICE
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.EmitChampionedEventEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Printed reminder text for champion, parameterized by the quality — the Lorwyn wording, which is
+ * what Scryfall carries on all nine champion cards.
+ */
+private fun championReminder(quality: String): String =
+    "Champion $quality (When this enters, sacrifice it unless you exile another $quality you " +
+        "control. When this leaves the battlefield, that card returns to the battlefield.)"
+
+/**
+ * The indefinite article for a quality noun. Champion's printed qualities are a creature type or
+ * the word "creature"; only "Elemental" among the nine printed cards takes "an", but the rule is
+ * general so a later Kindred quality gets it right too.
+ */
+private fun article(noun: String): String =
+    if (noun.first().uppercaseChar() in "AEIOU") "an $noun" else "a $noun"
+
+/**
+ * Add Champion (CR 702.72, Lorwyn) — keyword + the pair of linked triggered abilities.
+ *
+ * > **CR 702.72a** — "Champion represents two triggered abilities. 'Champion an [object]' means
+ * > 'When this permanent enters, sacrifice it unless you exile another [object] you control' and
+ * > 'When this permanent leaves the battlefield, return the exiled card to the battlefield under
+ * > its owner's control.'"
+ * > **CR 702.72b / 607.2k** — the two abilities are linked; the second returns only what the first
+ * > exiled.
+ * > **CR 702.72c** — a permanent is "championed" by another permanent if the latter exiles the
+ * > former as the direct result of a champion ability.
+ *
+ * The keyword is display-only; the behavior composes existing primitives, with no new executor:
+ *
+ *  - **Enters.** A Gather → Select → Move pipeline. `champion` says "exile another [object] you
+ *    control" with no "target", so the permanent is **chosen, not targeted** — gathered with
+ *    [CardSource.BattlefieldMatching] scoped to [Player.You] (projected control, so a permanent
+ *    you stole this turn is eligible and one you lost is not) and to
+ *    `GameObjectFilter.notSourceItself()` for "another". `notSourceItself` is *visit-aware*: it
+ *    compares the resolving ability's originating battlefield visit, so a champion that blinked
+ *    cannot exclude — or exile — the wrong instance of itself.
+ *    [SelectionMode.ChooseUpTo]`(1)` is the "unless": picking nothing is always legal, and is the
+ *    only option when you control no other matching permanent (the selection resolves without a
+ *    prompt over an empty candidate set). The move carries `linkToSource`, which files the card in
+ *    the *originating visit's* linked-exile pile.
+ *  - **The "unless".** An [IfYouDoEffect] gate over that pipeline whose criterion is
+ *    [SuccessCriterion.CollectionNonEmpty] on the move's `storeMovedAs` ([CHAMPIONED_CARDS]) — the
+ *    cards that actually reached exile, not merely the ones picked. Its `otherwise` is
+ *    [SacrificeSelfEffect]; its `then` is [EmitChampionedEventEffect], the CR 702.72c signal that
+ *    drives Mistbind Clique's "when a Faerie is championed with this creature".
+ *  - **Leaves.** An ordinary [Triggers.LeavesBattlefield] trigger running
+ *    [Effects.ReturnLinkedExileUnderOwnersControl], which reads the same originating visit's pile.
+ *
+ * Modelling this as **two separate triggers** rather than an "exile until this leaves" replacement
+ * is what CR 702.72a says and reproduces the printed interaction Fiend Hunter documents: if the
+ * champion leaves the battlefield before its enters trigger resolves, the leaves trigger resolves
+ * first against an empty pile and does nothing, and the enters trigger then exiles a permanent that
+ * never comes back. It also means the sacrifice is a genuine no-op when the champion is already
+ * gone, exactly as the printed instruction behaves.
+ *
+ * Multiple instances would install two independent pairs; no printed card has two, and because both
+ * halves would share one linked-exile pile per battlefield visit, a card that needs two would have
+ * to distinguish the pairs first (CR 607.2k links each pair separately).
+ *
+ * @param quality The [object] to champion, as a filter over **permanents** — champion's printed
+ *   quality is a bare tribal noun ("a Goblin"), which per CR 109.2 reads as a Goblin *permanent*,
+ *   so a Kindred noncreature Goblin is a legal choice. Use the [Subtype] overload for those; pass
+ *   `GameObjectFilter.Creature` for "champion a creature".
+ * @param qualityDescription The quality with its article, as printed ("a Goblin", "a creature").
+ */
+fun CardBuilder.champion(quality: GameObjectFilter, qualityDescription: String) {
+    keywordSet.add(Keyword.CHAMPION)
+
+    triggeredAbilities.add(
+        TriggeredAbility.create(
+            trigger = Triggers.EntersBattlefield.event,
+            binding = Triggers.EntersBattlefield.binding,
+            effect = IfYouDoEffect(
+                action = CompositeEffect(
+                    listOf(
+                        GatherCardsEffect(
+                            source = CardSource.BattlefieldMatching(
+                                filter = quality.notSourceItself(),
+                                player = Player.You
+                            ),
+                            storeAs = CHAMPION_CANDIDATES
+                        ),
+                        SelectFromCollectionEffect(
+                            from = CHAMPION_CANDIDATES,
+                            selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                            storeSelected = CHAMPION_CHOICE,
+                            // Choosing among permanents in play: keep it on the battlefield rather
+                            // than behind a card-list overlay, so counters, auras and board context
+                            // stay visible while deciding what to give up.
+                            useTargetingUI = true,
+                            prompt = "Exile another $qualityDescription you control, " +
+                                "or choose nothing to sacrifice this permanent",
+                            selectedLabel = "Exile"
+                        ),
+                        MoveCollectionEffect(
+                            from = CHAMPION_CHOICE,
+                            destination = CardDestination.ToZone(Zone.EXILE),
+                            linkToSource = true,
+                            storeMovedAs = CHAMPIONED_CARDS
+                        )
+                    )
+                ),
+                ifYouDo = EmitChampionedEventEffect(),
+                ifYouDont = SacrificeSelfEffect,
+                successCriterion = SuccessCriterion.CollectionNonEmpty(CHAMPIONED_CARDS)
+            ),
+            descriptionOverride = championReminder(qualityDescription)
+        )
+    )
+
+    triggeredAbilities.add(
+        TriggeredAbility.create(
+            trigger = Triggers.LeavesBattlefield.event,
+            binding = Triggers.LeavesBattlefield.binding,
+            effect = Effects.ReturnLinkedExileUnderOwnersControl(),
+            descriptionOverride = "When this permanent leaves the battlefield, return the exiled " +
+                "card to the battlefield under its owner's control."
+        )
+    )
+}
+
+/**
+ * "Champion a [subtype]" — the tribal form, which is eight of the nine printed champion cards.
+ *
+ * The quality is a **permanent** filter, not a creature filter: CR 109.2 reads a bare tribal noun
+ * as any permanent with that type, so a Kindred noncreature Faerie is a legal thing to champion
+ * with Mistbind Clique. Filtering to creatures here would silently narrow the choice.
+ */
+fun CardBuilder.champion(subtype: Subtype) =
+    champion(
+        quality = GameObjectFilter.Permanent.withSubtype(subtype),
+        qualityDescription = article(subtype.value)
+    )
+
+/** "Champion a creature" — Changeling Berserker / Hero / Titan. */
+fun CardBuilder.championCreature() =
+    champion(quality = GameObjectFilter.Creature, qualityDescription = "a creature")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -2807,6 +2807,40 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
         override val description: String = "this creature trains"
     }
 
+    /**
+     * When a permanent is championed with this permanent (CR 702.72c) — "a permanent is
+     * 'championed' by another permanent if the latter exiles the former as the direct result of a
+     * champion ability." Mistbind Clique's "When a Faerie is championed with this creature, tap all
+     * lands target player controls."
+     *
+     * Emitted by the champion ability's own resolution (the `then` branch of the gate the
+     * `champion()` helper builds, `com.wingedsheep.sdk.dsl.champion`) and **only when a permanent
+     * was actually exiled** — declining the choice sacrifices the champion instead and fires
+     * nothing, faithful to "as the direct result of a champion ability". Distinct from the raw
+     * [ZoneChangeEvent] the same exile also emits: that fires for any exile, this only for one a
+     * *resolving champion ability* performed (the same Option A distinction as [TrainedEvent]).
+     *
+     * A parameterless [EventPattern] whose subject is the **championing** permanent, selected by
+     * the watching ability's [com.wingedsheep.sdk.scripting.TriggerBinding], exactly like
+     * [TrainedEvent] and [ExploitedEvent]:
+     *  - [com.wingedsheep.sdk.scripting.TriggerBinding.SELF] — "championed with **this** creature"
+     *    (Mistbind Clique). The champion is the ability's own source.
+     *  - [com.wingedsheep.sdk.scripting.TriggerBinding.OTHER] — "championed with another permanent
+     *    you control" (none printed; supported for the next card).
+     *  - [com.wingedsheep.sdk.scripting.TriggerBinding.ANY] — no subject restriction.
+     *
+     * It carries no filter for the *championed* permanent's quality: the champion ability can only
+     * ever exile something matching its own quality, so the printed "a Faerie is championed with
+     * this creature" is already guaranteed by the champion clause above it. A card that needed a
+     * narrower quality than its own champion quality would add the filter then, mirroring
+     * [TrainedEvent]'s deliberately narrow shape.
+     */
+    @SerialName("ChampionedEvent")
+    @Serializable
+    data object ChampionedEvent : EventPattern {
+        override val description: String = "a permanent is championed with this permanent"
+    }
+
     // =========================================================================
     // Combat Damage Batch Triggers
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ChampionEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ChampionEffects.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.sdk.scripting.effects
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Pipeline collection holding the permanents the champion ability *offered* as legal choices —
+ * "another [quality] you control" (CR 702.72a).
+ */
+const val CHAMPION_CANDIDATES = "championCandidates"
+
+/** Pipeline collection holding the permanent the controller picked, before it moves. */
+const val CHAMPION_CHOICE = "championChoice"
+
+/**
+ * Pipeline collection holding the cards the champion ability actually *exiled*. Written by the
+ * move step's `storeMovedAs`, so it is empty both when the controller declined and when the pick
+ * failed to reach exile — which is exactly the "unless" of CR 702.72a, and what the ability's
+ * [SuccessCriterion.CollectionNonEmpty] gate reads to decide between "championed" and "sacrifice".
+ */
+const val CHAMPIONED_CARDS = "championedCards"
+
+/**
+ * Emit a `ChampionedEvent` (CR 702.72c) for each permanent the source just exiled as its champion
+ * ability resolved. Appended internally by [com.wingedsheep.sdk.dsl.champion] as the `then` branch
+ * of the ability's "exile … unless" gate, so "When a [quality] is championed with this creature"
+ * payoffs ([com.wingedsheep.sdk.scripting.EventPattern.ChampionedEvent], i.e. Mistbind Clique) fire.
+ *
+ * CR 702.72c: "A permanent is 'championed' by another permanent if the latter exiles the former as
+ * the direct result of a champion ability." The event is therefore emitted from *inside* the champion
+ * ability's own resolution rather than derived from the `ZoneChangeEvent` — a permanent exiled by any
+ * other effect, including another linked-exile ability on the same source, is not championed.
+ *
+ * The championed permanents are read out of the pipeline collection [from] (the champion pipeline's
+ * `storeMovedAs`), so nothing is emitted when the controller declined and the source was sacrificed
+ * instead. The champion is always the ability's source.
+ *
+ * Card authors should not use this directly; it is wired into the `champion()` helper.
+ *
+ * @property from Pipeline collection holding the cards actually exiled by this champion ability.
+ */
+@SerialName("EmitChampionedEvent")
+@Serializable
+data class EmitChampionedEventEffect(
+    val from: String = CHAMPIONED_CARDS
+) : Effect {
+    // Intentionally blank: this is an internal pipeline tail with no player-facing text.
+    override val description: String = ""
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -626,7 +626,7 @@ object CardLinter {
             "StoreCardName", "CastFromCollectionWithoutPayingCost", "PlayFromCollectionWithoutPayingCost",
             "CastAnyNumberFromCollectionWithoutPayingCost", "ExileFromStorage",
             "CopyCollectionIntoCollection", "RecordChosenLinkedExile",
-            "PairWithSource",
+            "PairWithSource", "EmitChampionedEvent",
         )) put(type to "from", read(Space.COLLECTION))
         put("ChoosePile" to "pileA", read(Space.COLLECTION))
         put("ChoosePile" to "pileB", read(Space.COLLECTION))

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BoggartMob.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BoggartMob.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.champion
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Boggart Mob
+ * {3}{B}
+ * Creature — Goblin Warrior
+ * 5/5
+ *
+ * Champion a Goblin
+ * Whenever a Goblin you control deals combat damage to a player, you may create a 1/1 black
+ * Goblin Rogue creature token.
+ *
+ * "A Goblin you control" is a bare tribal noun (CR 109.2) — a Goblin *permanent*, matched with
+ * `ANY` binding so the Mob's own combat damage triggers it too, alongside every other Goblin.
+ * One trigger per damaging Goblin, not one per combat: the printed text is the per-source
+ * "whenever a Goblin", not a batch wording.
+ */
+val BoggartMob = card("Boggart Mob") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Goblin Warrior"
+    power = 5
+    toughness = 5
+    oracleText = "Champion a Goblin (When this enters, sacrifice it unless you exile another " +
+        "Goblin you control. When this leaves the battlefield, that card returns to the battlefield.)\n" +
+        "Whenever a Goblin you control deals combat damage to a player, you may create a 1/1 " +
+        "black Goblin Rogue creature token."
+
+    champion(Subtype.GOBLIN)
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            sourceFilter = GameObjectFilter.Permanent.withSubtype(Subtype.GOBLIN).youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = MayEffect(
+            Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.BLACK),
+                creatureTypes = setOf("Goblin", "Rogue"),
+                imageUri = "https://cards.scryfall.io/normal/front/f/4/f44d5271-5d10-46b2-9ba2-5788d99de2e6.jpg?1783942839"
+            )
+        )
+        description = "Whenever a Goblin you control deals combat damage to a player, you may " +
+            "create a 1/1 black Goblin Rogue creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "104"
+        artist = "Thomas Denmark"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a61990de-0daf-4340-8e6b-c49852d46980.jpg?1783942893"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ChangelingBerserker.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ChangelingBerserker.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.championCreature
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Changeling Berserker
+ * {3}{R}
+ * Creature — Shapeshifter
+ * 5/3
+ *
+ * Changeling
+ * Haste
+ * Champion a creature
+ *
+ * Champion (CR 702.72) is two linked triggered abilities, wired by the [championCreature] helper:
+ * the enters half exiles another creature you control or sacrifices this, and the leaves half
+ * returns the exiled card. Changeling makes the Berserker every creature type, but its champion
+ * quality is the printed "a creature", not a tribe — so any creature you control is a legal choice.
+ */
+val ChangelingBerserker = card("Changeling Berserker") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Shapeshifter"
+    power = 5
+    toughness = 3
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "Haste\n" +
+        "Champion a creature (When this enters, sacrifice it unless you exile another creature " +
+        "you control. When this leaves the battlefield, that card returns to the battlefield.)"
+
+    keywords(Keyword.CHANGELING, Keyword.HASTE)
+    championCreature()
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "160"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9f2e8f24-2ee1-4516-bf60-7fe6a0c4baec.jpg?1783942877"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ChangelingHero.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ChangelingHero.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.championCreature
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Changeling Hero
+ * {4}{W}
+ * Creature — Shapeshifter
+ * 4/4
+ *
+ * Changeling
+ * Champion a creature
+ * Lifelink
+ */
+val ChangelingHero = card("Changeling Hero") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Shapeshifter"
+    power = 4
+    toughness = 4
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "Champion a creature (When this enters, sacrifice it unless you exile another creature " +
+        "you control. When this leaves the battlefield, that card returns to the battlefield.)\n" +
+        "Lifelink (Damage dealt by this creature also causes you to gain that much life.)"
+
+    keywords(Keyword.CHANGELING, Keyword.LIFELINK)
+    championCreature()
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "9"
+        artist = "Jeff Miracola"
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/24f0c586-a1a5-4907-801a-7815c4dceb39.jpg?1783942917"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ChangelingTitan.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ChangelingTitan.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.championCreature
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Changeling Titan
+ * {4}{G}
+ * Creature — Shapeshifter
+ * 7/7
+ *
+ * Changeling
+ * Champion a creature
+ */
+val ChangelingTitan = card("Changeling Titan") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Shapeshifter"
+    power = 7
+    toughness = 7
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "Champion a creature (When this enters, sacrifice it unless you exile another creature " +
+        "you control. When this leaves the battlefield, that card returns to the battlefield.)"
+
+    keywords(Keyword.CHANGELING)
+    championCreature()
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "200"
+        artist = "Jesper Ejsing"
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d5b9719-2861-477e-bb78-225fd03d7bbc.jpg?1783942866"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/MistbindClique.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/MistbindClique.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.champion
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.TapUntapCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Mistbind Clique
+ * {3}{U}
+ * Creature — Faerie Wizard
+ * 4/4
+ *
+ * Flash
+ * Flying
+ * Champion a Faerie
+ * When a Faerie is championed with this creature, tap all lands target player controls.
+ *
+ * The follow-up is a real triggered ability keyed to the CR 702.72c "championed" event
+ * ([Triggers.championedWith]), not a rider on the champion trigger itself. That is what makes the
+ * printed line behave: it fires only when a Faerie was *actually* exiled (declining the champion
+ * choice sacrifices the Clique and taps nothing), it is a separate object on the stack that can be
+ * responded to, and its player target is chosen when it goes on the stack rather than when the
+ * Clique enters. The "a Faerie" quality needs no restating — the champion clause above can only
+ * ever exile a Faerie permanent.
+ *
+ * "Tap all lands target player controls" is a group tap: gather the target player's lands, then
+ * [TapUntapCollectionEffect]. The lands are not targeted — only the player is.
+ */
+val MistbindClique = card("Mistbind Clique") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie Wizard"
+    power = 4
+    toughness = 4
+    oracleText = "Flash\n" +
+        "Flying\n" +
+        "Champion a Faerie (When this enters, sacrifice it unless you exile another Faerie you " +
+        "control. When this leaves the battlefield, that card returns to the battlefield.)\n" +
+        "When a Faerie is championed with this creature, tap all lands target player controls."
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+    champion(Subtype.FAERIE)
+
+    triggeredAbility {
+        trigger = Triggers.championedWith()
+        val player = target("target player", Targets.Player)
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.BattlefieldMatching(
+                        filter = GameObjectFilter.Land.targetPlayerControls(player),
+                        player = Player.Each
+                    ),
+                    storeAs = "mistbindClique_lands"
+                ),
+                TapUntapCollectionEffect("mistbindClique_lands", tap = true)
+            )
+        )
+        description = "When a Faerie is championed with this creature, tap all lands target " +
+            "player controls."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "75"
+        artist = "Ben Thompson"
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cfc421e2-0dd4-4bdf-b5f5-a60c4b0df63b.jpg?1783942900"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/NovaChaser.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/NovaChaser.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.champion
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nova Chaser
+ * {3}{R}
+ * Creature — Elemental Warrior
+ * 10/2
+ *
+ * Trample
+ * Champion an Elemental
+ *
+ * "An Elemental" is a bare tribal noun, so per CR 109.2 the champion quality is an Elemental
+ * *permanent* — Lorwyn's Kindred noncreature Elementals qualify, not just creatures. The
+ * [champion] `Subtype` overload builds exactly that filter.
+ */
+val NovaChaser = card("Nova Chaser") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental Warrior"
+    power = 10
+    toughness = 2
+    oracleText = "Trample\n" +
+        "Champion an Elemental (When this enters, sacrifice it unless you exile another Elemental " +
+        "you control. When this leaves the battlefield, that card returns to the battlefield.)"
+
+    keywords(Keyword.TRAMPLE)
+    champion(Subtype.ELEMENTAL)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "187"
+        artist = "Dan Murayama Scott"
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/07f97507-abbe-4c8b-9683-f044e38f8d4b.jpg?1783942870"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ThoughtweftTrio.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ThoughtweftTrio.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.champion
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CanBlockAnyNumber
+
+/**
+ * Thoughtweft Trio
+ * {2}{W}{W}
+ * Creature — Kithkin Soldier
+ * 5/5
+ *
+ * First strike, vigilance
+ * Champion a Kithkin
+ * This creature can block any number of creatures.
+ */
+val ThoughtweftTrio = card("Thoughtweft Trio") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kithkin Soldier"
+    power = 5
+    toughness = 5
+    oracleText = "First strike, vigilance\n" +
+        "Champion a Kithkin (When this enters, sacrifice it unless you exile another Kithkin you " +
+        "control. When this leaves the battlefield, that card returns to the battlefield.)\n" +
+        "This creature can block any number of creatures."
+
+    keywords(Keyword.FIRST_STRIKE, Keyword.VIGILANCE)
+    champion(Subtype.KITHKIN)
+
+    staticAbility {
+        ability = CanBlockAnyNumber()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "44"
+        artist = "Wayne Reynolds"
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9e48d34d-063c-4703-870b-4a22d5774c89.jpg?1783942908"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WanderwineProphets.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WanderwineProphets.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.champion
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+
+/**
+ * Wanderwine Prophets
+ * {4}{U}{U}
+ * Creature — Merfolk Wizard
+ * 4/4
+ *
+ * Champion a Merfolk
+ * Whenever this creature deals combat damage to a player, you may sacrifice a Merfolk. If you do,
+ * take an extra turn after this one.
+ *
+ * "You may sacrifice a Merfolk. If you do, …" is [MayEffect] over [IfYouDoEffect]: the yes/no is
+ * the "may", and the extra turn is gated on the sacrifice actually happening — declining, or having
+ * no Merfolk to give, takes no extra turn. The Prophets are themselves a Merfolk, so sacrificing
+ * this creature to its own trigger is a legal (and printed) line.
+ */
+val WanderwineProphets = card("Wanderwine Prophets") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    power = 4
+    toughness = 4
+    oracleText = "Champion a Merfolk (When this enters, sacrifice it unless you exile another " +
+        "Merfolk you control. When this leaves the battlefield, that card returns to the battlefield.)\n" +
+        "Whenever this creature deals combat damage to a player, you may sacrifice a Merfolk. If " +
+        "you do, take an extra turn after this one."
+
+    champion(Subtype.MERFOLK)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = MayEffect(
+            IfYouDoEffect(
+                action = Effects.SacrificeOwn(
+                    GameObjectFilter.Permanent.withSubtype(Subtype.MERFOLK)
+                ),
+                ifYouDo = Effects.TakeExtraTurn(),
+                successCriterion = SuccessCriterion.PermanentsSacrificed
+            )
+        )
+        description = "Whenever this creature deals combat damage to a player, you may sacrifice " +
+            "a Merfolk. If you do, take an extra turn after this one."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "95"
+        artist = "Alex Horley-Orlandelli"
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6cdbb6ff-c945-4dd6-aba6-4fd4b77824c0.jpg?1783942895"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WrensRunPackmaster.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WrensRunPackmaster.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.champion
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Wren's Run Packmaster
+ * {3}{G}
+ * Creature — Elf Warrior
+ * 5/5
+ *
+ * Champion an Elf
+ * {2}{G}: Create a 2/2 green Wolf creature token.
+ * Wolves you control have deathtouch.
+ *
+ * The lord clause is every Wolf permanent you control, not only the tokens this makes
+ * (2007-10-01 ruling), and the Packmaster is not itself a Wolf so there is no self-exclusion.
+ */
+val WrensRunPackmaster = card("Wren's Run Packmaster") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    power = 5
+    toughness = 5
+    oracleText = "Champion an Elf (When this creature enters, sacrifice it unless you exile " +
+        "another Elf you control. When this creature leaves the battlefield, that card returns " +
+        "to the battlefield.)\n" +
+        "{2}{G}: Create a 2/2 green Wolf creature token.\n" +
+        "Wolves you control have deathtouch."
+
+    champion(Subtype.ELF)
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{G}")
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Wolf"),
+            imageUri = "https://cards.scryfall.io/normal/front/0/2/02a80dc2-0811-4df0-95f1-dd80ce9e24de.jpg?1783942837"
+        )
+        description = "Create a 2/2 green Wolf creature token."
+    }
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.DEATHTOUCH,
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.withSubtype(Subtype.WOLF).youControl()
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "244"
+        artist = "Mark Zug"
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3e97f29a-1551-4e75-80e8-2dd31cb6c0db.jpg?1783942855"
+
+        ruling(
+            "2007-10-01",
+            "Wren's Run Packmaster gives deathtouch to all Wolf permanents you control, not just " +
+                "the tokens it creates."
+        )
+        ruling(
+            "2009-10-01",
+            "A Wolf's deathtouch ability will apply if both Wren's Run Packmaster and that Wolf " +
+                "are on the battlefield at the time the Wolf deals damage. The creature dealt " +
+                "damage by the Wolf will be destroyed the next time state-based actions are " +
+                "checked, even if the Wolf or Wren's Run Packmaster leaves the battlefield."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BoggartMobScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BoggartMobScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CombatResolutionDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Boggart Mob (LRW #104) — champion a Goblin, plus "whenever a Goblin you control deals combat
+ * damage to a player, you may create a 1/1 black Goblin Rogue creature token."
+ *
+ * The champion keyword's matrix lives in `ChampionKeywordTest`; this pins the Mob's Goblin quality
+ * and the second ability's three easy-to-get-wrong axes: it watches *any* Goblin you control (not
+ * just the Mob), it is a "may", and an opponent's Goblin doesn't count.
+ */
+class BoggartMobScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Boggart Mob — champion a Goblin") {
+
+            test("only Goblins you control are offered as the champion choice") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Boggart Mob")
+                    .withCardOnBattlefield(1, "Boggart Forager")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Mad Auntie")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Boggart Mob").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                decision.options shouldContain game.findPermanent("Boggart Forager")!!
+                withClue("a Bear is not a Goblin") {
+                    decision.options shouldNotContain game.findPermanent("Grizzly Bears")!!
+                }
+                withClue("Bob's Goblin is not one you control") {
+                    decision.options shouldNotContain game.findPermanent("Mad Auntie")!!
+                }
+            }
+
+            test("exiling the Goblin keeps the Mob, and it returns when the Mob dies") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Boggart Mob")
+                    .withCardInHand(1, "Murder")
+                    .withCardOnBattlefield(1, "Boggart Forager")
+                    .withLandsOnBattlefield(1, "Swamp", 8)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forager = game.findPermanent("Boggart Forager")!!
+                game.castSpell(1, "Boggart Mob").error shouldBe null
+                game.resolveStack()
+                game.selectCards(listOf(forager)).error shouldBe null
+                game.resolveStack()
+                game.isInExile(1, "Boggart Forager") shouldBe true
+
+                game.castSpell(1, "Murder", game.findPermanent("Boggart Mob")!!).error shouldBe null
+                game.resolveStack()
+                game.isOnBattlefield("Boggart Forager") shouldBe true
+            }
+        }
+
+        context("Boggart Mob — whenever a Goblin you control deals combat damage to a player") {
+
+            test("another Goblin's combat damage makes a token when you say yes") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Boggart Mob", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Boggart Forager", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Boggart Forager" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.getPendingDecision() is CombatResolutionDecision) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+                game.answerYesNo(true).error shouldBe null
+                game.resolveStack()
+
+                withClue("the trigger watches every Goblin you control, not only the Mob") {
+                    game.findPermanents("Goblin Rogue Token").size shouldBe 1
+                }
+            }
+
+            test("declining the 'may' makes no token") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Boggart Mob", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Boggart Mob" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.getPendingDecision() is CombatResolutionDecision) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+                game.answerYesNo(false).error shouldBe null
+                game.resolveStack()
+
+                game.findPermanents("Goblin Rogue Token").size shouldBe 0
+            }
+
+            test("a non-Goblin attacker does not trigger it") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Boggart Mob", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.getPendingDecision() is CombatResolutionDecision) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("no Goblin dealt the damage, so nothing was asked") {
+                    game.hasPendingDecision() shouldBe false
+                    game.findPermanents("Goblin Rogue Token").size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ChangelingBerserkerScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ChangelingBerserkerScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+
+/**
+ * Changeling Berserker (LRW #160) — changeling, haste, champion a creature.
+ *
+ * The Champion keyword's own rules matrix lives in `ChampionKeywordTest`; what this file pins is
+ * that *this card* is wired to it with the printed quality ("a creature", not a tribe) and that its
+ * two other keywords survive alongside it.
+ */
+class ChangelingBerserkerScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Changeling Berserker — champion a creature") {
+
+            test("the champion choice offers every other creature you control, whatever its type") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Changeling Berserker")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Llanowar Elves")
+                    .withCardOnBattlefield(2, "Savannah Lions")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Changeling Berserker").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                withClue("'another creature you control' — not the Berserker, not Bob's Bears") {
+                    decision.options shouldContainExactlyInAnyOrder listOf(
+                        game.findPermanent("Grizzly Bears")!!,
+                        game.findPermanent("Llanowar Elves")!!
+                    )
+                }
+            }
+
+            test("exiling an Elf keeps the Berserker, and the Elf comes back when it dies") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Changeling Berserker")
+                    .withCardInHand(1, "Doom Blade")
+                    .withCardOnBattlefield(1, "Llanowar Elves")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val elf = game.findPermanent("Llanowar Elves")!!
+                game.castSpell(1, "Changeling Berserker").error shouldBe null
+                game.resolveStack()
+                game.selectCards(listOf(elf)).error shouldBe null
+                game.resolveStack()
+
+                val berserker = game.findPermanent("Changeling Berserker")!!
+                withClue("the Berserker stays; the Elf is exiled") {
+                    game.isOnBattlefield("Changeling Berserker") shouldBe true
+                    game.isInExile(1, "Llanowar Elves") shouldBe true
+                }
+
+                game.castSpell(1, "Doom Blade", berserker).error shouldBe null
+                game.resolveStack()
+
+                withClue("the leaves trigger returns the championed Elf") {
+                    game.isOnBattlefield("Changeling Berserker") shouldBe false
+                    game.isOnBattlefield("Llanowar Elves") shouldBe true
+                }
+            }
+
+            test("declining the choice sacrifices the Berserker") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Changeling Berserker")
+                    .withCardOnBattlefield(1, "Llanowar Elves")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Changeling Berserker").error shouldBe null
+                game.resolveStack()
+                game.skipSelection().error shouldBe null
+                game.resolveStack()
+
+                game.isInGraveyard(1, "Changeling Berserker") shouldBe true
+                withClue("nothing was exiled") {
+                    game.isOnBattlefield("Llanowar Elves") shouldBe true
+                }
+            }
+
+            test("it is every creature type and has haste") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Changeling Berserker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val berserker = game.findPermanent("Changeling Berserker")!!
+                val projected = stateProjector.project(game.state)
+                projected.hasKeyword(berserker, Keyword.CHANGELING) shouldBe true
+                projected.hasKeyword(berserker, Keyword.HASTE) shouldBe true
+                projected.getPower(berserker) shouldBe 5
+                projected.getToughness(berserker) shouldBe 3
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ChangelingHeroScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ChangelingHeroScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Changeling Hero (LRW #9) — changeling, champion a creature, lifelink.
+ *
+ * The Champion keyword's rules matrix lives in `ChampionKeywordTest`; this pins the card's own
+ * wiring: the champion clause with the printed "a creature" quality, and lifelink surviving it.
+ */
+class ChangelingHeroScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Changeling Hero — champion a creature, lifelink") {
+
+            test("exiling a creature keeps the Hero, and it returns when the Hero dies") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Changeling Hero")
+                    .withCardInHand(1, "Doom Blade")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Changeling Hero").error shouldBe null
+                game.resolveStack()
+                game.selectCards(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Changeling Hero") shouldBe true
+                game.isInExile(1, "Grizzly Bears") shouldBe true
+
+                game.castSpell(1, "Doom Blade", game.findPermanent("Changeling Hero")!!).error shouldBe null
+                game.resolveStack()
+
+                withClue("the linked leaves trigger returns the championed Bears") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("with no other creature the Hero is sacrificed, with no prompt") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Changeling Hero")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Changeling Hero").error shouldBe null
+                game.resolveStack()
+
+                withClue("nothing to exile means nothing to ask") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                game.isInGraveyard(1, "Changeling Hero") shouldBe true
+            }
+
+            test("it is every creature type and has lifelink") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Changeling Hero")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hero = game.findPermanent("Changeling Hero")!!
+                val projected = stateProjector.project(game.state)
+                projected.hasKeyword(hero, Keyword.CHANGELING) shouldBe true
+                projected.hasKeyword(hero, Keyword.LIFELINK) shouldBe true
+                projected.getPower(hero) shouldBe 4
+                projected.getToughness(hero) shouldBe 4
+            }
+
+            test("lifelink gains life when it deals combat damage") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Changeling Hero", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Changeling Hero" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                game.getLifeTotal(2) shouldBe 16
+                withClue("lifelink: 4 damage dealt is 4 life gained") {
+                    game.getLifeTotal(1) shouldBe 24
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ChangelingTitanScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ChangelingTitanScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Changeling Titan (LRW #200) — changeling, champion a creature, 7/7.
+ *
+ * The Champion keyword's rules matrix lives in `ChampionKeywordTest`; this pins the card's own
+ * wiring and the one thing changeling makes worth restating: being every creature type does not
+ * make the Titan a legal choice for its *own* champion ability ("another").
+ */
+class ChangelingTitanScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Changeling Titan — champion a creature") {
+
+            test("the Titan is never its own champion choice, despite being every creature type") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Changeling Titan")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Changeling Titan").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                val titan = game.findPermanent("Changeling Titan")!!
+                withClue("'another creature you control' excludes the Titan itself") {
+                    decision.options shouldNotContain titan
+                }
+                decision.options shouldBe listOf(game.findPermanent("Grizzly Bears")!!)
+            }
+
+            test("exiling a creature keeps the Titan, and it returns when the Titan dies") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Changeling Titan")
+                    .withCardInHand(1, "Doom Blade")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Changeling Titan").error shouldBe null
+                game.resolveStack()
+                game.selectCards(listOf(bears)).error shouldBe null
+                game.resolveStack()
+                game.isInExile(1, "Grizzly Bears") shouldBe true
+
+                game.castSpell(1, "Doom Blade", game.findPermanent("Changeling Titan")!!).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Grizzly Bears") shouldBe true
+            }
+
+            test("it is a 7/7 of every creature type") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Changeling Titan")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val titan = game.findPermanent("Changeling Titan")!!
+                val projected = stateProjector.project(game.state)
+                projected.hasKeyword(titan, Keyword.CHANGELING) shouldBe true
+                projected.getPower(titan) shouldBe 7
+                projected.getToughness(titan) shouldBe 7
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MistbindCliqueScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MistbindCliqueScenarioTest.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mistbind Clique (LRW #75) — flash, flying, champion a Faerie, and the CR 702.72c payoff:
+ * "When a Faerie is championed with this creature, tap all lands target player controls."
+ *
+ * The champion keyword's own matrix lives in `ChampionKeywordTest`. What this file pins is the
+ * follow-up trigger: that it fires *only* when a Faerie was actually championed, that it is a
+ * separate targeted ability (so the player is chosen on the stack), and that it taps only that
+ * player's lands.
+ */
+class MistbindCliqueScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    private fun tappedCount(game: ScenarioTestBase.TestGame, ids: List<EntityId>): Int =
+        ids.count { game.state.getEntity(it)?.has<TappedComponent>() == true }
+
+    init {
+        context("Mistbind Clique — when a Faerie is championed with this creature") {
+
+            test("championing a Faerie taps all lands the targeted player controls") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Mistbind Clique")
+                    .withCardOnBattlefield(1, "Spellstutter Sprite")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withLandsOnBattlefield(2, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bobLands = game.findPermanents("Forest")
+                val sprite = game.findPermanent("Spellstutter Sprite")!!
+
+                game.castSpell(1, "Mistbind Clique").error shouldBe null
+                game.resolveStack()
+                game.selectCards(listOf(sprite)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the champion clause exiled the Faerie, so the Clique stays") {
+                    game.isOnBattlefield("Mistbind Clique") shouldBe true
+                    game.isInExile(1, "Spellstutter Sprite") shouldBe true
+                }
+
+                // Alice's own Islands are already tapped — she paid for the Clique with them — so
+                // the honest assertion is that the trigger changes nothing on her side.
+                val aliceTappedBefore = tappedCount(game, game.findPermanents("Island"))
+                withClue("nothing has tapped Bob's lands yet") {
+                    tappedCount(game, bobLands) shouldBe 0
+                }
+
+                // The follow-up trigger is a separate object on the stack with its own player
+                // target, chosen when it is put on the stack rather than when the Clique entered.
+                game.selectTargets(listOf(game.player2Id)).error shouldBe null
+                game.resolveStack()
+
+                withClue("all three of Bob's lands are tapped") {
+                    tappedCount(game, bobLands) shouldBe 3
+                }
+                withClue("Alice's own lands are untouched — only the targeted player's tap") {
+                    tappedCount(game, game.findPermanents("Island")) shouldBe aliceTappedBefore
+                }
+            }
+
+            test("declining the champion choice sacrifices the Clique and taps nothing") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Mistbind Clique")
+                    .withCardOnBattlefield(1, "Spellstutter Sprite")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withLandsOnBattlefield(2, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Mistbind Clique").error shouldBe null
+                game.resolveStack()
+                game.skipSelection().error shouldBe null
+                game.resolveStack()
+
+                game.isInGraveyard(1, "Mistbind Clique") shouldBe true
+                withClue("nothing was championed, so the follow-up never triggered") {
+                    game.hasPendingDecision() shouldBe false
+                    tappedCount(game, game.findPermanents("Forest")) shouldBe 0
+                }
+            }
+
+            test("it is a 4/4 with flying") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Mistbind Clique")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val clique = game.findPermanent("Mistbind Clique")!!
+                val projected = stateProjector.project(game.state)
+                projected.hasKeyword(clique, Keyword.FLYING) shouldBe true
+                projected.getPower(clique) shouldBe 4
+                projected.getToughness(clique) shouldBe 4
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NovaChaserScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NovaChaserScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Nova Chaser (LRW #187) — trample, champion an Elemental.
+ *
+ * The tribal champion quality is the point here: "an Elemental" is a bare tribal noun, so per
+ * CR 109.2 it means an Elemental *permanent*, not just an Elemental creature — and a creature of
+ * some other type is not a legal choice at all.
+ */
+class NovaChaserScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Nova Chaser — champion an Elemental") {
+
+            test("only Elementals you control are offered — a Bear is not") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Nova Chaser")
+                    .withCardOnBattlefield(1, "Smokebraider")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Nova Chaser").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                decision.options shouldContain game.findPermanent("Smokebraider")!!
+                withClue("Grizzly Bears is a Bear, not an Elemental") {
+                    decision.options shouldNotContain game.findPermanent("Grizzly Bears")!!
+                }
+            }
+
+            test("exiling the Elemental keeps the Chaser, and it returns when the Chaser dies") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Nova Chaser")
+                    .withCardInHand(1, "Doom Blade")
+                    .withCardOnBattlefield(1, "Smokebraider")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val smokebraider = game.findPermanent("Smokebraider")!!
+                game.castSpell(1, "Nova Chaser").error shouldBe null
+                game.resolveStack()
+                game.selectCards(listOf(smokebraider)).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Nova Chaser") shouldBe true
+                game.isInExile(1, "Smokebraider") shouldBe true
+
+                game.castSpell(1, "Doom Blade", game.findPermanent("Nova Chaser")!!).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Smokebraider") shouldBe true
+            }
+
+            test("with no other Elemental the Chaser is sacrificed") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Nova Chaser")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Nova Chaser").error shouldBe null
+                game.resolveStack()
+
+                game.hasPendingDecision() shouldBe false
+                game.isInGraveyard(1, "Nova Chaser") shouldBe true
+                withClue("the Bear was never a legal choice, so it is untouched") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("it is a 10/2 with trample") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Nova Chaser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val chaser = game.findPermanent("Nova Chaser")!!
+                val projected = stateProjector.project(game.state)
+                projected.hasKeyword(chaser, Keyword.TRAMPLE) shouldBe true
+                projected.getPower(chaser) shouldBe 10
+                projected.getToughness(chaser) shouldBe 2
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ThoughtweftTrioScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ThoughtweftTrioScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Thoughtweft Trio (LRW #44) — first strike, vigilance, champion a Kithkin, and "this creature can
+ * block any number of creatures."
+ *
+ * The champion keyword's matrix lives in `ChampionKeywordTest`; this pins the Kithkin quality and
+ * the multi-block static, which is the ability a normal blocking-legality check would refuse.
+ */
+class ThoughtweftTrioScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Thoughtweft Trio — champion a Kithkin") {
+
+            test("only Kithkin you control are offered") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Thoughtweft Trio")
+                    .withCardOnBattlefield(1, "Kinsbaile Balloonist")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Thoughtweft Trio").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                decision.options shouldContain game.findPermanent("Kinsbaile Balloonist")!!
+                withClue("a Bear is not a Kithkin") {
+                    decision.options shouldNotContain game.findPermanent("Grizzly Bears")!!
+                }
+            }
+
+            test("exiling the Kithkin keeps the Trio, and it returns when the Trio dies") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Thoughtweft Trio")
+                    .withCardInHand(1, "Doom Blade")
+                    .withCardOnBattlefield(1, "Kinsbaile Balloonist")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kithkin = game.findPermanent("Kinsbaile Balloonist")!!
+                game.castSpell(1, "Thoughtweft Trio").error shouldBe null
+                game.resolveStack()
+                game.selectCards(listOf(kithkin)).error shouldBe null
+                game.resolveStack()
+                game.isInExile(1, "Kinsbaile Balloonist") shouldBe true
+
+                game.castSpell(1, "Doom Blade", game.findPermanent("Thoughtweft Trio")!!).error shouldBe null
+                game.resolveStack()
+                game.isOnBattlefield("Kinsbaile Balloonist") shouldBe true
+            }
+        }
+
+        context("Thoughtweft Trio — can block any number of creatures") {
+
+            test("it blocks two attackers at once and kills both with first strike") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Thoughtweft Trio", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Savannah Lions", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 1, "Savannah Lions" to 1))
+                    .error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(
+                    mapOf("Thoughtweft Trio" to listOf("Grizzly Bears", "Savannah Lions"))
+                ).error shouldBe null
+                game.resolveStack()
+                game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+
+                withClue("a 5/5 first striker splitting 5 damage kills a 2/2 and a 2/1") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isOnBattlefield("Savannah Lions") shouldBe false
+                }
+                withClue("first strike means neither attacker ever dealt its damage back") {
+                    game.isOnBattlefield("Thoughtweft Trio") shouldBe true
+                }
+            }
+
+            test("it is a 5/5 with first strike and vigilance") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Thoughtweft Trio")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val trio = game.findPermanent("Thoughtweft Trio")!!
+                val projected = stateProjector.project(game.state)
+                projected.hasKeyword(trio, Keyword.FIRST_STRIKE) shouldBe true
+                projected.hasKeyword(trio, Keyword.VIGILANCE) shouldBe true
+                projected.getPower(trio) shouldBe 5
+                projected.getToughness(trio) shouldBe 5
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WanderwineProphetsScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WanderwineProphetsScenarioTest.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CombatResolutionDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.player.SkipNextTurnComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wanderwine Prophets (LRW #95) — champion a Merfolk, plus "whenever this creature deals combat
+ * damage to a player, you may sacrifice a Merfolk. If you do, take an extra turn after this one."
+ *
+ * The champion keyword's matrix lives in `ChampionKeywordTest`; this pins the Merfolk quality and
+ * the extra-turn clause's gate: the turn is owed to the *sacrifice actually happening*, not to
+ * saying yes. In a two-player game an extra turn is modelled as the opponent skipping their next,
+ * which is what the assertions read.
+ */
+class WanderwineProphetsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Wanderwine Prophets — champion a Merfolk") {
+
+            test("only Merfolk you control are offered") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Wanderwine Prophets")
+                    .withCardOnBattlefield(1, "Sygg, River Guide")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Wanderwine Prophets").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                decision.options shouldContain game.findPermanent("Sygg, River Guide")!!
+                withClue("a Bear is not a Merfolk") {
+                    decision.options shouldNotContain game.findPermanent("Grizzly Bears")!!
+                }
+            }
+
+            test("exiling the Merfolk keeps the Prophets, and it returns when they die") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Wanderwine Prophets")
+                    .withCardInHand(1, "Doom Blade")
+                    .withCardOnBattlefield(1, "Sygg, River Guide")
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sygg = game.findPermanent("Sygg, River Guide")!!
+                game.castSpell(1, "Wanderwine Prophets").error shouldBe null
+                game.resolveStack()
+                game.selectCards(listOf(sygg)).error shouldBe null
+                game.resolveStack()
+                game.isInExile(1, "Sygg, River Guide") shouldBe true
+
+                game.castSpell(1, "Doom Blade", game.findPermanent("Wanderwine Prophets")!!)
+                    .error shouldBe null
+                game.resolveStack()
+                game.isOnBattlefield("Sygg, River Guide") shouldBe true
+            }
+        }
+
+        context("Wanderwine Prophets — combat damage, sacrifice a Merfolk, extra turn") {
+
+            test("sacrificing a Merfolk takes an extra turn") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Wanderwine Prophets", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Sygg, River Guide")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sygg = game.findPermanent("Sygg, River Guide")!!
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Wanderwine Prophets" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.getPendingDecision() is CombatResolutionDecision) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+                game.answerYesNo(true).error shouldBe null
+                if (game.getPendingDecision() is SelectCardsDecision) {
+                    game.selectCards(listOf(sygg)).error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the sacrifice happened, so the extra turn is owed") {
+                    game.isInGraveyard(1, "Sygg, River Guide") shouldBe true
+                    game.state.getEntity(game.player2Id)?.has<SkipNextTurnComponent>() shouldBe true
+                }
+            }
+
+            test("declining takes no extra turn") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Wanderwine Prophets", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Sygg, River Guide")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Wanderwine Prophets" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.getPendingDecision() is CombatResolutionDecision) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+                game.answerYesNo(false).error shouldBe null
+                game.resolveStack()
+
+                withClue("no sacrifice, no extra turn") {
+                    game.isOnBattlefield("Sygg, River Guide") shouldBe true
+                    game.state.getEntity(game.player2Id)?.has<SkipNextTurnComponent>() shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WrensRunPackmasterScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WrensRunPackmasterScenarioTest.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.WrensRunPackmaster
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wren's Run Packmaster (LRW #244) — champion an Elf, "{2}{G}: Create a 2/2 green Wolf creature
+ * token", and "Wolves you control have deathtouch."
+ *
+ * The champion keyword's matrix lives in `ChampionKeywordTest`; this pins the Elf quality and the
+ * lord clause's printed scope — every Wolf permanent you control, not only the tokens this makes
+ * (2007-10-01 ruling).
+ */
+class WrensRunPackmasterScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+    private val wolfAbility = WrensRunPackmaster.activatedAbilities.single().id
+
+    init {
+        context("Wren's Run Packmaster — champion an Elf") {
+
+            test("only Elves you control are offered") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Wren's Run Packmaster")
+                    .withCardOnBattlefield(1, "Llanowar Elves")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Wren's Run Packmaster").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                decision.options shouldContain game.findPermanent("Llanowar Elves")!!
+                withClue("a Bear is not an Elf") {
+                    decision.options shouldNotContain game.findPermanent("Grizzly Bears")!!
+                }
+            }
+
+            test("exiling the Elf keeps the Packmaster, and it returns when the Packmaster dies") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Wren's Run Packmaster")
+                    .withCardInHand(1, "Doom Blade")
+                    .withCardOnBattlefield(1, "Llanowar Elves")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val elf = game.findPermanent("Llanowar Elves")!!
+                game.castSpell(1, "Wren's Run Packmaster").error shouldBe null
+                game.resolveStack()
+                game.selectCards(listOf(elf)).error shouldBe null
+                game.resolveStack()
+                game.isInExile(1, "Llanowar Elves") shouldBe true
+
+                game.castSpell(1, "Doom Blade", game.findPermanent("Wren's Run Packmaster")!!)
+                    .error shouldBe null
+                game.resolveStack()
+                game.isOnBattlefield("Llanowar Elves") shouldBe true
+            }
+        }
+
+        context("Wren's Run Packmaster — Wolves and deathtouch") {
+
+            test("the activated ability makes a 2/2 Wolf token, and it has deathtouch") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Wren's Run Packmaster")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val packmaster = game.findPermanent("Wren's Run Packmaster")!!
+                game.execute(ActivateAbility(game.player1Id, packmaster, wolfAbility))
+                    .error shouldBe null
+                game.resolveStack()
+
+                val wolf = game.findPermanent("Wolf Token")!!
+                val projected = stateProjector.project(game.state)
+                projected.getPower(wolf) shouldBe 2
+                projected.getToughness(wolf) shouldBe 2
+                withClue("Wolves you control have deathtouch") {
+                    projected.hasKeyword(wolf, Keyword.DEATHTOUCH) shouldBe true
+                }
+                withClue("the Packmaster is an Elf Warrior, not a Wolf — it gets nothing") {
+                    projected.hasKeyword(packmaster, Keyword.DEATHTOUCH) shouldBe false
+                }
+            }
+
+            test("the lord clause reaches every Wolf you control, and no opponent's") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Wren's Run Packmaster")
+                    .withCardOnBattlefield(1, "Timber Wolves")
+                    .withCardOnBattlefield(2, "Timber Wolves")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wolves = game.findPermanents("Timber Wolves")
+                val projected = stateProjector.project(game.state)
+                val mine = wolves.first { projected.getController(it) == game.player1Id }
+                val theirs = wolves.first { projected.getController(it) == game.player2Id }
+
+                withClue("a Wolf that did not come from this Packmaster still gets deathtouch") {
+                    projected.hasKeyword(mine, Keyword.DEATHTOUCH) shouldBe true
+                }
+                withClue("'Wolves you control' — Bob's Wolf is untouched") {
+                    projected.hasKeyword(theirs, Keyword.DEATHTOUCH) shouldBe false
+                }
+            }
+
+            test("it is a 5/5") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Wren's Run Packmaster")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val packmaster = game.findPermanent("Wren's Run Packmaster")!!
+                val projected = stateProjector.project(game.state)
+                projected.getPower(packmaster) shouldBe 5
+                projected.getToughness(packmaster) shouldBe 5
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/WrensRunPackmasterReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/WrensRunPackmasterReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wren's Run Packmaster reprint in Commander 2014. Its canonical card definition lives in Lorwyn;
+ * this file contributes only the Commander 2014 presentation data.
+ */
+val WrensRunPackmasterReprint = Printing(
+    oracleId = "d4d27fef-e86b-4dd3-a15e-a0db8d0725ee",
+    name = "Wren's Run Packmaster",
+    setCode = "C14",
+    collectorNumber = "227",
+    scryfallId = "28f75cac-a93f-4908-a524-b61e7b3fb275",
+    artist = "Mark Zug",
+    imageUri = "https://cards.scryfall.io/normal/front/2/8/28f75cac-a93f-4908-a524-b61e7b3fb275.jpg?1783938825",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -1679,6 +1679,162 @@
     ]
 }
 
+// Boggart Mob
+{
+    "name": "Boggart Mob",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Champion a Goblin (When this enters, sacrifice it unless you exile another Goblin you control. When this leaves the battlefield, that card returns to the battlefield.)\nWhenever a Goblin you control deals combat damage to a player, you may create a 1/1 black Goblin Rogue creature token.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "CHAMPION"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "BattlefieldMatching",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                "IsPermanent",
+                                                {
+                                                    "type": "HasSubtype",
+                                                    "subtype": "Goblin"
+                                                }
+                                            ],
+                                            "statePredicates": [
+                                                {
+                                                    "type": "StateNot",
+                                                    "predicate": "IsSource"
+                                                }
+                                            ]
+                                        },
+                                        "player": "You"
+                                    },
+                                    "storeAs": "championCandidates"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "championCandidates",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "championChoice",
+                                    "prompt": "Exile another a Goblin you control, or choose nothing to sacrifice this permanent",
+                                    "selectedLabel": "Exile",
+                                    "useTargetingUI": true
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "championChoice",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Exile"
+                                    },
+                                    "linkToSource": true,
+                                    "storeMovedAs": "championedCards"
+                                }
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "championedCards"
+                        }
+                    },
+                    "then": "EmitChampionedEvent",
+                    "otherwise": "SacrificeSelf"
+                },
+                "descriptionOverride": "Champion a Goblin (When this enters, sacrifice it unless you exile another a Goblin you control. When this leaves the battlefield, that card returns to the battlefield.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this permanent leaves the battlefield, return the exiled card to the battlefield under its owner's control."
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer",
+                    "sourceFilter": "permanent Goblin ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "BLACK"
+                        ],
+                        "creatureTypes": [
+                            "Goblin",
+                            "Rogue"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f44d5271-5d10-46b2-9ba2-5788d99de2e6.jpg?1783942839"
+                    }
+                },
+                "descriptionOverride": "Whenever a Goblin you control deals combat damage to a player, you may create a 1/1 black Goblin Rogue creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "104",
+        "rarity": "RARE",
+        "artist": "Thomas Denmark",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a61990de-0daf-4340-8e6b-c49852d46980.jpg?1783942893"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Boggart Shenanigans
 {
     "name": "Boggart Shenanigans",
@@ -2424,6 +2580,383 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Changeling Berserker
+{
+    "name": "Changeling Berserker",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\nHaste\nChampion a creature (When this enters, sacrifice it unless you exile another creature you control. When this leaves the battlefield, that card returns to the battlefield.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "keywords": [
+        "CHANGELING",
+        "HASTE",
+        "CHAMPION"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "BattlefieldMatching",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                "IsCreature"
+                                            ],
+                                            "statePredicates": [
+                                                {
+                                                    "type": "StateNot",
+                                                    "predicate": "IsSource"
+                                                }
+                                            ]
+                                        },
+                                        "player": "You"
+                                    },
+                                    "storeAs": "championCandidates"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "championCandidates",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "championChoice",
+                                    "prompt": "Exile another a creature you control, or choose nothing to sacrifice this permanent",
+                                    "selectedLabel": "Exile",
+                                    "useTargetingUI": true
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "championChoice",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Exile"
+                                    },
+                                    "linkToSource": true,
+                                    "storeMovedAs": "championedCards"
+                                }
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "championedCards"
+                        }
+                    },
+                    "then": "EmitChampionedEvent",
+                    "otherwise": "SacrificeSelf"
+                },
+                "descriptionOverride": "Champion a creature (When this enters, sacrifice it unless you exile another a creature you control. When this leaves the battlefield, that card returns to the battlefield.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this permanent leaves the battlefield, return the exiled card to the battlefield under its owner's control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "rarity": "UNCOMMON",
+        "artist": "Warren Mahy",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9f2e8f24-2ee1-4516-bf60-7fe6a0c4baec.jpg?1783942877"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Changeling Hero
+{
+    "name": "Changeling Hero",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\nChampion a creature (When this enters, sacrifice it unless you exile another creature you control. When this leaves the battlefield, that card returns to the battlefield.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "CHANGELING",
+        "LIFELINK",
+        "CHAMPION"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "BattlefieldMatching",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                "IsCreature"
+                                            ],
+                                            "statePredicates": [
+                                                {
+                                                    "type": "StateNot",
+                                                    "predicate": "IsSource"
+                                                }
+                                            ]
+                                        },
+                                        "player": "You"
+                                    },
+                                    "storeAs": "championCandidates"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "championCandidates",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "championChoice",
+                                    "prompt": "Exile another a creature you control, or choose nothing to sacrifice this permanent",
+                                    "selectedLabel": "Exile",
+                                    "useTargetingUI": true
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "championChoice",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Exile"
+                                    },
+                                    "linkToSource": true,
+                                    "storeMovedAs": "championedCards"
+                                }
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "championedCards"
+                        }
+                    },
+                    "then": "EmitChampionedEvent",
+                    "otherwise": "SacrificeSelf"
+                },
+                "descriptionOverride": "Champion a creature (When this enters, sacrifice it unless you exile another a creature you control. When this leaves the battlefield, that card returns to the battlefield.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this permanent leaves the battlefield, return the exiled card to the battlefield under its owner's control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "UNCOMMON",
+        "artist": "Jeff Miracola",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/24f0c586-a1a5-4907-801a-7815c4dceb39.jpg?1783942917"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Changeling Titan
+{
+    "name": "Changeling Titan",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\nChampion a creature (When this enters, sacrifice it unless you exile another creature you control. When this leaves the battlefield, that card returns to the battlefield.)",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "CHANGELING",
+        "CHAMPION"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "BattlefieldMatching",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                "IsCreature"
+                                            ],
+                                            "statePredicates": [
+                                                {
+                                                    "type": "StateNot",
+                                                    "predicate": "IsSource"
+                                                }
+                                            ]
+                                        },
+                                        "player": "You"
+                                    },
+                                    "storeAs": "championCandidates"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "championCandidates",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "championChoice",
+                                    "prompt": "Exile another a creature you control, or choose nothing to sacrifice this permanent",
+                                    "selectedLabel": "Exile",
+                                    "useTargetingUI": true
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "championChoice",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Exile"
+                                    },
+                                    "linkToSource": true,
+                                    "storeMovedAs": "championedCards"
+                                }
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "championedCards"
+                        }
+                    },
+                    "then": "EmitChampionedEvent",
+                    "otherwise": "SacrificeSelf"
+                },
+                "descriptionOverride": "Champion a creature (When this enters, sacrifice it unless you exile another a creature you control. When this leaves the battlefield, that card returns to the battlefield.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this permanent leaves the battlefield, return the exiled card to the battlefield under its owner's control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "200",
+        "rarity": "UNCOMMON",
+        "artist": "Jesper Ejsing",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d5b9719-2861-477e-bb78-225fd03d7bbc.jpg?1783942866"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -10429,6 +10962,173 @@
     ]
 }
 
+// Mistbind Clique
+{
+    "name": "Mistbind Clique",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Faerie Wizard",
+    "oracleText": "Flash\nFlying\nChampion a Faerie (When this enters, sacrifice it unless you exile another Faerie you control. When this leaves the battlefield, that card returns to the battlefield.)\nWhen a Faerie is championed with this creature, tap all lands target player controls.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING",
+        "CHAMPION"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "BattlefieldMatching",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                "IsPermanent",
+                                                {
+                                                    "type": "HasSubtype",
+                                                    "subtype": "Faerie"
+                                                }
+                                            ],
+                                            "statePredicates": [
+                                                {
+                                                    "type": "StateNot",
+                                                    "predicate": "IsSource"
+                                                }
+                                            ]
+                                        },
+                                        "player": "You"
+                                    },
+                                    "storeAs": "championCandidates"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "championCandidates",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "championChoice",
+                                    "prompt": "Exile another a Faerie you control, or choose nothing to sacrifice this permanent",
+                                    "selectedLabel": "Exile",
+                                    "useTargetingUI": true
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "championChoice",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Exile"
+                                    },
+                                    "linkToSource": true,
+                                    "storeMovedAs": "championedCards"
+                                }
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "championedCards"
+                        }
+                    },
+                    "then": "EmitChampionedEvent",
+                    "otherwise": "SacrificeSelf"
+                },
+                "descriptionOverride": "Champion a Faerie (When this enters, sacrifice it unless you exile another a Faerie you control. When this leaves the battlefield, that card returns to the battlefield.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this permanent leaves the battlefield, return the exiled card to the battlefield under its owner's control."
+            },
+            {
+                "id": "ability_3",
+                "trigger": "ChampionedEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsLand"
+                                    ],
+                                    "controllerPredicate": {
+                                        "type": "ControlledByReferencedPlayer",
+                                        "target": {
+                                            "type": "BoundVariable",
+                                            "name": "target player"
+                                        }
+                                    }
+                                }
+                            },
+                            "storeAs": "mistbindClique_lands"
+                        },
+                        {
+                            "type": "TapUntapCollection",
+                            "collectionName": "mistbindClique_lands"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                },
+                "descriptionOverride": "When a Faerie is championed with this creature, tap all lands target player controls."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "rarity": "RARE",
+        "artist": "Ben Thompson",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/f/cfc421e2-0dd4-4bdf-b5f5-a60c4b0df63b.jpg?1783942900"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Moonglove Extract
 {
     "name": "Moonglove Extract",
@@ -11351,6 +12051,135 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Nova Chaser
+{
+    "name": "Nova Chaser",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Elemental Warrior",
+    "oracleText": "Trample\nChampion an Elemental (When this enters, sacrifice it unless you exile another Elemental you control. When this leaves the battlefield, that card returns to the battlefield.)",
+    "creatureStats": {
+        "power": 10,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE",
+        "CHAMPION"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "BattlefieldMatching",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                "IsPermanent",
+                                                {
+                                                    "type": "HasSubtype",
+                                                    "subtype": "Elemental"
+                                                }
+                                            ],
+                                            "statePredicates": [
+                                                {
+                                                    "type": "StateNot",
+                                                    "predicate": "IsSource"
+                                                }
+                                            ]
+                                        },
+                                        "player": "You"
+                                    },
+                                    "storeAs": "championCandidates"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "championCandidates",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "championChoice",
+                                    "prompt": "Exile another an Elemental you control, or choose nothing to sacrifice this permanent",
+                                    "selectedLabel": "Exile",
+                                    "useTargetingUI": true
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "championChoice",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Exile"
+                                    },
+                                    "linkToSource": true,
+                                    "storeMovedAs": "championedCards"
+                                }
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "championedCards"
+                        }
+                    },
+                    "then": "EmitChampionedEvent",
+                    "otherwise": "SacrificeSelf"
+                },
+                "descriptionOverride": "Champion an Elemental (When this enters, sacrifice it unless you exile another an Elemental you control. When this leaves the battlefield, that card returns to the battlefield.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this permanent leaves the battlefield, return the exiled card to the battlefield under its owner's control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "rarity": "RARE",
+        "artist": "Dan Murayama Scott",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/07f97507-abbe-4c8b-9683-f044e38f8d4b.jpg?1783942870"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -15503,6 +16332,139 @@
     ]
 }
 
+// Thoughtweft Trio
+{
+    "name": "Thoughtweft Trio",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Kithkin Soldier",
+    "oracleText": "First strike, vigilance\nChampion a Kithkin (When this enters, sacrifice it unless you exile another Kithkin you control. When this leaves the battlefield, that card returns to the battlefield.)\nThis creature can block any number of creatures.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FIRST_STRIKE",
+        "VIGILANCE",
+        "CHAMPION"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "BattlefieldMatching",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                "IsPermanent",
+                                                {
+                                                    "type": "HasSubtype",
+                                                    "subtype": "Kithkin"
+                                                }
+                                            ],
+                                            "statePredicates": [
+                                                {
+                                                    "type": "StateNot",
+                                                    "predicate": "IsSource"
+                                                }
+                                            ]
+                                        },
+                                        "player": "You"
+                                    },
+                                    "storeAs": "championCandidates"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "championCandidates",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "championChoice",
+                                    "prompt": "Exile another a Kithkin you control, or choose nothing to sacrifice this permanent",
+                                    "selectedLabel": "Exile",
+                                    "useTargetingUI": true
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "championChoice",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Exile"
+                                    },
+                                    "linkToSource": true,
+                                    "storeMovedAs": "championedCards"
+                                }
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "championedCards"
+                        }
+                    },
+                    "then": "EmitChampionedEvent",
+                    "otherwise": "SacrificeSelf"
+                },
+                "descriptionOverride": "Champion a Kithkin (When this enters, sacrifice it unless you exile another a Kithkin you control. When this leaves the battlefield, that card returns to the battlefield.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this permanent leaves the battlefield, return the exiled card to the battlefield under its owner's control."
+            }
+        ],
+        "staticAbilities": [
+            "CanBlockAnyNumber"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "rarity": "RARE",
+        "artist": "Wayne Reynolds",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9e48d34d-063c-4703-870b-4a22d5774c89.jpg?1783942908"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Thousand-Year Elixir
 {
     "name": "Thousand-Year Elixir",
@@ -16418,6 +17380,159 @@
     ]
 }
 
+// Wanderwine Prophets
+{
+    "name": "Wanderwine Prophets",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "Champion a Merfolk (When this enters, sacrifice it unless you exile another Merfolk you control. When this leaves the battlefield, that card returns to the battlefield.)\nWhenever this creature deals combat damage to a player, you may sacrifice a Merfolk. If you do, take an extra turn after this one.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "CHAMPION"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "BattlefieldMatching",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                "IsPermanent",
+                                                {
+                                                    "type": "HasSubtype",
+                                                    "subtype": "Merfolk"
+                                                }
+                                            ],
+                                            "statePredicates": [
+                                                {
+                                                    "type": "StateNot",
+                                                    "predicate": "IsSource"
+                                                }
+                                            ]
+                                        },
+                                        "player": "You"
+                                    },
+                                    "storeAs": "championCandidates"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "championCandidates",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "championChoice",
+                                    "prompt": "Exile another a Merfolk you control, or choose nothing to sacrifice this permanent",
+                                    "selectedLabel": "Exile",
+                                    "useTargetingUI": true
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "championChoice",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Exile"
+                                    },
+                                    "linkToSource": true,
+                                    "storeMovedAs": "championedCards"
+                                }
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "championedCards"
+                        }
+                    },
+                    "then": "EmitChampionedEvent",
+                    "otherwise": "SacrificeSelf"
+                },
+                "descriptionOverride": "Champion a Merfolk (When this enters, sacrifice it unless you exile another a Merfolk you control. When this leaves the battlefield, that card returns to the battlefield.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this permanent leaves the battlefield, return the exiled card to the battlefield under its owner's control."
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "Sacrifice",
+                                "filter": "permanent Merfolk"
+                            },
+                            "successCriterion": "SuccessCriterion.PermanentsSacrificed"
+                        },
+                        "then": "TakeExtraTurn"
+                    }
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a player, you may sacrifice a Merfolk. If you do, take an extra turn after this one."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "rarity": "RARE",
+        "artist": "Alex Horley-Orlandelli",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6cdbb6ff-c945-4dd6-aba6-4fd4b77824c0.jpg?1783942895"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Warren Pilferers
 {
     "name": "Warren Pilferers",
@@ -17323,6 +18438,178 @@
     "colorIdentityOverride": [
         "BLACK",
         "RED"
+    ]
+}
+
+// Wren's Run Packmaster
+{
+    "name": "Wren's Run Packmaster",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "Champion an Elf (When this creature enters, sacrifice it unless you exile another Elf you control. When this creature leaves the battlefield, that card returns to the battlefield.)\n{2}{G}: Create a 2/2 green Wolf creature token.\nWolves you control have deathtouch.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "CHAMPION"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "BattlefieldMatching",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                "IsPermanent",
+                                                {
+                                                    "type": "HasSubtype",
+                                                    "subtype": "Elf"
+                                                }
+                                            ],
+                                            "statePredicates": [
+                                                {
+                                                    "type": "StateNot",
+                                                    "predicate": "IsSource"
+                                                }
+                                            ]
+                                        },
+                                        "player": "You"
+                                    },
+                                    "storeAs": "championCandidates"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "championCandidates",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "championChoice",
+                                    "prompt": "Exile another an Elf you control, or choose nothing to sacrifice this permanent",
+                                    "selectedLabel": "Exile",
+                                    "useTargetingUI": true
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "championChoice",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Exile"
+                                    },
+                                    "linkToSource": true,
+                                    "storeMovedAs": "championedCards"
+                                }
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "championedCards"
+                        }
+                    },
+                    "then": "EmitChampionedEvent",
+                    "otherwise": "SacrificeSelf"
+                },
+                "descriptionOverride": "Champion an Elf (When this enters, sacrifice it unless you exile another an Elf you control. When this leaves the battlefield, that card returns to the battlefield.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this permanent leaves the battlefield, return the exiled card to the battlefield under its owner's control."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Wolf"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/0/2/02a80dc2-0811-4df0-95f1-dd80ce9e24de.jpg?1783942837"
+                },
+                "descriptionOverride": "Create a 2/2 green Wolf creature token."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DEATHTOUCH",
+                "filter": {
+                    "baseFilter": "permanent Wolf ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "244",
+        "rarity": "RARE",
+        "artist": "Mark Zug",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3e97f29a-1551-4e75-80e8-2dd31cb6c0db.jpg?1783942855",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "Wren's Run Packmaster gives deathtouch to all Wolf permanents you control, not just the tokens it creates."
+            },
+            {
+                "date": "2009-10-01",
+                "text": "A Wolf's deathtouch ability will apply if both Wren's Run Packmaster and that Wolf are on the battlefield at the time the Wolf deals damage. The creature dealt damage by the Wolf will be destroyed the next time state-based actions are checked, even if the Wolf or Wren's Run Packmaster leaves the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
@@ -49,6 +49,17 @@ internal fun BridgeBuilder.keywords() {
     // cost was paid, …" trigger; on an instant/sorcery it's `Patterns.Mechanic.giftSpell(…)`. The emitter
     // declines (SCAFFOLD): which GiftKind is listed, and how the card's *other* text branches on
     // `Conditions.GiftWasPromised`, is a per-card read.
+    // Champion an [object] (CR 702.72, Lorwyn) — a PARAMETERIZED keyword: the IR carries the quality
+    // as the rule's `_Permanents` argument (`IsCreatureType: Goblin` for Boggart Mob, `IsCreature` for
+    // the three Changelings), so `supported` rather than a bare `keyword`. `Keyword.CHAMPION` exists but
+    // stamping it alone would print the word and drop the whole mechanic — the two linked triggered
+    // abilities (CR 702.72b / 607.2k) that the `champion(Subtype)` / `champion(filter, description)` /
+    // `championCreature()` CardBuilder helpers compose. Emitter declines (SCAFFOLD): turning an arbitrary
+    // `_Permanents` node into the right helper overload is a per-card read, and the reminder text the
+    // helper writes carries the printed quality noun with its article. The nine hand-authored Lorwyn
+    // champions and `ChampionKeywordTest` are ground truth. See the Champion keyword entry in
+    // card-sdk-language-reference.md.
+    supported("Champion", "keyword ability: Champion an [object] -> champion(Subtype) / champion(filter, description) / championCreature() (CR 702.72)")
     supported("Gift", "keyword ability: Gift a [something] -> gift(GiftKind.…) on permanents / Patterns.Mechanic.giftSpell on instants & sorceries (CR 702.174)")
     // Bargain (CR 702.166, Wilds of Eldraine) — "You may sacrifice an artifact, enchantment, or token
     // as you cast this spell." `composed`, not a bare `keyword`: `Keyword.BARGAIN` exists, but stamping

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -149,6 +149,16 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // policy declines — so it leaves the card at SCAFFOLD (like the exploit payoff). The hand-authored
     // Savior of Ollenbock card + its scenario test are ground truth. See the Triggers.trains() /
     // TrainedEvent entries in card-sdk-language-reference.md.
+    // Champion payoff (CR 702.72c) — "when a [quality] is championed with this creature, …" (Mistbind
+    // Clique). Like the exploit and training payoffs above, NOT an engine gap: the shipped
+    // `champion(...)` helper composes the whole mechanic and its success branch emits the
+    // parameterless `EventPattern.ChampionedEvent`, which this trigger keys on via
+    // `Triggers.championedWith()` (SELF binding). Capability-only: the emitter would have to fuse the
+    // paired Champion-keyword rule + this trigger and recover the targeted group-tap payoff, so it
+    // leaves the card at SCAFFOLD. The hand-authored Mistbind Clique + its scenario test are ground
+    // truth. See the Triggers.championedWith() / ChampionedEvent entries in
+    // card-sdk-language-reference.md.
+    supported("WhenAPermanentIsChampionedWithAPermanent", "trigger: a permanent is championed with this permanent (champion payoff — Triggers.championedWith(), ChampionedEvent) — capability only, emitter scaffolds")
     supported("WhenAPermanentTrains", "trigger: this creature trains (training payoff — Triggers.trains(), TrainedEvent) — capability only, emitter scaffolds")
     // "When this permanent leaves the battlefield, …" — the self leaves-the-battlefield trigger
     // (Triggers.LeavesBattlefield). Savior of Ollenbock uses it to return every linked

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -1644,6 +1644,37 @@ data class TrainedEvent(
     val sourceName: String
 ) : GameEvent
 
+/**
+ * A permanent was championed (CR 702.72c): a resolving champion ability exiled it as the direct
+ * result of that ability. Emitted by `EmitChampionedEventExecutor` — the `then` branch of the gate
+ * the `champion()` helper builds (`com.wingedsheep.sdk.dsl.champion`) — and therefore **only when a
+ * permanent actually reached exile**; declining the choice sacrifices the champion instead and fires
+ * nothing. Drives "When a [quality] is championed with this creature" payoffs
+ * ([com.wingedsheep.sdk.scripting.EventPattern.ChampionedEvent], i.e. Mistbind Clique).
+ *
+ * Distinct from the [ZoneChangeEvent] the same exile also emits for generic "whenever a permanent is
+ * exiled" watchers: this marks that the exile came from a *resolving champion ability* specifically,
+ * which is what CR 702.72c defines "championed" to mean. A permanent exiled by any other effect —
+ * including another linked-exile ability on the same source — is not championed.
+ *
+ * @property championId The permanent that did the championing (the trigger's subject; selected by
+ *   the watching ability's `TriggerBinding` — SELF for "championed with this creature"). This is the
+ *   champion ability's source.
+ * @property championControllerId The champion's controller at champion time.
+ * @property championedId The permanent that was championed — still a live entity, in exile.
+ * @property championedName The championed permanent's name (for display / logging).
+ * @property sourceName The champion's name (for display / logging).
+ */
+@Serializable
+@SerialName("ChampionedEvent")
+data class ChampionedEvent(
+    val championId: EntityId,
+    val championControllerId: EntityId,
+    val championedId: EntityId,
+    val championedName: String,
+    val sourceName: String
+) : GameEvent
+
 // =============================================================================
 // Class Level Events
 // =============================================================================

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -156,6 +156,7 @@ val engineSerializersModule = SerializersModule {
         subclass(PermanentsSacrificedEvent::class)
         subclass(ExploitedEvent::class)
         subclass(TrainedEvent::class)
+        subclass(ChampionedEvent::class)
         subclass(StatsModifiedEvent::class)
         subclass(TargetReselectedEvent::class)
         subclass(TurnFaceUpEvent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -88,6 +88,7 @@ enum class TriggerCategory {
     CONNIVED,
     EXPLOITED,
     TRAINED,
+    CHAMPIONED,
     YOU_BEND,
     MANIFESTED_DREAD,
     SEARCH_LIBRARY,
@@ -303,6 +304,7 @@ class TriggerIndex(
                 is SdkGameEvent.ConnivedEvent -> CONNIVED_LIST
                 is SdkGameEvent.ExploitedEvent -> EXPLOITED_LIST
                 is SdkGameEvent.TrainedEvent -> TRAINED_LIST
+                is SdkGameEvent.ChampionedEvent -> CHAMPIONED_LIST
                 is SdkGameEvent.BendPerformedEvent -> BEND_LIST
                 is SdkGameEvent.ManifestedDreadEvent -> MANIFESTED_DREAD_LIST
                 is SdkGameEvent.SearchLibraryEvent -> SEARCH_LIBRARY_LIST
@@ -363,6 +365,7 @@ class TriggerIndex(
             is com.wingedsheep.engine.core.PermanentConnivedEvent -> CONNIVED_LIST
             is com.wingedsheep.engine.core.ExploitedEvent -> EXPLOITED_LIST
             is com.wingedsheep.engine.core.TrainedEvent -> TRAINED_LIST
+            is com.wingedsheep.engine.core.ChampionedEvent -> CHAMPIONED_LIST
             is com.wingedsheep.engine.core.BendPerformedEvent -> BEND_LIST
             is com.wingedsheep.engine.core.ManifestedDreadEvent -> MANIFESTED_DREAD_LIST
             is com.wingedsheep.engine.core.LibrarySearchedEvent -> SEARCH_LIBRARY_LIST
@@ -415,6 +418,7 @@ class TriggerIndex(
         private val CONNIVED_LIST = listOf(TriggerCategory.CONNIVED)
         private val EXPLOITED_LIST = listOf(TriggerCategory.EXPLOITED)
         private val TRAINED_LIST = listOf(TriggerCategory.TRAINED)
+        private val CHAMPIONED_LIST = listOf(TriggerCategory.CHAMPIONED)
         private val BEND_LIST = listOf(TriggerCategory.YOU_BEND)
         private val MANIFESTED_DREAD_LIST = listOf(TriggerCategory.MANIFESTED_DREAD)
         private val SEARCH_LIBRARY_LIST = listOf(TriggerCategory.SEARCH_LIBRARY)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -710,6 +710,17 @@ class TriggerMatcher(
                 if (binding == TriggerBinding.OTHER && event.trainedId == sourceId) return false
                 true
             }
+            is EventPattern.ChampionedEvent -> {
+                if (event !is com.wingedsheep.engine.core.ChampionedEvent) return false
+                // "When a Faerie is championed with THIS creature" (Mistbind Clique): SELF binding
+                // restricts to the ability's own source — the *championing* permanent, not the one
+                // that was exiled. OTHER would be "championed with another permanent you control";
+                // ANY has no restriction. The emit already gates on a permanent actually reaching
+                // exile (CR 702.72c), so any ChampionedEvent reaching here is a genuine champion.
+                if (binding == TriggerBinding.SELF && event.championId != sourceId) return false
+                if (binding == TriggerBinding.OTHER && event.championId == sourceId) return false
+                true
+            }
             is EventPattern.BendPerformedEvent -> {
                 event is com.wingedsheep.engine.core.BendPerformedEvent &&
                     event.bendType in trigger.types &&

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/linkedexile/EmitChampionedEventExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/linkedexile/EmitChampionedEventExecutor.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.handlers.effects.linkedexile
+
+import com.wingedsheep.engine.core.ChampionedEvent
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.effects.EmitChampionedEventEffect
+import kotlin.reflect.KClass
+
+/**
+ * `then` branch of the champion ability's "exile … unless" gate (wired by
+ * [com.wingedsheep.sdk.dsl.champion]): emits one [ChampionedEvent] (CR 702.72c) for each permanent
+ * the source just exiled as its champion ability resolved, so "when a [quality] is championed with
+ * this creature" payoffs ([com.wingedsheep.sdk.scripting.EventPattern.ChampionedEvent], i.e.
+ * Mistbind Clique) fire.
+ *
+ * CR 702.72c: "A permanent is 'championed' by another permanent if the latter exiles the former as
+ * the direct result of a champion ability." The championed permanents are read out of the pipeline
+ * collection [EmitChampionedEventEffect.from] — the champion move's `storeMovedAs`, i.e. the cards
+ * that *actually reached exile*. That is stricter than the cards the controller picked: a pick that
+ * never moved is not championed. Because this only runs on the gate's success branch, declining the
+ * choice (which sacrifices the champion instead) emits nothing.
+ *
+ * The champion is [EffectContext.sourceId] and its controller [EffectContext.controllerId]. The
+ * championed permanent is still a live entity in exile at this point, so its name reads directly off
+ * the entity rather than needing last-known information — the opposite of the exploit twin, whose
+ * subject has been sacrificed by the time the event is built.
+ *
+ * Card authors should not use [EmitChampionedEventEffect] directly; it is wired into `champion()`.
+ */
+class EmitChampionedEventExecutor : EffectExecutor<EmitChampionedEventEffect> {
+
+    override val effectType: KClass<EmitChampionedEventEffect> = EmitChampionedEventEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: EmitChampionedEventEffect,
+        context: EffectContext
+    ): EffectResult {
+        val championId = context.sourceId ?: return EffectResult.success(state)
+        val sourceName = state.getEntity(championId)?.get<CardComponent>()?.name ?: "Unknown"
+
+        val events: List<GameEvent> = context.pipeline.storedCollections[effect.from]
+            .orEmpty()
+            .map { championedId ->
+                ChampionedEvent(
+                    championId = championId,
+                    championControllerId = context.controllerId,
+                    championedId = championedId,
+                    championedName = state.getEntity(championedId)?.get<CardComponent>()?.name
+                        ?: "Unknown",
+                    sourceName = sourceName
+                )
+            }
+
+        return EffectResult.success(state, events)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/linkedexile/LinkedExileExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/linkedexile/LinkedExileExecutors.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.engine.handlers.effects.ExecutorModule
  */
 class LinkedExileExecutors : ExecutorModule {
     override fun executors(): List<EffectExecutor<*>> = listOf(
+        EmitChampionedEventExecutor(),
         ExileUntilLeavesExecutor(),
         ExileWithAurasNotingCountersExecutor(),
         MarkExileOnDeathExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
@@ -1448,6 +1448,10 @@ is PermanentsSacrificedEvent -> {
             // Ollenbock); the +1/+1 counter the training ability placed is already surfaced by its
             // own CountersAddedEvent (animation + log), so no separate client event.
             is TrainedEvent,
+            // Internal signal that fires "when a [quality] is championed with this creature"
+            // watcher triggers (Mistbind Clique); the exile itself is already surfaced by its own
+            // zone-change event, so no separate client event.
+            is ChampionedEvent,
             is BendPerformedEvent,
             is ManifestedDreadEvent,
             is LibrarySearchedEvent,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChampionKeywordTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChampionKeywordTest.kt
@@ -1,0 +1,464 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChampionedEvent
+import com.wingedsheep.engine.core.OrderObjectsDecision
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.champion
+import com.wingedsheep.sdk.dsl.championCreature
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Champion keyword (CR 702.72) end to end: the enters "sacrifice it unless you exile another
+ * [object] you control" trigger, the linked leaves-the-battlefield return, and the CR 702.72c
+ * "championed" signal that Mistbind Clique's follow-up reads.
+ *
+ * Uses inline probe cards rather than the printed Lorwyn nine so the rules matrix is independent of
+ * any card's other abilities. Each test names the rule it pins.
+ */
+class ChampionKeywordTest : FunSpec({
+
+    // "Champion a Goblin" — the tribal form (Boggart Mob's shape).
+    val goblinChampion = card("Champion Probe Goblin") {
+        manaCost = "{3}{B}"
+        typeLine = "Creature — Goblin Warrior"
+        power = 5
+        toughness = 5
+        champion(Subtype.GOBLIN)
+    }
+
+    // "Champion a creature" — the Changeling form.
+    val creatureChampion = card("Champion Probe Creature") {
+        manaCost = "{3}{R}"
+        typeLine = "Creature — Shapeshifter"
+        power = 5
+        toughness = 3
+        championCreature()
+    }
+
+    // Mistbind Clique's shape: champion + the CR 702.72c payoff, with a trivial untargeted effect
+    // so the test asserts the trigger fired rather than a targeting flow.
+    val payoffChampion = card("Champion Probe Payoff") {
+        manaCost = "{3}{U}"
+        typeLine = "Creature — Faerie Wizard"
+        power = 4
+        toughness = 4
+        champion(Subtype.FAERIE)
+        triggeredAbility {
+            trigger = Triggers.championedWith()
+            effect = Effects.DrawCards(1)
+            description = "When a Faerie is championed with this creature, draw a card."
+        }
+    }
+
+    val testGoblin = card("Champion Test Goblin") {
+        manaCost = "{1}{B}"
+        typeLine = "Creature — Goblin"
+        power = 2
+        toughness = 2
+    }
+
+    val testFaerie = card("Champion Test Faerie") {
+        manaCost = "{1}{U}"
+        typeLine = "Creature — Faerie"
+        power = 1
+        toughness = 1
+    }
+
+    // A *noncreature* Kindred Goblin: champion's printed quality is a bare tribal noun, which per
+    // CR 109.2 reads as a Goblin permanent, so this is a legal thing to champion.
+    val goblinShrine = card("Champion Test Goblin Shrine") {
+        manaCost = "{1}{B}"
+        typeLine = "Kindred Enchantment — Goblin"
+    }
+
+    val testBear = card("Champion Test Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    val banish = card("Champion Banish") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        spell {
+            val creature = target("creature", Targets.Creature)
+            effect = Effects.Exile(creature)
+        }
+    }
+
+    val blink = card("Champion Blink") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        spell {
+            val creature = target("creature", Targets.Creature)
+            effect = Effects.Exile(creature).then(Effects.PutOntoBattlefield(creature))
+        }
+    }
+
+    val steal = card("Champion Steal") {
+        manaCost = "{U}"
+        typeLine = "Sorcery"
+        spell {
+            val creature = target("creature", TargetCreature())
+            effect = Effects.GainControl(creature)
+        }
+    }
+
+    // Makes a non-Goblin into a Goblin, so the candidate gather has to read *projected* types.
+    val goblinify = card("Champion Goblinify") {
+        manaCost = "{B}"
+        typeLine = "Sorcery"
+        spell {
+            val creature = target("creature", Targets.Creature)
+            effect = Effects.AddCreatureType("Goblin", creature)
+        }
+    }
+
+    val tokenMaker = card("Champion Token Maker") {
+        manaCost = "{B}"
+        typeLine = "Sorcery"
+        spell {
+            effect = Effects.CreateToken(
+                power = 1, toughness = 1, colors = setOf(Color.BLACK),
+                creatureTypes = setOf("Goblin")
+            )
+        }
+    }
+
+    val probes = listOf(
+        goblinChampion, creatureChampion, payoffChampion, testGoblin, testFaerie,
+        goblinShrine, testBear, banish, blink, steal, goblinify, tokenMaker
+    )
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + probes)
+        initMirrorMatch(deck = Deck.of("Island" to 40), startingPlayer = 0)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    /** Drain the stack, answering each champion choice with [selected] (empty list = decline). */
+    fun GameTestDriver.resolveChoosing(selected: EntityId? = null) {
+        var guard = 0
+        while (stackSize > 0 || pendingDecision != null) {
+            check(guard++ < 24) { "Resolution did not settle" }
+            when (val decision = pendingDecision) {
+                null -> bothPass().error shouldBe null
+                is SelectCardsDecision -> submitCardSelection(
+                    decision.playerId, selected?.let { listOf(it) } ?: emptyList()
+                ).error shouldBe null
+                is OrderObjectsDecision -> submitDecision(
+                    decision.playerId, OrderedResponse(decision.id, decision.objects)
+                ).error shouldBe null
+                else -> error("Unexpected decision: $decision")
+            }
+        }
+    }
+
+    /** Top up every colour the probe cards use, so a cast never fails on colour. */
+    fun GameTestDriver.giveProbeMana(player: EntityId) {
+        listOf(Color.BLUE, Color.BLACK, Color.RED, Color.GREEN).forEach { giveMana(player, it, 4) }
+    }
+
+    /** Cast [name] from hand for its (mana-cheated) cost and stop at the champion choice. */
+    fun GameTestDriver.castChampion(name: String): EntityId {
+        val source = putCardInHand(player1, name)
+        giveProbeMana(player1)
+        castSpell(player1, source).error shouldBe null
+        return source
+    }
+
+    fun GameTestDriver.graveyardOf(playerId: EntityId): List<EntityId> = state.getGraveyard(playerId)
+
+    /** Pass until the champion ability's choice is on the table, and return it. */
+    fun GameTestDriver.passUntilChampionChoice(): SelectCardsDecision {
+        var guard = 0
+        while (pendingDecision !is SelectCardsDecision) {
+            check(guard++ < 8) { "No champion choice was offered" }
+            bothPass().error shouldBe null
+        }
+        return pendingDecision as SelectCardsDecision
+    }
+
+    // -------------------------------------------------------------------------
+    // CR 702.72a — "sacrifice it unless you exile another [object] you control"
+    // -------------------------------------------------------------------------
+
+    test("CR 702.72a: exiling another matching permanent keeps the champion on the battlefield") {
+        val d = driver()
+        val goblin = d.putCreatureOnBattlefield(d.player1, "Champion Test Goblin")
+        val source = d.castChampion("Champion Probe Goblin")
+        d.resolveChoosing(goblin)
+
+        d.state.getBattlefield() shouldContain source
+        d.state.getBattlefield() shouldNotContain goblin
+        d.state.getZone(com.wingedsheep.engine.state.ZoneKey(d.player1, Zone.EXILE)) shouldContain goblin
+    }
+
+    test("CR 702.72a: declining the choice sacrifices the champion, exiling nothing") {
+        val d = driver()
+        val goblin = d.putCreatureOnBattlefield(d.player1, "Champion Test Goblin")
+        val source = d.castChampion("Champion Probe Goblin")
+        d.resolveChoosing(selected = null)
+
+        d.state.getBattlefield() shouldNotContain source
+        d.graveyardOf(d.player1) shouldContain source
+        // The declined permanent is untouched.
+        d.state.getBattlefield() shouldContain goblin
+    }
+
+    test("CR 702.72a: with no eligible permanent the champion is sacrificed and no choice is offered") {
+        val d = driver()
+        // A Bear is not a Goblin, so the candidate set is empty.
+        d.putCreatureOnBattlefield(d.player1, "Champion Test Bear")
+        val source = d.castChampion("Champion Probe Goblin")
+
+        var sawSelection = false
+        var guard = 0
+        while (d.stackSize > 0 || d.pendingDecision != null) {
+            check(guard++ < 16) { "Resolution did not settle" }
+            when (val decision = d.pendingDecision) {
+                null -> d.bothPass().error shouldBe null
+                is SelectCardsDecision -> {
+                    sawSelection = true
+                    d.submitCardSelection(decision.playerId, emptyList()).error shouldBe null
+                }
+                else -> error("Unexpected decision: $decision")
+            }
+        }
+        sawSelection shouldBe false
+        d.graveyardOf(d.player1) shouldContain source
+    }
+
+    test("CR 702.72a: 'another' excludes the champion itself from the candidates") {
+        val d = driver()
+        val goblin = d.putCreatureOnBattlefield(d.player1, "Champion Test Goblin")
+        val source = d.castChampion("Champion Probe Goblin")
+        val decision = d.passUntilChampionChoice()
+        // The champion is itself a Goblin on the battlefield; only the *other* Goblin is offered.
+        decision.options shouldContainExactlyInAnyOrder listOf(goblin)
+        decision.options shouldNotContain source
+    }
+
+    test("CR 702.72a: only permanents you control are candidates") {
+        val d = driver()
+        val mine = d.putCreatureOnBattlefield(d.player1, "Champion Test Goblin")
+        d.putCreatureOnBattlefield(d.player2, "Champion Test Goblin")
+        d.castChampion("Champion Probe Goblin")
+        d.passUntilChampionChoice().options shouldContainExactlyInAnyOrder listOf(mine)
+    }
+
+    test("CR 109.2: a bare tribal quality means a permanent, so a noncreature Kindred Goblin qualifies") {
+        val d = driver()
+        val shrine = d.putPermanentOnBattlefield(d.player1, "Champion Test Goblin Shrine")
+        d.castChampion("Champion Probe Goblin")
+        d.passUntilChampionChoice().options shouldContain shrine
+    }
+
+    test("candidates read projected types: a Bear turned into a Goblin becomes a legal choice") {
+        val d = driver()
+        val bear = d.putCreatureOnBattlefield(d.player1, "Champion Test Bear")
+        val spell = d.putCardInHand(d.player1, "Champion Goblinify")
+        d.giveProbeMana(d.player1)
+        d.castSpell(d.player1, spell, listOf(bear)).error shouldBe null
+        d.bothPass().error shouldBe null
+
+        d.castChampion("Champion Probe Goblin")
+        d.passUntilChampionChoice().options shouldContainExactlyInAnyOrder listOf(bear)
+    }
+
+    test("'Champion a creature' offers every creature you control, and no noncreature") {
+        val d = driver()
+        val bear = d.putCreatureOnBattlefield(d.player1, "Champion Test Bear")
+        val goblin = d.putCreatureOnBattlefield(d.player1, "Champion Test Goblin")
+        d.putPermanentOnBattlefield(d.player1, "Champion Test Goblin Shrine")
+        d.castChampion("Champion Probe Creature")
+        d.passUntilChampionChoice().options shouldContainExactlyInAnyOrder
+            listOf(bear, goblin)
+    }
+
+    // -------------------------------------------------------------------------
+    // CR 702.72a / 702.72b — the linked leaves-the-battlefield return
+    // -------------------------------------------------------------------------
+
+    test("CR 702.72a: the championed card returns when the champion leaves the battlefield") {
+        val d = driver()
+        val goblin = d.putCreatureOnBattlefield(d.player1, "Champion Test Goblin")
+        val source = d.castChampion("Champion Probe Goblin")
+        d.resolveChoosing(goblin)
+        d.state.getBattlefield() shouldNotContain goblin
+
+        val removal = d.putCardInHand(d.player1, "Champion Banish")
+        d.giveProbeMana(d.player1)
+        d.castSpell(d.player1, removal, listOf(source)).error shouldBe null
+        d.resolveChoosing()
+
+        d.state.getBattlefield() shouldContain goblin
+        d.state.getBattlefield() shouldNotContain source
+    }
+
+    test("CR 702.72a: the championed card returns under its OWNER's control, not the champion's") {
+        val d = driver()
+        // player2 owns the Goblin; player1 steals it, then champions it.
+        val goblin = d.putCreatureOnBattlefield(d.player2, "Champion Test Goblin")
+        val theft = d.putCardInHand(d.player1, "Champion Steal")
+        d.giveProbeMana(d.player1)
+        d.castSpell(d.player1, theft, listOf(goblin)).error shouldBe null
+        d.bothPass().error shouldBe null
+        // Control change is a continuous effect, so read it off projected state.
+        d.state.projectedState.getController(goblin) shouldBe d.player1
+
+        val source = d.castChampion("Champion Probe Goblin")
+        d.resolveChoosing(goblin)
+
+        val removal = d.putCardInHand(d.player1, "Champion Banish")
+        d.giveProbeMana(d.player1)
+        d.castSpell(d.player1, removal, listOf(source)).error shouldBe null
+        d.resolveChoosing()
+
+        d.state.getBattlefield() shouldContain goblin
+        d.state.projectedState.getController(goblin) shouldBe d.player2
+    }
+
+    test("CR 702.72b: the leaves trigger returns only what this champion exiled") {
+        val d = driver()
+        val championed = d.putCreatureOnBattlefield(d.player1, "Champion Test Goblin")
+        val bystander = d.putCreatureOnBattlefield(d.player1, "Champion Test Bear")
+        val source = d.castChampion("Champion Probe Goblin")
+        d.resolveChoosing(championed)
+
+        // Exile the bystander by an unrelated effect — it is not linked to the champion.
+        val unrelated = d.putCardInHand(d.player1, "Champion Banish")
+        d.giveProbeMana(d.player1)
+        d.castSpell(d.player1, unrelated, listOf(bystander)).error shouldBe null
+        d.resolveChoosing()
+
+        val removal = d.putCardInHand(d.player1, "Champion Banish")
+        d.giveProbeMana(d.player1)
+        d.castSpell(d.player1, removal, listOf(source)).error shouldBe null
+        d.resolveChoosing()
+
+        d.state.getBattlefield() shouldContain championed
+        d.state.getBattlefield() shouldNotContain bystander
+    }
+
+    test("CR 111.7: a championed token ceases to exist and never returns") {
+        val d = driver()
+        val maker = d.putCardInHand(d.player1, "Champion Token Maker")
+        d.giveProbeMana(d.player1)
+        d.castSpell(d.player1, maker).error shouldBe null
+        d.bothPass().error shouldBe null
+        val token = d.getCreatures(d.player1).single()
+
+        val source = d.castChampion("Champion Probe Goblin")
+        d.resolveChoosing(token)
+        d.state.getBattlefield() shouldNotContain token
+
+        val removal = d.putCardInHand(d.player1, "Champion Banish")
+        d.giveProbeMana(d.player1)
+        d.castSpell(d.player1, removal, listOf(source)).error shouldBe null
+        d.resolveChoosing()
+
+        d.state.getBattlefield() shouldNotContain token
+    }
+
+    test("the leaves trigger resolving before the enters trigger exiles a card that never returns") {
+        val d = driver()
+        val goblin = d.putCreatureOnBattlefield(d.player1, "Champion Test Goblin")
+        val source = d.castChampion("Champion Probe Goblin")
+        // Leave the enters trigger on the stack, then remove the champion: its leaves trigger goes
+        // on top and resolves first, against an empty linked-exile pile.
+        d.bothPass().error shouldBe null
+        d.stackSize shouldBe 1
+
+        val removal = d.putCardInHand(d.player1, "Champion Banish")
+        d.giveProbeMana(d.player1)
+        d.castSpell(d.player1, removal, listOf(source)).error shouldBe null
+        d.resolveChoosing(goblin)
+
+        d.state.getBattlefield() shouldNotContain source
+        // The enters trigger still exiled it — with the return already spent, indefinitely.
+        d.state.getBattlefield() shouldNotContain goblin
+        d.state.getZone(com.wingedsheep.engine.state.ZoneKey(d.player1, Zone.EXILE)) shouldContain goblin
+    }
+
+    test("a champion that blinks does not sacrifice for, or return, the previous visit's card") {
+        val d = driver()
+        val first = d.putCreatureOnBattlefield(d.player1, "Champion Test Goblin")
+        val second = d.putCreatureOnBattlefield(d.player1, "Champion Test Goblin")
+        val source = d.castChampion("Champion Probe Goblin")
+        d.resolveChoosing(first)
+
+        val flicker = d.putCardInHand(d.player1, "Champion Blink")
+        d.giveProbeMana(d.player1)
+        d.castSpell(d.player1, flicker, listOf(source)).error shouldBe null
+        // The old visit's leaves trigger returns `first`; the new visit's enters trigger champions
+        // `second`. The new visit is not sacrificed by the old visit's obligations.
+        d.resolveChoosing(second)
+
+        d.state.getBattlefield() shouldContain first
+        d.state.getBattlefield() shouldNotContain second
+        d.state.getBattlefield() shouldContain source
+    }
+
+    // -------------------------------------------------------------------------
+    // CR 702.72c — "championed"
+    // -------------------------------------------------------------------------
+
+    test("CR 702.72c: championing a permanent fires the 'is championed with this creature' payoff") {
+        val d = driver()
+        val faerie = d.putCreatureOnBattlefield(d.player1, "Champion Test Faerie")
+        val handBefore = d.getHand(d.player1).size
+        val source = d.castChampion("Champion Probe Payoff")
+        d.resolveChoosing(faerie)
+
+        d.events.filterIsInstance<ChampionedEvent>().map { it.championId to it.championedId } shouldBe
+            listOf(source to faerie)
+        d.getHand(d.player1).size shouldBe handBefore + 1
+    }
+
+    test("CR 702.72c: declining champions nothing, so the payoff does not fire") {
+        val d = driver()
+        d.putCreatureOnBattlefield(d.player1, "Champion Test Faerie")
+        val handBefore = d.getHand(d.player1).size
+        d.castChampion("Champion Probe Payoff")
+        d.resolveChoosing(selected = null)
+
+        d.events.filterIsInstance<ChampionedEvent>() shouldBe emptyList()
+        d.getHand(d.player1).size shouldBe handBefore
+    }
+
+    test("CR 702.72c: the payoff is bound to its own champion, not to another player's") {
+        val d = driver()
+        val faerie = d.putCreatureOnBattlefield(d.player1, "Champion Test Faerie")
+        val watcher = d.putCreatureOnBattlefield(d.player1, "Champion Probe Payoff")
+        val handBefore = d.getHand(d.player1).size
+
+        // A *different* champion does the championing; the watcher's SELF-bound payoff must not fire.
+        val source = d.castChampion("Champion Probe Creature")
+        d.resolveChoosing(faerie)
+
+        d.events.filterIsInstance<ChampionedEvent>().map { it.championId } shouldBe listOf(source)
+        d.getHand(d.player1).size shouldBe handBefore
+        // The watcher is untouched; only the chosen Faerie left.
+        d.state.getBattlefield() shouldContain watcher
+    }
+})

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -197,6 +197,10 @@ export enum Keyword {
   PROWESS = 'PROWESS',
   FLURRY = 'FLURRY',
   CHANGELING = 'CHANGELING',
+  // Enters/leaves ability pair (Lorwyn, CR 702.72). Deliberately absent from
+  // displayableKeywords: "Champion" alone loses the quality that makes it readable
+  // ("Champion a Goblin"), which the card's two ability lines already spell out.
+  CHAMPION = 'CHAMPION',
   DEVOID = 'DEVOID',
   CRAFT = 'CRAFT',
   // Cost reduction
@@ -297,6 +301,7 @@ export const KeywordDisplayNames: Record<Keyword, string> = {
   [Keyword.PROWESS]: 'Prowess',
   [Keyword.FLURRY]: 'Flurry',
   [Keyword.CHANGELING]: 'Changeling',
+  [Keyword.CHAMPION]: 'Champion',
   [Keyword.DEVOID]: 'Devoid',
   [Keyword.CRAFT]: 'Craft',
   [Keyword.CONVOKE]: 'Convoke',


### PR DESCRIPTION
Champion (CR 702.72) was the largest single gap left in Lorwyn — it blocked nine
of the eighteen remaining cards. This ships the keyword and all nine, taking the
set from 268/286 to **277/286**.

## The keyword

Champion is two linked triggered abilities (CR 702.72b / 607.2k): "When this
permanent enters, sacrifice it unless you exile another [object] you control" and
"When this permanent leaves the battlefield, return the exiled card to the
battlefield under its owner's control."

It composes from existing primitives — no new executor for the mechanic itself.
`Keyword.CHAMPION` is display-only; `champion(Subtype)` /
`champion(filter, description)` / `championCreature()` build the pair:

- **enters** — an `IfYouDoEffect` over a Gather → Select → Move pipeline. The
  permanent is *chosen, not targeted* (the printed text has no "target"):
  `BattlefieldMatching(quality.notSourceItself(), player = You)`, then
  `ChooseUpTo(1)` on the battlefield UI, then a move to exile carrying
  `linkToSource`. `ChooseUpTo(1)` **is** the "unless" — picking nothing is always
  legal, and with no eligible permanent the selection resolves with no prompt at
  all. The gate reads the move's `storeMovedAs` (the cards that actually reached
  exile, not merely the ones picked), with `otherwise = SacrificeSelfEffect`.
- **leaves** — `Triggers.LeavesBattlefield` running
  `ReturnLinkedExileUnderOwnersControl()`, which reads the *originating
  battlefield visit's* linked-exile pile, so a champion that blinks never returns
  the other visit's card and never sacrifices for the other visit's obligation.

Two decisions worth calling out:

- **The quality is a permanent filter.** "Champion a Goblin" is a bare tribal
  noun, so per CR 109.2 a Kindred noncreature Goblin is a legal choice. Narrowing
  it to `Creature` would silently drop those. `notSourceItself()` supplies
  "another" and is visit-aware.
- **Two triggers, not an "exile until this leaves" replacement.** That is what CR
  702.72a says, and it reproduces the printed interaction Fiend Hunter documents:
  a champion removed before its enters trigger resolves has already run its leaves
  trigger against an empty pile, and then exiles a permanent that never comes back.

The one piece of genuinely new vocabulary is the CR 702.72c "championed" signal
Mistbind Clique needs: `EmitChampionedEventEffect` (the gate's success branch) →
`ChampionedEvent` → `EventPattern.ChampionedEvent`, reached by
`Triggers.championedWith()`. Modelled on the exploit/training twins — a
parameterless pattern whose subject is the *championing* permanent, selected by
the ability's `TriggerBinding`. It fires only when a permanent actually reached
exile, so declining the choice fires nothing.

## The nine cards

| Card | What it adds beyond champion |
|---|---|
| Changeling Berserker | changeling, haste — champion a creature |
| Changeling Hero | changeling, lifelink |
| Changeling Titan | changeling, 7/7 |
| Nova Chaser | trample — champion an Elemental (tribal quality) |
| Thoughtweft Trio | first strike, vigilance, `CanBlockAnyNumber` |
| Boggart Mob | ANY-bound `dealsDamage` over Goblin permanents you control → optional Goblin Rogue token |
| Wanderwine Prophets | `MayEffect(IfYouDoEffect(SacrificeOwn(Merfolk), TakeExtraTurn))` |
| Wren's Run Packmaster | Wolf token ability + `GrantKeyword(DEATHTOUCH)` lord; C14 reprint row |
| Mistbind Clique | flash, flying, and the `championedWith` payoff — tap all lands target player controls |

All nine are canonical in LRW. Each has its own scenario test.

## Verification

- `just test` — green (3m 58s, 107 tasks), run on the committed tree.
- `ChampionKeywordTest` — 17 engine scenarios pinning the rules matrix: accept /
  decline / no eligible permanent (and that no prompt is offered), "another"
  excluding the source, tribal-vs-creature quality, a noncreature Kindred
  permanent qualifying, projected type reads, only permanents you control, the
  return under the **owner's** control, linkage (only what *this* champion
  exiled), a championed token ceasing to exist, the leaves trigger resolving
  before the enters trigger, blinking, and the championed event firing / not
  firing / binding to its own champion.
- Nine card scenario tests, 36 cases.
- `just assay-gate --limit 2000` — clean. `just assay-differential --set LRW` —
  108/111 agree, the same three pre-existing folds (Boggart Sprite-Chaser, Epic
  Proportions, Kithkin Greatheart). Assay has no champion grammar band yet, so it
  declines all nine; that is a decline, not a pass.
- `just check-card-printing` — ok for all nine (the C14 Packmaster row was the one
  gap; it is added here).
- Card golden re-blessed: exactly the nine new entries added, **nothing else
  changed** (262 → 271 objects, zero modified).
- Fresh Scryfall metadata for every card; all twelve image URLs (nine cards, two
  tokens, the C14 reprint) return HTTP 200.
- Web client typechecks; `Keyword.CHAMPION` is added to the TS enum and display
  names but deliberately **not** to `displayableKeywords` — a "Champion" badge
  alone loses the quality that makes it readable, which the card's two ability
  lines already spell out.
- `docs/card-sdk-language-reference.md` updated in the same change (Champion
  keyword entry, `ChampionedEvent` pattern entry, display-only roll-call).
- mtgish generator taught the two new IR tags (`Champion`,
  `WhenAPermanentIsChampionedWithAPermanent`) as capability-only entries — fusing
  the paired keyword rule and payoff trigger back into one `champion()` call is a
  per-card read, so the emitter scaffolds.

## Not done

No manual playthrough in the running client and no e2e test. The champion choice
reuses the existing on-battlefield selection UI and the payoff reuses ordinary
player targeting, so no new decision component was needed — but that is an
argument from the server side, not an observation of the client.

The remaining Lorwyn nine are Purity / Vigor / Hostility (the Incarnations'
prevention riders), Dread, Cairn Wanderer, Guile, Chandra Nalaar, Needle Drop and
Twinning Glass — all `add-feature` territory, none blocked on champion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvLRhVP3UzWZrq3NWeSqWu
