### PR TITLE
Add Dread with graveyard arrival trigger support

### DIFF
--- a/backlog/sets/lorwyn/cards.md
+++ b/backlog/sets/lorwyn/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 cards
 **Release Date:** October 12, 2007
-**Implemented:** 277 / 286
+**Implemented:** 278 / 286
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 49    | 43   |
@@ -129,7 +129,7 @@
 - [x] Boggart Mob
 - [ ] Cairn Wanderer
 - [x] Colfenor's Plans
-- [ ] Dread
+- [x] Dread
 - [x] Dreamspoiler Witches
 - [x] Exiled Boggart
 - [x] Eyeblight's Ending

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5125,6 +5125,13 @@ abilities that should do nothing, a "while" filed as an "if" fizzles abilities t
 so `InterveningIfClassificationTest` re-derives the reading from each card's own Oracle text and
 fails the build on a mismatch, over the population where the pairing is unambiguous.
 
+A self-bound `EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD)` with
+`triggerZone = Zone.GRAVEYARD` models "put into a graveyard from anywhere" (Dread).
+It checks the card after the move, including a battlefield departure that restores abilities
+removed by Lignify. Explicit `from = Zone.BATTLEFIELD` triggers still use the departure snapshot.
+For "shuffle it into its owner's library", compose a graveyard-gated `Effects.Move` to the library
+with `ShuffleLibraryEffect()` so the owner still shuffles if the card has left the graveyard.
+
 **`triggerZones` — which zones the trigger condition functions in (CR 113.6b).** Defaults to
 `setOf(Zone.BATTLEFIELD)`, which CR 113.6 makes the rule for a permanent card's abilities. It is a
 *set* because CR 113.6k lets one ability function from several zones at once. `triggerZone` is the

--- a/manual-scenarios/cards/d/dread.json
+++ b/manual-scenarios/cards/d/dread.json
@@ -1,0 +1,85 @@
+{
+  "player1Name": "Dread",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Dread",
+      "Lignify",
+      "Terminate"
+    ],
+    "battlefield": [
+      {
+        "name": "Dread"
+      },
+      {
+        "name": "Prodigal Sorcerer"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      }
+    ],
+    "library": [
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Cremate"
+    ],
+    "battlefield": [
+      {
+        "name": "Grizzly Bears"
+      },
+      {
+        "name": "Llanowar Elves"
+      },
+      {
+        "name": "Ornithopter"
+      },
+      {
+        "name": "Swamp"
+      }
+    ],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Dread.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Dread.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+val Dread = card("Dread") {
+    manaCost = "{3}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Elemental Incarnation"
+    power = 6
+    toughness = 6
+    oracleText = "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nWhenever a creature deals damage to you, destroy it.\nWhen Dread is put into a graveyard from anywhere, shuffle it into its owner's library."
+
+    keywords(Keyword.FEAR)
+
+    triggeredAbility {
+        trigger = Triggers.damageDealtToYou(GameObjectFilter.Creature)
+        effect = Effects.Destroy(EffectTarget.TriggeringEntity)
+    }
+
+    triggeredAbility {
+        triggerZone = Zone.GRAVEYARD
+        trigger = TriggerSpec(
+            event = EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD),
+            binding = TriggerBinding.SELF
+        )
+        // Shuffle even if the card has left the graveyard before this resolves.
+        effect = Effects.Move(EffectTarget.Self, Zone.LIBRARY, fromZone = Zone.GRAVEYARD) then
+            ShuffleLibraryEffect()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "107"
+        artist = "Matt Cavotta"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b608658-9150-439b-b0a0-4a994722b95c.jpg?1783942892"
+        ruling("2007-10-01", "The last ability triggers when the Incarnation is put into its owner’s graveyard from any zone, not just from on the battlefield.")
+        ruling("2007-10-01", "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn’t *specifically* trigger on leaving the battlefield, so it doesn’t behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard.")
+        ruling("2007-10-01", "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner’s library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn’t trigger and the Incarnation would remain in the graveyard.")
+        ruling("2007-10-01", "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles their library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won’t trigger at all.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DreadScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DreadScenarioTest.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.LibraryShuffledEvent
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+class DreadScenarioTest : ScenarioTestBase() {
+    init {
+        fun base() = scenario().withPlayers("P1", "P2")
+            .withActivePlayer(1).inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+        test("destroyed Dread shuffles into its owner's library") {
+            val game = base().withCardOnBattlefield(1, "Dread")
+                .withCardInHand(1, "Terminate")
+                .withLandsOnBattlefield(1, "Swamp", 1)
+                .withLandsOnBattlefield(1, "Mountain", 1).build()
+            game.castSpell(1, "Terminate", game.findPermanent("Dread")!!).error shouldBe null
+            game.resolveStack()
+            game.findCardsInLibrary(1, "Dread").size shouldBe 1
+            game.isInGraveyard(1, "Dread") shouldBe false
+        }
+
+        test("Lignify cannot suppress the ability that triggers from the graveyard") {
+            val game = base().withCardOnBattlefield(1, "Dread")
+                .withCardInHand(1, "Lignify").withCardInHand(1, "Terminate")
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .withLandsOnBattlefield(1, "Swamp", 1)
+                .withLandsOnBattlefield(1, "Mountain", 1).build()
+            val dread = game.findPermanent("Dread")!!
+            game.castSpell(1, "Lignify", dread).error shouldBe null
+            game.resolveStack()
+            game.castSpell(1, "Terminate", dread).error shouldBe null
+            game.resolveStack()
+            game.findCardsInLibrary(1, "Dread").size shouldBe 1
+        }
+
+        test("milling Dread triggers its shuffle") {
+            val game = base().withCardInLibrary(1, "Dread")
+                .withCardInHand(1, "Tome Scour")
+                .withLandsOnBattlefield(1, "Island", 1).build()
+            game.castSpellTargetingPlayer(1, "Tome Scour", 1).error shouldBe null
+            game.resolveStack()
+            game.findCardsInLibrary(1, "Dread").size shouldBe 1
+        }
+
+        test("discarding Dread triggers its shuffle") {
+            val game = base().withCardInHand(1, "Dread").withCardInHand(1, "Mind Rot")
+                .withLandsOnBattlefield(1, "Swamp", 3).build()
+            game.castSpellTargetingPlayer(1, "Mind Rot", 1).error shouldBe null
+            game.resolveStack()
+            game.findCardsInLibrary(1, "Dread").size shouldBe 1
+        }
+
+        test("countering Dread triggers the shuffle from the stack") {
+            val game = base().withCardInHand(1, "Dread").withCardInHand(2, "Counterspell")
+                .withLandsOnBattlefield(1, "Swamp", 6)
+                .withLandsOnBattlefield(2, "Island", 2).build()
+            game.castSpell(1, "Dread").error shouldBe null
+            game.passPriority().error shouldBe null
+            game.castSpellTargetingStackSpell(2, "Counterspell", "Dread").error shouldBe null
+            game.resolveStack()
+            game.findCardsInLibrary(1, "Dread").size shouldBe 1
+        }
+
+        test("exiling Dread in response still shuffles but leaves Dread exiled") {
+            val game = base().withCardOnBattlefield(1, "Dread")
+                .withCardInHand(1, "Terminate").withCardInHand(1, "Cremate")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withCardInLibrary(1, "Forest").withCardInLibrary(1, "Island").build()
+            game.castSpell(1, "Terminate", game.findPermanent("Dread")!!).error shouldBe null
+            game.passPriority().error shouldBe null
+            game.passPriority().error shouldBe null
+            game.isInGraveyard(1, "Dread") shouldBe true
+            game.state.stack.size shouldBe 1
+            game.castSpellTargetingGraveyardCard(1, "Cremate", 1, "Dread").error shouldBe null
+            val results = game.resolveStack()
+            game.findCardsInLibrary(1, "Dread").size shouldBe 0
+            game.isInGraveyard(1, "Dread") shouldBe false
+            results.flatMap { it.events }.filterIsInstance<LibraryShuffledEvent>().size shouldBe 1
+        }
+
+        test("a graveyard replacement prevents the shuffle trigger") {
+            val game = base().withCardOnBattlefield(1, "Dread")
+                .withCardOnBattlefield(2, "Rest in Peace")
+                .withCardInHand(1, "Terminate")
+                .withLandsOnBattlefield(1, "Swamp", 1)
+                .withLandsOnBattlefield(1, "Mountain", 1).build()
+            game.castSpell(1, "Terminate", game.findPermanent("Dread")!!).error shouldBe null
+            val results = game.resolveStack()
+            game.findCardsInLibrary(1, "Dread").size shouldBe 0
+            results.flatMap { it.events }.filterIsInstance<LibraryShuffledEvent>().size shouldBe 0
+        }
+
+        test("creature damage to you destroys the source without targeting") {
+            val game = base().withCardOnBattlefield(1, "Dread")
+                .withCardOnBattlefield(1, "Prodigal Sorcerer").build()
+            game.execute(ActivateAbility(
+                game.player1Id, game.findPermanent("Prodigal Sorcerer")!!,
+                cardRegistry.getCard("Prodigal Sorcerer")!!.activatedAbilities.single().id,
+                targets = listOf(ChosenTarget.Player(game.player1Id))
+            )).error shouldBe null
+            game.resolveStack()
+            game.getLifeTotal(1) shouldBe 19
+            game.isInGraveyard(1, "Prodigal Sorcerer") shouldBe true
+        }
+
+        test("creature damage to another player does not retaliate") {
+            val game = base().withCardOnBattlefield(1, "Dread")
+                .withCardOnBattlefield(1, "Prodigal Sorcerer").build()
+            game.execute(ActivateAbility(
+                game.player1Id, game.findPermanent("Prodigal Sorcerer")!!,
+                cardRegistry.getCard("Prodigal Sorcerer")!!.activatedAbilities.single().id,
+                targets = listOf(ChosenTarget.Player(game.player2Id))
+            )).error shouldBe null
+            game.resolveStack()
+            game.getLifeTotal(2) shouldBe 19
+            game.isInGraveyard(1, "Prodigal Sorcerer") shouldBe false
+        }
+
+        test("spell damage does not trigger retaliation") {
+            val game = base().withCardOnBattlefield(1, "Dread")
+                .withCardInHand(1, "Lightning Bolt")
+                .withLandsOnBattlefield(1, "Mountain", 1).build()
+            game.castSpellTargetingPlayer(1, "Lightning Bolt", 1).error shouldBe null
+            game.resolveStack()
+            game.getLifeTotal(1) shouldBe 17
+            game.isInGraveyard(1, "Dread") shouldBe false
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -4013,6 +4013,89 @@
     ]
 }
 
+// Dread
+{
+    "name": "Dread",
+    "manaCost": "{3}{B}{B}{B}",
+    "typeLine": "Creature — Elemental Incarnation",
+    "oracleText": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nWhenever a creature deals damage to you, destroy it.\nWhen Dread is put into a graveyard from anywhere, shuffle it into its owner's library.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FEAR"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "recipient": "You",
+                    "sourceFilter": "creature"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "TriggeringEntity",
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "Self",
+                            "destination": "Library",
+                            "fromZone": "Graveyard"
+                        },
+                        "ShuffleLibrary"
+                    ]
+                },
+                "activeZones": [
+                    "Graveyard"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "rarity": "RARE",
+        "artist": "Matt Cavotta",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b608658-9150-439b-b0a0-4a994722b95c.jpg?1783942892",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "The last ability triggers when the Incarnation is put into its owner’s graveyard from any zone, not just from on the battlefield."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "Although this ability triggers when the Incarnation is put into a graveyard from the battlefield, it doesn’t *specifically* trigger on leaving the battlefield, so it doesn’t behave like other leaves-the-battlefield abilities. The ability will trigger from the graveyard."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "If the Incarnation had lost this ability while on the battlefield (due to Lignify, for example) and then was destroyed, the ability would still trigger and it would get shuffled into its owner’s library. However, if the Incarnation lost this ability when it was put into the graveyard (due to Yixlid Jailer, for example), the ability wouldn’t trigger and the Incarnation would remain in the graveyard."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "If the Incarnation is removed from the graveyard after the ability triggers but before it resolves, it will remain in its new zone when its owner shuffles their library. Similarly, if a replacement effect has the Incarnation move to a different zone instead of being put into the graveyard, the ability won’t trigger at all."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Dreamspoiler Witches
 {
     "name": "Dreamspoiler Witches",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1569,23 +1569,17 @@ class TriggerDetector(
                     val container = state.getEntity(entityId) ?: continue
                     val cardComponent = container.get<CardComponent>() ?: continue
 
-                    // The card's OWN battlefield-exit (its death / leaving) is owned by the dedicated
-                    // death and leaves-battlefield detectors below, which resolve the dying entity's
-                    // abilities regardless of activeZones. Skipping it here prevents a
-                    // graveyard-active dies trigger (triggerZone = GRAVEYARD, e.g. Paramecia
-                    // Coloniex) from being detected twice — once here, because the dead card already
-                    // sits in the graveyard and its trigger pattern matches its own death event, and
-                    // once in detectDeathTriggers. The same guard covers a commander that died and
-                    // went to the command zone instead. Other zone-resident reactions (another
-                    // creature dying, entering, a spell being cast) still fall through to the
-                    // matcher below.
-                    if (event is ZoneChangeEvent && event.fromZone == Zone.BATTLEFIELD &&
-                        event.entityId == entityId) continue
-
                     val abilities = abilityResolver.getTriggeredAbilities(entityId, cardComponent.cardDefinitionId, state, index.statics)
 
                     for (ability in abilities) {
                         if (zone !in ability.activeZones) continue
+                        // Explicit battlefield-exit triggers use the dedicated look-back detectors.
+                        // "From anywhere" triggers instead see the card in its destination zone,
+                        // including abilities restored when it leaves the battlefield.
+                        if (event is ZoneChangeEvent && event.fromZone == Zone.BATTLEFIELD &&
+                            event.entityId == entityId &&
+                            (ability.trigger as? EventPattern.ZoneChangeEvent)?.from == Zone.BATTLEFIELD
+                        ) continue
                         if (isGraveyardToHandSelfTrigger(ability, event, entityId)) continue
                         val ownerId = cardComponent.ownerId
                             ?: container.get<OwnerComponent>()?.playerId


### PR DESCRIPTION
Dread’s “put into a graveyard from anywhere” ability must trigger from the graveyard, including when Lignify removed its abilities on the battlefield. The engine previously skipped every self battlefield-departure event in the graveyard scan. Narrow that skip to explicit battlefield-exit triggers so destination-zone triggers work while ordinary dies triggers retain their existing detection path.

Add Dread to its original Lorwyn printing using existing fear, damage-to-you, destruction, zone-move, and shuffle primitives. Its owner still shuffles if Dread is exiled in response. This is a single-card PR because the card needed an engine correction.

Includes ten Dread scenario tests, a manual client scenario, the SDK reference update, the Dread-only golden snapshot addition, and the Lorwyn backlog update to 278/286. Both abilities use the existing automatic trigger/stack flow and require no new client decisions.

Validation:

- `just test`: full project test gate passes.
- `just test-class DreadScenarioTest`: ten tests pass, covering destruction, Lignify, milling, discarding, countering, exile in response, graveyard replacement, and retaliation source/recipient restrictions.
- `just rebless-cards`: only Dread was added to LRW.json.
- `just check-card-printing Dread`: passes; LRW is the earliest real printing.
- Fresh Scryfall field comparison and exact image URL check pass.
- `just assay-differential --set LRW`: 108 agree, three existing parser grouping differences (Boggart Sprite-Chaser, Epic Proportions, Kithkin Greatheart). Dread’s trigger text is declined, not independently verified by Assay.

Manual scenario: `manual-scenarios/cards/d/dread.json` (JSON and card names checked; not manually played through the UI).
