### PR TITLE
Add Mindleech Mass to Ravnica

### DIFF
--- a/backlog/sets/ravnica-city-of-guilds/cards.md
+++ b/backlog/sets/ravnica-city-of-guilds/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards
 **Release Date:** October 7, 2005
-**Implemented:** 271 / 291
+**Implemented:** 272 / 291
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 37    | 33   |
@@ -10,7 +10,7 @@
 | Black      | 37    | 35   |
 | Red        | 39    | 38   |
 | Green      | 37    | 37   |
-| Multicolor | 64    | 56   |
+| Multicolor | 64    | 57   |
 | Artifact   | 21    | 17   |
 | Land       | 17    | 17   |
 
@@ -252,7 +252,7 @@
 - [x] Loxodon Hierarch
 - [x] Lurking Informant
 - [ ] Master Warcraft
-- [ ] Mindleech Mass
+- [x] Mindleech Mass
 - [x] Moroii
 - [x] Perplex
 - [x] Phytohydra

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/MindleechMass.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/MindleechMass.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.LookAtTargetHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+val MindleechMass = card("Mindleech Mass") {
+    manaCost = "{5}{U}{B}{B}"
+    colorIdentity = "UB"
+    typeLine = "Creature — Horror"
+    oracleText = "Trample\nWhenever this creature deals combat damage to a player, you may look at that player's hand. If you do, you may cast a spell from among those cards without paying its mana cost."
+    power = 6
+    toughness = 6
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        optional = true
+        effect = Effects.Composite(
+            LookAtTargetHandEffect(EffectTarget.PlayerRef(Player.TriggeringPlayer)),
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.HAND, Player.TriggeringPlayer),
+                storeAs = "opponentsHand"
+            ),
+            SelectFromCollectionEffect(
+                from = "opponentsHand",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                filter = GameObjectFilter.Nonland,
+                storeSelected = "spellToCast",
+                showAllCards = true,
+                prompt = "You may cast a nonland card without paying its mana cost",
+                selectedLabel = "Cast for free"
+            ),
+            Effects.CastFromCollectionWithoutPayingCost("spellToCast")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "215"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7cd1ace7-d4fe-4f96-9434-7ab1442bf36f.jpg?1783943617"
+        ruling("2024-01-12", "If you cast a permanent spell this way, it will enter the battlefield under your control when it resolves. If you cast an instant or sorcery spell this way, that card will be put into its owner's graveyard when it resolves.")
+        ruling("2024-01-12", "The spell you cast via the triggered ability is cast as part of the resolution of that ability. Timing restrictions based on the card's type are ignored. Other restrictions, such as \"Cast [this spell] only during an opponent's turn,\" are not.")
+        ruling("2024-01-12", "If you cast a spell without paying its mana cost, you can't choose to cast it for any alternative costs, such as overload costs. You can pay additional costs, such as kicker costs. If the spell has any mandatory additional costs, you must pay those.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MindleechMassScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MindleechMassScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CombatResolutionDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+class MindleechMassScenarioTest : ScenarioTestBase() {
+    init {
+        fun combat(hand: List<String> = listOf("Grizzly Bears", "Island")): TestGame {
+            val setup = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Mindleech Mass", summoningSickness = false)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            hand.forEach { setup.withCardInHand(2, it) }
+            val game = setup.build()
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Mindleech Mass" to 2)).error shouldBe null
+            game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+            game.resolveStack()
+            if (game.state.pendingDecision is CombatResolutionDecision) {
+                game.submitDefaultCombatDamage()
+                game.resolveStack()
+            }
+            (game.state.pendingDecision is YesNoDecision) shouldBe true
+            return game
+        }
+
+        test("casts an opponent's creature during combat for free under your control") {
+            val game = combat()
+            val bears = game.findCardsInHand(2, "Grizzly Bears").single()
+            game.answerYesNo(true).error shouldBe null
+            game.resolveStack()
+            (game.state.pendingDecision is SelectCardsDecision) shouldBe true
+            game.selectCards(listOf(bears)).error shouldBe null
+            game.resolveStack()
+            game.isInHand(2, "Grizzly Bears") shouldBe false
+            game.state.projectedState.getController(bears) shouldBe game.player1Id
+            game.isInHand(2, "Island") shouldBe true
+        }
+
+        test("casts a targeted spell and sends it to its owner's graveyard") {
+            val game = combat(listOf("Lightning Bolt"))
+            val bolt = game.findCardsInHand(2, "Lightning Bolt").single()
+            game.answerYesNo(true).error shouldBe null
+            game.resolveStack()
+            game.selectCards(listOf(bolt)).error shouldBe null
+            game.selectTargets(listOf(game.player2Id)).error shouldBe null
+            game.resolveStack()
+            game.getLifeTotal(2) shouldBe 11
+            game.isInGraveyard(2, "Lightning Bolt") shouldBe true
+        }
+
+        test("a land cannot be selected as a spell") {
+            val game = combat()
+            val island = game.findCardsInHand(2, "Island").single()
+            game.answerYesNo(true).error shouldBe null
+            game.resolveStack()
+            game.selectCards(listOf(island)).isSuccess shouldBe false
+            game.isInHand(2, "Island") shouldBe true
+        }
+
+        for (hand in listOf(emptyList(), listOf("Island"))) {
+            test("hand with no spells completes without a cast: $hand") {
+                val game = combat(hand)
+                game.answerYesNo(true).error shouldBe null
+                game.resolveStack()
+                if (hand.isNotEmpty()) {
+                    game.selectCards(emptyList()).error shouldBe null
+                    game.resolveStack()
+                }
+                game.state.pendingDecision shouldBe null
+                game.state.getHand(game.player2Id).size shouldBe hand.size
+            }
+        }
+
+        test("may look at the hand and decline to cast") {
+            val game = combat()
+            game.answerYesNo(true).error shouldBe null
+            game.resolveStack()
+            game.selectCards(emptyList()).error shouldBe null
+            game.resolveStack()
+            game.isInHand(2, "Grizzly Bears") shouldBe true
+            game.state.pendingDecision shouldBe null
+        }
+
+        test("may decline to look at the hand") {
+            val game = combat()
+            game.answerYesNo(false).error shouldBe null
+            game.resolveStack()
+            game.isInHand(2, "Grizzly Bears") shouldBe true
+            game.state.pendingDecision shouldBe null
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -8867,6 +8867,102 @@
     ]
 }
 
+// Mindleech Mass
+{
+    "name": "Mindleech Mass",
+    "manaCost": "{5}{U}{B}{B}",
+    "typeLine": "Creature — Horror",
+    "oracleText": "Trample\nWhenever this creature deals combat damage to a player, you may look at that player's hand. If you do, you may cast a spell from among those cards without paying its mana cost.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "LookAtTargetHand",
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "TriggeringPlayer"
+                                }
+                            },
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": "TriggeringPlayer"
+                                },
+                                "storeAs": "opponentsHand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "opponentsHand",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "filter": "nonland",
+                                "storeSelected": "spellToCast",
+                                "prompt": "You may cast a nonland card without paying its mana cost",
+                                "selectedLabel": "Cast for free",
+                                "showAllCards": true
+                            },
+                            {
+                                "type": "CastFromCollectionWithoutPayingCost",
+                                "from": "spellToCast"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "RARE",
+        "artist": "Kev Walker",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7cd1ace7-d4fe-4f96-9434-7ab1442bf36f.jpg?1783943617",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "If you cast a permanent spell this way, it will enter the battlefield under your control when it resolves. If you cast an instant or sorcery spell this way, that card will be put into its owner's graveyard when it resolves."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "The spell you cast via the triggered ability is cast as part of the resolution of that ability. Timing restrictions based on the card's type are ignored. Other restrictions, such as \"Cast [this spell] only during an opponent's turn,\" are not."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "If you cast a spell without paying its mana cost, you can't choose to cast it for any alternative costs, such as overload costs. You can pay additional costs, such as kicker costs. If the spell has any mandatory additional costs, you must pay those."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Mindmoil
 {
     "name": "Mindmoil",


### PR DESCRIPTION
Add Mindleech Mass to Ravnica: City of Guilds. Its combat-damage trigger lets its controller inspect the damaged player's hand, then optionally cast one nonland card for free during resolution. The card composes the existing hand-look, collection selection, and free-cast primitives; no engine or SDK changes are needed.

Includes the authoritative Ravnica metadata and Scryfall rulings, the card snapshot, and backlog bookkeeping (272/291).

Validation:
- `just build`
- `just test-class MindleechMassScenarioTest` — seven passing scenarios: creature and targeted-spell casting, ownership, land rejection, empty/all-land hands, and both optional declines.
- `just rebless-cards` — only Mindleech Mass added to RAV's golden.
- `just assay-differential --set RAV` — no divergences among 103 covered cards. Assay declines Mindleech Mass's ability; its behavior is covered by the scenarios above.
- Canonical-printing and backlog checks passed; metadata was re-fetched and compared against Scryfall, and the image URL returned HTTP 200.

Scope: Spawnbroker was investigated and deferred because its power-dependent second target requires a new target-selection flow. This PR keeps the completed card separate from that engine work.
