### PR TITLE
Add Chandra Nalaar with variable loyalty costs

### DIFF
--- a/backlog/sets/lorwyn/cards.md
+++ b/backlog/sets/lorwyn/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 cards
 **Release Date:** October 12, 2007
-**Implemented:** 278 / 286
+**Implemented:** 279 / 286
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 49    | 43   |
@@ -183,7 +183,7 @@
 - [x] Boggart Sprite-Chaser
 - [x] Caterwauling Boggart
 - [x] Ceaseless Searblades
-- [ ] Chandra Nalaar
+- [x] Chandra Nalaar
 - [x] Changeling Berserker
 - [x] Consuming Bonfire
 - [x] Crush Underfoot

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -8483,6 +8483,12 @@ copy of it (CR 707.10e). The activated-ability analogue of the spell-level `cant
 - `loyaltyAbility(+N) { ... }` — add loyalty + effect.
 - `loyaltyAbility(-N) { ... }` — remove loyalty + effect.
 - `loyaltyAbility(0) { ... }` — 0-loyalty ability.
+- `loyaltyAbilityX { ... }` — a −X loyalty cost (`AbilityCost.LoyaltyX`). The player chooses
+  X from zero through the source's current loyalty when activating; payment removes that many
+  loyalty counters and the effect reads the locked-in choice with `DynamicAmount.XValue`.
+  Uses the ordinary server X picker and the same sorcery-speed / per-turn loyalty restrictions
+  as fixed costs. Spending all loyalty is legal; the ability still resolves after its source leaves.
+  The client ability menu receives `loyaltyX = true` and renders −X. Chandra Nalaar uses this shape.
 
 ---
 

--- a/e2e-scenarios/tests/lorwyn/chandra-nalaar.spec.ts
+++ b/e2e-scenarios/tests/lorwyn/chandra-nalaar.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '../../fixtures/scenarioFixture'
+
+test('Chandra shows minus X, chooses loyalty to spend, and damages a creature', async ({ createGame }) => {
+  const { player1, player2 } = await createGame({
+    player1: {
+      battlefield: [{ name: 'Chandra Nalaar', counters: { LOYALTY: 6 } }],
+      library: ['Mountain', 'Mountain', 'Mountain'],
+    },
+    player2: {
+      battlefield: [{ name: 'Grizzly Bears' }],
+      library: ['Island', 'Island', 'Island'],
+    },
+    phase: 'PRECOMBAT_MAIN',
+    activePlayer: 1,
+  })
+  const p1 = player1.gamePage
+  await p1.clickCard('Chandra Nalaar')
+  const ability = player1.page.getByRole('button').filter({ hasText: 'deals X damage to target creature' })
+  await expect(ability.locator('.ms-loyalty-down.ms-loyalty-x')).toBeVisible()
+  await p1.screenshot('Chandra loyalty menu with minus X')
+  await ability.click()
+  await expect(player1.page.getByText('Maximum X: 6')).toBeVisible()
+  await p1.screenshot('Chandra X picker capped at six loyalty')
+  await p1.selectXValue(2)
+  await p1.selectTarget('Grizzly Bears')
+  await p1.confirmTargets()
+  await player2.gamePage.resolveStack('Chandra Nalaar ability')
+  await p1.expectNotOnBattlefield('Grizzly Bears')
+  await player2.gamePage.expectNotOnBattlefield('Grizzly Bears')
+})

--- a/manual-scenarios/cards/c/chandra-nalaar.json
+++ b/manual-scenarios/cards/c/chandra-nalaar.json
@@ -1,0 +1,65 @@
+{
+  "player1Name": "Chandra",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Chandra Nalaar"
+    ],
+    "battlefield": [
+      {
+        "name": "Chandra Nalaar",
+        "counters": {
+          "LOYALTY": 8
+        }
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Mountain",
+      "Mountain",
+      "Mountain",
+      "Mountain"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {
+        "name": "Jace Beleren",
+        "counters": {
+          "LOYALTY": 3
+        }
+      },
+      {
+        "name": "Grizzly Bears"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Island",
+      "Island",
+      "Island",
+      "Island"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -588,6 +588,13 @@ class CardBuilder(private val name: String) {
         activatedAbilities.add(builder.build())
     }
 
+    /** A −X loyalty ability. X is chosen at activation and may be zero. */
+    fun loyaltyAbilityX(init: LoyaltyAbilityBuilder.() -> Unit) {
+        val builder = LoyaltyAbilityBuilder(AbilityCost.LoyaltyX)
+        builder.init()
+        activatedAbilities.add(builder.build())
+    }
+
     // =========================================================================
     // Equipment
     // =========================================================================
@@ -1890,7 +1897,8 @@ class StaticAbilityBuilder {
 // =============================================================================
 
 @CardDsl
-class LoyaltyAbilityBuilder(private val loyaltyChange: Int) {
+class LoyaltyAbilityBuilder(private val loyaltyCost: AbilityCost) {
+    constructor(loyaltyChange: Int) : this(AbilityCost.Loyalty(loyaltyChange))
     var effect: Effect? = null
     var target: TargetRequirement? = null
     var description: String? = null
@@ -1913,7 +1921,7 @@ class LoyaltyAbilityBuilder(private val loyaltyChange: Int) {
         }
         return ActivatedAbility(
             id = AbilityId.generate(),
-            cost = AbilityCost.Loyalty(loyaltyChange),
+            cost = loyaltyCost,
             effect = effect!!,
             targetRequirements = targetReqs,
             isPlaneswalkerAbility = true,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -444,6 +444,9 @@ object Costs {
     fun Loyalty(change: Int): AbilityCost =
         AbilityCost.Loyalty(change)
 
+    /** Remove the chosen X loyalty counters from the source (−X). */
+    val LoyaltyX: AbilityCost = AbilityCost.LoyaltyX
+
     // =========================================================================
     // Tap Permanents Costs
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -603,6 +603,13 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
         override val description: String = if (change >= 0) "+$change" else "$change"
     }
 
+    /** A variable negative loyalty cost (−X), chosen when the ability is activated. */
+    @SerialName("CostLoyaltyX")
+    @Serializable
+    data object LoyaltyX : AbilityCost {
+        override val description: String = "−X"
+    }
+
     /**
      * Forage: exile three cards from your graveyard or sacrifice a Food.
      * Used as an activated ability cost for Bloomburrow cards.

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ChandraNalaar.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ChandraNalaar.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+// Current Oracle targets players or planeswalkers directly for +1 and −8.
+val ChandraNalaar = card("Chandra Nalaar") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Planeswalker — Chandra"
+    startingLoyalty = 6
+    oracleText = "+1: Chandra Nalaar deals 1 damage to target player or planeswalker.\n−X: Chandra Nalaar deals X damage to target creature.\n−8: Chandra Nalaar deals 10 damage to target player or planeswalker and each creature that player or that planeswalker's controller controls."
+
+    loyaltyAbility(+1) {
+        val recipient = target("target player or planeswalker", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(1, recipient)
+    }
+
+    loyaltyAbilityX {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(DynamicAmount.XValue, creature)
+    }
+
+    loyaltyAbility(-8) {
+        val recipient = target("target player or planeswalker", Targets.PlayerOrPlaneswalker)
+        // The target is either the player themself or a permanent they control. Only that
+        // recipient is targeted; their creatures are affected even if they have shroud.
+        // An animated planeswalker in both groups is still dealt ten damage only once.
+        val creatures = GameObjectFilter.Creature.targetPlayerControls(recipient) or
+            GameObjectFilter.Creature.targetPlayerControls(EffectTarget.TargetController)
+        effect = Effects.DealDamage(10, recipient) then
+            Patterns.Group.dealDamageToAll(10, GroupFilter(creatures, excludeTarget = true))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "159"
+        artist = "Aleksi Briclot"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/317e7ab7-7639-4877-aae2-3746563f2ec9.jpg?1783942878"
+        ruling("2007-10-01", "To activate the second ability, you choose a value of X equal to or less than the number of loyalty counters on Chandra Nalaar. You may choose 0. You can’t choose a negative number.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ChandraNalaarScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ChandraNalaarScenarioTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.LoyaltyChangedEvent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.ChandraNalaar
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.JaceBeleren
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ChandraNalaarScenarioTest : FunSpec({
+    val animatedWalker = card("Animated Planeswalker Test") {
+        manaCost = "{3}{U}"
+        typeLine = "Artifact Creature Planeswalker — Golem"
+        startingLoyalty = 15
+        power = 1
+        toughness = 30
+    }
+    fun driver(): GameTestDriver = GameTestDriver().also {
+        it.registerCards(TestCards.all + listOf(ChandraNalaar, JaceBeleren, animatedWalker))
+        it.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        it.passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+    fun putChandra(d: GameTestDriver, player: EntityId): EntityId =
+        d.putPermanentOnBattlefield(player, "Chandra Nalaar").also {
+            d.addComponent(it, CountersComponent(mapOf(CounterType.LOYALTY to 6)))
+        }
+    fun loyalty(d: GameTestDriver, id: EntityId) =
+        d.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+    val abilities = ChandraNalaar.script.activatedAbilities
+
+    test("casting Chandra gives her six starting loyalty counters") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val chandra = d.putCardInHand(me, "Chandra Nalaar")
+        d.giveMana(me, com.wingedsheep.sdk.core.Color.RED, 5)
+        d.castSpell(me, chandra).isSuccess shouldBe true
+        d.bothPass()
+        loyalty(d, chandra) shouldBe 6
+    }
+
+    test("plus one damages only the targeted player and adds loyalty as a cost") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+        val chandra = putChandra(d, me)
+        d.submitSuccess(ActivateAbility(me, chandra, abilities[0].id,
+            targets = listOf(ChosenTarget.Player(opp))))
+        loyalty(d, chandra) shouldBe 7
+        d.bothPass()
+        d.getLifeTotal(opp) shouldBe 19
+        d.getLifeTotal(me) shouldBe 20
+    }
+
+    for (x in listOf(0, 2, 6)) {
+        test("minus X pays and resolves with X=$x even when Chandra spends all loyalty") {
+            val d = driver()
+            val me = d.activePlayer!!
+            val chandra = putChandra(d, me)
+            val creature = d.putPermanentOnBattlefield(d.getOpponent(me), "Grizzly Bears")
+            val result = d.submitSuccess(ActivateAbility(me, chandra, abilities[1].id,
+                targets = listOf(ChosenTarget.Permanent(creature)), xValue = x))
+            loyalty(d, chandra) shouldBe 6 - x
+            result.events.filterIsInstance<LoyaltyChangedEvent>().single().change shouldBe -x
+            d.bothPass()
+            if (x == 0) {
+                d.state.getEntity(creature)?.get<DamageComponent>()?.amount.orZero() shouldBe 0
+            } else {
+                d.getGraveyard(d.getOpponent(me)).contains(creature) shouldBe true
+            }
+        }
+    }
+
+    for (x in listOf(-1, 7)) {
+        test("rejects an unaffordable or negative X=$x without paying loyalty") {
+            val d = driver()
+            val me = d.activePlayer!!
+            val chandra = putChandra(d, me)
+            val creature = d.putPermanentOnBattlefield(d.getOpponent(me), "Grizzly Bears")
+            d.submit(ActivateAbility(me, chandra, abilities[1].id,
+                targets = listOf(ChosenTarget.Permanent(creature)), xValue = x)).isSuccess shouldBe false
+            loyalty(d, chandra) shouldBe 6
+        }
+    }
+
+    test("minus X fizzles if its creature leaves while its loyalty cost stays paid") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val chandra = putChandra(d, me)
+        val creature = d.putPermanentOnBattlefield(d.getOpponent(me), "Grizzly Bears")
+        d.submitSuccess(ActivateAbility(me, chandra, abilities[1].id,
+            targets = listOf(ChosenTarget.Permanent(creature)), xValue = 2))
+        d.moveToGraveyard(creature)
+        d.bothPass()
+        loyalty(d, chandra) shouldBe 4
+        d.getLifeTotal(me) shouldBe 20
+        d.getLifeTotal(d.getOpponent(me)) shouldBe 20
+    }
+
+    for (targetPlaneswalker in listOf(false, true)) {
+        test("ultimate damages the recipient and their creatures - planeswalker=$targetPlaneswalker") {
+            val d = driver()
+            val me = d.activePlayer!!
+            val opp = d.getOpponent(me)
+            val chandra = putChandra(d, me)
+            d.addComponent(chandra, CountersComponent(mapOf(CounterType.LOYALTY to 8)))
+            val mine = d.putPermanentOnBattlefield(me, "Grizzly Bears")
+            val theirs = d.putPermanentOnBattlefield(opp, "Grizzly Bears")
+            val jace = if (targetPlaneswalker) d.putPermanentOnBattlefield(opp, "Jace Beleren").also {
+                d.addComponent(it, CountersComponent(mapOf(CounterType.LOYALTY to 15)))
+            } else null
+            val target = jace?.let { ChosenTarget.Permanent(it) } ?: ChosenTarget.Player(opp)
+            d.submitSuccess(ActivateAbility(me, chandra, abilities[2].id, targets = listOf(target)))
+            d.bothPass()
+            d.getLifeTotal(opp) shouldBe if (targetPlaneswalker) 20 else 10
+            if (jace != null) loyalty(d, jace) shouldBe 5
+            d.getGraveyard(opp).contains(theirs) shouldBe true
+            d.getGraveyard(me).contains(mine) shouldBe false
+        }
+    }
+    test("ultimate does not damage an animated target planeswalker twice") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+        val chandra = putChandra(d, me)
+        d.addComponent(chandra, CountersComponent(mapOf(CounterType.LOYALTY to 8)))
+        val target = d.putPermanentOnBattlefield(opp, animatedWalker.name)
+        d.addComponent(target, CountersComponent(mapOf(CounterType.LOYALTY to 15)))
+        d.submitSuccess(ActivateAbility(me, chandra, abilities[2].id,
+            targets = listOf(ChosenTarget.Permanent(target))))
+        d.bothPass()
+        loyalty(d, target) shouldBe 5
+        d.getLifeTotal(opp) shouldBe 20
+    }
+
+})
+
+private fun Int?.orZero() = this ?: 0

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/ChandraNalaarReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/ChandraNalaarReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+// Canonical definition: Lorwyn. This row supplies only the reprint presentation.
+val ChandraNalaarReprint = Printing(
+    oracleId = "f4da7a43-e9d5-47ea-b2f0-3cf55a156f4a",
+    name = "Chandra Nalaar",
+    setCode = "M10",
+    collectorNumber = "132",
+    scryfallId = "a3ce115a-28f8-4350-8e66-74e7a3727657",
+    artist = "Aleksi Briclot",
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a3ce115a-28f8-4350-8e66-74e7a3727657.jpg?1783942374",
+    releaseDate = "2009-07-17",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/ChandraNalaarReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/ChandraNalaarReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+// Canonical definition: Lorwyn. This row supplies only the reprint presentation.
+val ChandraNalaarReprint = Printing(
+    oracleId = "f4da7a43-e9d5-47ea-b2f0-3cf55a156f4a",
+    name = "Chandra Nalaar",
+    setCode = "M11",
+    collectorNumber = "127",
+    scryfallId = "ac44125d-28de-4ecf-a55b-1299daa5539e",
+    artist = "Aleksi Briclot",
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/ac44125d-28de-4ecf-a55b-1299daa5539e.jpg?1783941809",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -2583,6 +2583,156 @@
     ]
 }
 
+// Chandra Nalaar
+{
+    "name": "Chandra Nalaar",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Legendary Planeswalker — Chandra",
+    "oracleText": "+1: Chandra Nalaar deals 1 damage to target player or planeswalker.\n−X: Chandra Nalaar deals X damage to target creature.\n−8: Chandra Nalaar deals 10 damage to target player or planeswalker and each creature that player or that planeswalker's controller controls.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player or planeswalker"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayerOrPlaneswalker",
+                        "id": "target player or planeswalker"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostLoyaltyX",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": "XValue",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -8
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 10
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player or planeswalker"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": {
+                                        "anyOf": [
+                                            {
+                                                "cardPredicates": [
+                                                    "IsCreature"
+                                                ],
+                                                "controllerPredicate": {
+                                                    "type": "ControlledByReferencedPlayer",
+                                                    "target": {
+                                                        "type": "BoundVariable",
+                                                        "name": "target player or planeswalker"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "cardPredicates": [
+                                                    "IsCreature"
+                                                ],
+                                                "controllerPredicate": {
+                                                    "type": "ControlledByReferencedPlayer",
+                                                    "target": "TargetController"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "excludeTarget": true
+                                }
+                            },
+                            "body": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 10
+                                },
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayerOrPlaneswalker",
+                        "id": "target player or planeswalker"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "159",
+        "rarity": "RARE",
+        "artist": "Aleksi Briclot",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/317e7ab7-7639-4877-aae2-3746563f2ec9.jpg?1783942878",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "To activate the second ability, you choose a value of X equal to or less than the number of loyalty counters on Chandra Nalaar. You may choose 0. You can’t choose a negative number."
+            }
+        ]
+    },
+    "startingLoyalty": 6,
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Changeling Berserker
 {
     "name": "Changeling Berserker",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -286,7 +286,7 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // Planeswalker loyalty cost (CR 606) — the +N / -N ability activation cost. The engine models it
     // via `loyaltyAbility(loyaltyChange) { }` with `startingLoyalty`. Oko, the Ringleader. The emitter
     // declines the whole loyalty-ability envelope (Activated) -> SCAFFOLD, so this is capability-only.
-    supported("Loyalty", "cost: planeswalker loyalty +N/-N (loyaltyAbility(change) { })")
+    supported("Loyalty", "cost: planeswalker loyalty +N/-N/-X (loyaltyAbility(change) / loyaltyAbilityX)")
     supported("SacrificeAPermanent", "cost: sacrifice")
     supported("SacrificeNumberPermanents", "cost: sacrifice N")
     // Variable-count permanent costs — "exile/sacrifice **one or more** [filter] you control" as an

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -211,6 +211,7 @@ class CostHandler {
             is AbilityCost.Composite -> {
                 cost.costs.all { canPayAbilityCost(state, it, sourceId, controllerId, manaPool, abilityContext, granterId) }
             }
+            AbilityCost.LoyaltyX -> true // X = 0 is always payable; the chosen X is checked at payment.
             is AbilityCost.Loyalty -> {
                 // Check if we have enough loyalty to pay the cost
                 // Positive changes (like +1) can always be paid
@@ -550,6 +551,16 @@ class CostHandler {
                     allEvents.addAll(result.events)
                 }
                 CostPaymentResult.success(currentState, currentPool, allEvents)
+            }
+            AbilityCost.LoyaltyX -> {
+                val loyalty = state.getEntity(sourceId)?.get<CountersComponent>()
+                    ?.getCount(CounterType.LOYALTY) ?: 0
+                if (choices.xValue < 0 || choices.xValue > loyalty) {
+                    CostPaymentResult.failure("Not enough loyalty to pay X")
+                } else {
+                    payAbilityCost(state, AbilityCost.Loyalty(-choices.xValue), sourceId,
+                        controllerId, manaPool, choices, abilityContext)
+                }
             }
             is AbilityCost.Loyalty -> {
                 // Adjust loyalty counters based on the cost change

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -7,6 +7,8 @@ import com.wingedsheep.engine.core.AbilityActivatedEvent
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.suspendForDecision
 import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.engine.core.LoyaltyChangedEvent
 import com.wingedsheep.engine.core.ManaAddedEvent
 import com.wingedsheep.engine.core.PaymentStrategy
@@ -702,6 +704,12 @@ class ActivateAbilityHandler(
         val abilityLookup = lookupActivatedAbility(state, action.sourceId, action.abilityId)
             ?: return ExecutionResult.error(state, "Ability not found")
         val ability = abilityLookup.ability
+        if (ability.cost == AbilityCost.LoyaltyX && action.xValue != null) {
+            val loyalty = container.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+            if (action.xValue !in 0..loyalty) {
+                return ExecutionResult.error(state, "X must be between 0 and $loyalty")
+            }
+        }
         val staticGranterId = abilityLookup.staticGranterId
         val abilityIdentity = abilityLookup.definitionIdentity
 
@@ -840,9 +848,11 @@ class ActivateAbilityHandler(
         // gets to choose X. The engine-direct path (xValue pre-filled) skips this.
         // -------------------------------------------------------------------
         val manaXCost = extractManaCost(effectiveCost)
-        if (manaXCost?.hasX == true && action.xValue == null && tapXCost == null) {
-            val fixedMana = manaXCost.cmc // the non-X portion ({X} alone is 0; {1}{X} is 1)
-            val maxX = (manaSolver.getAvailableManaCount(state, action.playerId) - fixedMana).coerceAtLeast(0)
+        if ((manaXCost?.hasX == true || effectiveCost == AbilityCost.LoyaltyX) && action.xValue == null && tapXCost == null) {
+            val fixedMana = manaXCost?.cmc ?: 0 // the non-X portion ({X} alone is 0; {1}{X} is 1)
+            val maxX = if (effectiveCost == AbilityCost.LoyaltyX) {
+                container.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+            } else (manaSolver.getAvailableManaCount(state, action.playerId) - fixedMana).coerceAtLeast(0)
             // "X can't be 0" abilities (Gogo, Master of Mimicry) set a minimum; clamp it to what the
             // player can actually pay so the decision bounds stay valid.
             val minX = ability.minimumXValue.coerceAtMost(maxX)
@@ -1558,6 +1568,8 @@ class ActivateAbilityHandler(
         val abilityCost = ability.cost
         if (abilityCost is AbilityCost.Loyalty) {
             events.add(LoyaltyChangedEvent(action.sourceId, sourceName, abilityCost.change))
+        } else if (abilityCost == AbilityCost.LoyaltyX) {
+            events.add(LoyaltyChangedEvent(action.sourceId, sourceName, -xValue))
         }
 
         // Snapshot of the activation's cost-side events (cost payment + the {T}/tap/loyalty events

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
@@ -634,6 +634,7 @@ class CostEnumerationUtils(
             cost is AbilityCost.Atom &&
                 (cost.atom as? CostAtom.RemoveCounters)?.count is DynamicAmount.XValue
         return when (abilityCost) {
+            AbilityCost.LoyaltyX -> true
             is AbilityCost.TapXPermanents -> true
             is AbilityCost.Atom -> isXCounterRemoval(abilityCost)
             is AbilityCost.Composite -> abilityCost.costs.any {
@@ -666,6 +667,12 @@ class CostEnumerationUtils(
             ((availableSources - fixedCost).coerceAtLeast(0)) / xSymbols
         } else {
             Int.MAX_VALUE
+        }
+
+        if (abilityCost == AbilityCost.LoyaltyX) {
+            val loyalty = sourceId?.let { state.getEntity(it)?.get<CountersComponent>() }
+                ?.getCount(com.wingedsheep.sdk.core.CounterType.LOYALTY) ?: 0
+            maxX = minOf(maxX, loyalty)
         }
 
         // Cap by the graveyard cards an ExileXFromGraveyard cost could actually exile. The cap must

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -755,6 +755,8 @@ data class ClientPlaneswalkerAbility(
     val abilityId: String,
     /** Signed loyalty change (e.g., +1, -2, -8). */
     val loyaltyChange: Int,
+    /** True for a −X cost; the chosen X is supplied through the ordinary X picker. */
+    val loyaltyX: Boolean = false,
     /** Ability text (e.g., "Create a 1/1 green and white Kithkin creature token"). */
     val description: String
 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1511,14 +1511,18 @@ class ClientStateTransformer(
         val oracleDescriptions = parseOracleLoyaltyLines(cardDef.oracleText)
             .mapValues { (_, lines) -> ArrayDeque(lines) }
         return abilities.mapNotNull { ability ->
+            val loyaltyX = ability.cost == com.wingedsheep.sdk.scripting.AbilityCost.LoyaltyX
             val loyalty = (ability.cost as? com.wingedsheep.sdk.scripting.AbilityCost.Loyalty)?.change
-                ?: return@mapNotNull null
-            val description = oracleDescriptions[loyalty]?.removeFirstOrNull()
+                ?: if (loyaltyX) 0 else return@mapNotNull null
+            val description = (if (loyaltyX) cardDef.oracleText.lines()
+                .firstOrNull { it.startsWith("−X:") || it.startsWith("-X:") }
+                ?.substringAfter(":")?.trim() else oracleDescriptions[loyalty]?.removeFirstOrNull())
                 ?: ability.descriptionOverride
                 ?: effectDisplayText(ability.effect, "this planeswalker")
             ClientPlaneswalkerAbility(
                 abilityId = ability.id.value,
                 loyaltyChange = loyalty,
+                loyaltyX = loyaltyX,
                 description = description
             )
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VariableLoyaltyCostTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VariableLoyaltyCostTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.NumberChosenResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.ClientStateTransformer
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+
+class VariableLoyaltyCostTest : FunSpec({
+    val walker = card("Variable Loyalty Test") {
+        manaCost = "{2}{U}"
+        typeLine = "Legendary Planeswalker — Test"
+        startingLoyalty = 3
+        oracleText = "−X: Draw X cards."
+        loyaltyAbilityX { effect = Effects.DrawCards(DynamicAmount.XValue) }
+    }
+    fun driver() = GameTestDriver().also {
+        it.registerCards(TestCards.all + walker)
+        it.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        it.passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("variable loyalty survives SDK serialization") {
+        val decoded = Json.decodeFromString<CardDefinition>(Json.encodeToString(walker))
+        decoded.script.activatedAbilities.single().cost shouldBe walker.script.activatedAbilities.single().cost
+    }
+
+    for (x in listOf(0, 2, 3)) {
+        test("legal action and number continuation cap X at loyalty and retain X=$x") {
+            val d = driver()
+            val me = d.activePlayer!!
+            val source = d.putPermanentOnBattlefield(me, walker.name).also {
+                d.addComponent(it, CountersComponent(mapOf(CounterType.LOYALTY to 3)))
+            }
+            val action = d.legalActions(me).single {
+                (it.action as? ActivateAbility)?.sourceId == source
+            }
+            action.hasXCost shouldBe true
+            action.maxAffordableX shouldBe 3
+            action.minX shouldBe 0
+            val hand = d.getHandSize(me)
+            d.submit(action.action).isPaused shouldBe true
+            val question = d.pendingDecision as ChooseNumberDecision
+            question.minValue shouldBe 0
+            question.maxValue shouldBe 3
+            d.submitDecision(me, NumberChosenResponse(question.id, x)).error shouldBe null
+            d.bothPass()
+            d.getHandSize(me) shouldBe hand + x
+            // A variable cost counts as the permanent's loyalty activation this turn.
+            d.legalActions(me).any { (it.action as? ActivateAbility)?.sourceId == source } shouldBe false
+        }
+    }
+
+    test("variable loyalty remains visible with its oracle description in the client menu") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val source = d.putPermanentOnBattlefield(me, walker.name).also {
+            d.addComponent(it, CountersComponent(mapOf(CounterType.LOYALTY to 3)))
+        }
+        val menu = ClientStateTransformer(cardRegistry = d.cardRegistry)
+            .transform(d.state, viewingPlayerId = me).cards[source]!!.planeswalkerAbilities!!
+        menu.single().loyaltyX shouldBe true
+        menu.single().description shouldBe "Draw X cards."
+    }
+
+    test("a variable loyalty ability cannot be used on an opponent's turn") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+        val source = d.putPermanentOnBattlefield(opp, walker.name)
+        d.passPriority(me)
+        d.submit(ActivateAbility(opp, source, walker.script.activatedAbilities.single().id, xValue = 0))
+            .isSuccess shouldBe false
+    }
+})

--- a/web-client/src/components/ui/ActionMenu.tsx
+++ b/web-client/src/components/ui/ActionMenu.tsx
@@ -174,13 +174,15 @@ export function ActionMenu() {
  *
  * Magnitude > 20 falls back to the plain chevron (mana-font ships variants up to 20).
  */
-function LoyaltyIcon({ change }: { change: number }) {
+function LoyaltyIcon({ change, variable = false }: { change: number; variable?: boolean }) {
   const magnitude = Math.abs(change)
-  const direction = change > 0 ? 'up' : change < 0 ? 'down' : 'zero'
+  const direction = variable ? 'down' : change > 0 ? 'up' : change < 0 ? 'down' : 'zero'
   // mana-font ships ms-loyalty-{0..20,25} digit overlays; combine with the direction class
   // so 0-cost abilities render the neutral marker with a "0" inside, matching ±N styling.
   const hasNumberVariant = (direction === 'zero' && magnitude === 0) || (magnitude >= 1 && magnitude <= 20)
-  const className = hasNumberVariant
+  const className = variable
+    ? 'ms ms-loyalty-down ms-loyalty-x'
+    : hasNumberVariant
     ? `ms ms-loyalty-${direction} ms-loyalty-${magnitude}`
     : `ms ms-loyalty-${direction}`
   return (
@@ -294,7 +296,7 @@ function ActionOptionButton({
       >
         <span className={styles.actionButtonLeading}>
           {option.loyaltyChange !== undefined && (
-            <LoyaltyIcon change={option.loyaltyChange} />
+            <LoyaltyIcon change={option.loyaltyChange} variable={option.loyaltyX ?? false} />
           )}
           {option.impendingTime !== undefined && (
             <ImpendingTimeIcon time={option.impendingTime} />

--- a/web-client/src/components/ui/XCostSelector.tsx
+++ b/web-client/src/components/ui/XCostSelector.tsx
@@ -78,7 +78,7 @@ export function XCostSelector() {
         </div>
 
         <p style={styles.manaInfo}>
-          Available mana: {maxX + (xSelectionState.actionInfo.action.type === 'CastSpell' ? 0 : 0)}
+          {isRepeatCount ? 'Maximum activations' : 'Maximum X'}: {maxX}
         </p>
 
         <div style={styles.buttonRow}>

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -625,6 +625,7 @@ export interface ClientPlaneswalkerAbility {
   readonly abilityId: string
   /** Signed loyalty change (+1, -2, -8, etc.). */
   readonly loyaltyChange: number
+  readonly loyaltyX?: boolean
   /** Ability text. */
   readonly description: string
 }

--- a/web-client/src/utils/actionOptions.ts
+++ b/web-client/src/utils/actionOptions.ts
@@ -46,6 +46,7 @@ export interface ActionOption {
    * When present, the button renders a mana-font loyalty icon instead of a text prefix.
    */
   loyaltyChange?: number
+  loyaltyX?: boolean
   /**
    * For the impending cast option (CR 702.176): the number of time counters the permanent enters
    * with. When present, the button renders a time-counter glyph + count to mark the option as
@@ -543,6 +544,7 @@ export function buildActionOptions(
         action: match ?? null,
         actionType: 'activate',
         loyaltyChange: pw.loyaltyChange,
+        loyaltyX: pw.loyaltyX ?? false,
       })
     })
   }


### PR DESCRIPTION
Adds **Chandra Nalaar** to Lorwyn, with M10 and M11 reprint rows. Her −X ability introduces reusable variable loyalty costs, so this PR stays focused on one card.

- `loyaltyAbilityX` / `Costs.LoyaltyX`: the server bounds X by current loyalty, permits zero, pays the chosen amount, and preserves X through the number-choice continuation and stack resolution. Existing loyalty timing and activation limits apply.
- The client shows the −X loyalty icon and uses the existing X picker. Its caption now says “Maximum X” because X can be paid with loyalty or other non-mana resources.
- The ultimate targets a player or planeswalker and damages that recipient's creature group. A target that is also a creature is counted once.
- Includes a manual scenario, SDK reference update, printing metadata, and the Lorwyn checklist update to 279/286.

Validation: full `just test` passed. After the final card-only recipient exclusion, all 11 Chandra scenarios and card snapshots passed again. The six variable-loyalty engine tests cover serialization, X=0/full loyalty, continuation, timing, and client visibility. Frontend typecheck, the two-player Playwright scenario, canonical-printing checks, and backlog checks passed. Only Chandra changed in the snapshot golden.

Assay differential: 108/111 compared definitions agree. The three existing divergences are structural folds: Boggart Sprite-Chaser and Kithkin Greatheart combine stat/keyword grants under one condition; Epic Proportions combines stat/trample grants and differs in a cosmetic aura target ID. Chandra's loyalty text is not yet covered by Assay; its behavior is verified by the scenario and browser tests.

Screenshots from the running client (hosted on a throwaway screenshot branch):

![Chandra's loyalty menu](https://raw.githubusercontent.com/wingedsheep/argentum-engine/chandra-nalaar-screenshots-20260908/chandra-menu.png)

![X picker capped at current loyalty](https://raw.githubusercontent.com/wingedsheep/argentum-engine/chandra-nalaar-screenshots-20260908/chandra-x-picker.png)
