### PR TITLE
Add Brightflame with actual damage accounting

### DIFF
--- a/backlog/sets/ravnica-city-of-guilds/cards.md
+++ b/backlog/sets/ravnica-city-of-guilds/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards
 **Release Date:** October 7, 2005
-**Implemented:** 272 / 291
+**Implemented:** 273 / 291
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 37    | 33   |
@@ -224,7 +224,7 @@
 - [x] Boros Guildmage
 - [x] Boros Recruit
 - [x] Boros Swiftblade
-- [ ] Brightflame
+- [x] Brightflame
 - [x] Centaur Safeguard
 - [ ] Chorus of the Conclave
 - [x] Circu, Dimir Lobotomist

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -11053,6 +11053,13 @@ something other than the source.
   (`ManaCost.coloredSymbolCount`), so they agree symbol-for-symbol and differ only in scope.
   Being `Triggering`-scoped, it is rejected by `SetBaseStatsEffect(reevaluateContinuously = true)`
   like every other context-scoped amount; read off `EntityReference.Source` it is projector-safe.
+- `DynamicAmount.EntityProperty(entity, EntityNumericProperty.DamageDealtThisTurn)` — actual damage
+  dealt by a battlefield permanent or resolving spell this turn, including combat and noncombat
+  damage to any recipient. The tally is bound to the source’s object identity. Prevention
+  and damage replacement effects modify the tally; damage replaced entirely with counters contributes
+  zero. Turn changes make the value read zero and zone changes clear it. For “damage dealt this way”,
+  store the value before the damage and subtract it afterward (Brightflame). The stored baseline and
+  damage history survive resolution decisions, including optional damage redirection.
 - `EntityProperty(entity, EntityNumericProperty.ExcessMarkedDamage)` — the excess damage (CR 120.4a)
   marked on a creature: `max(0, marked − toughness)`, read from post-damage state. Amount-valued twin of
   the `TargetMarkedDamageExceedsToughness` condition. Read it AFTER a deal-damage step in the same

--- a/manual-scenarios/cards/b/brightflame.json
+++ b/manual-scenarios/cards/b/brightflame.json
@@ -1,0 +1,70 @@
+{
+  "player1Name": "Boros",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 10,
+    "hand": [
+      "Brightflame"
+    ],
+    "battlefield": [
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Centaur Courser"
+      },
+      {
+        "name": "Light of Sanction"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Mountain",
+      "Plains",
+      "Mountain"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {
+        "name": "Watchwolf"
+      },
+      {
+        "name": "Courier Hawk"
+      },
+      {
+        "name": "Glass Golem"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Plains",
+      "Forest"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityNumericProperty.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityNumericProperty.kt
@@ -16,6 +16,16 @@ import kotlinx.serialization.Serializable
 sealed interface EntityNumericProperty {
     val description: String
 
+    /** Actual damage dealt by this object this turn, after prevention and replacement effects.
+     * For battlefield permanents and resolving spells; includes damage to any recipient.
+     * Zone changes reset the history. Damage from a departed source does not mark its new object.
+     */
+    @SerialName("DamageDealtThisTurn")
+    @Serializable
+    data object DamageDealtThisTurn : EntityNumericProperty {
+        override val description: String = "damage dealt this turn"
+    }
+
     @SerialName("Power")
     @Serializable
     data object Power : EntityNumericProperty {

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Brightflame.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Brightflame.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+val Brightflame = card("Brightflame") {
+    manaCost = "{X}{R}{R}{W}{W}"
+    colorIdentity = "RW"
+    typeLine = "Sorcery"
+    oracleText = "Radiance — Brightflame deals X damage to target creature and each other creature that shares a color with it. You gain life equal to the damage dealt this way."
+
+    spell {
+        val victim = target("target creature", Targets.Creature)
+        val damageDealt = DynamicAmount.EntityProperty(
+            EntityReference.Source, EntityNumericProperty.DamageDealtThisTurn
+        )
+        effect = Effects.Pipeline {
+            val before = storeNumber(damageDealt)
+            // Fix the radiance group before any damage or damage replacements happen.
+            val others = gather(CardSource.BattlefieldMatching(
+                filter = GameObjectFilter.Creature.sharingColorWith(EntityReference.Target(0)),
+                excludeChosenTargets = true
+            ))
+            run(Effects.DealDamage(DynamicAmount.XValue, victim))
+            run(ForEachInCollectionEffect(
+                collection = others.key,
+                effect = Effects.DealDamage(DynamicAmount.XValue, EffectTarget.Self)
+            ))
+            run(Effects.GainLife(DynamicAmount.Subtract(damageDealt, before.amount)))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "194"
+        artist = "Dave Dorman"
+        flavorText = "\"Let the pyres of the unbelievers light our way.\"\n—Razia"
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9a3acf27-5d07-48e6-8e19-a2e6d4cd49d1.jpg?1783943626"
+        ruling("2005-10-01", "You gain life equal to the total damage dealt by Brightflame to all creatures. You don’t gain life for any damage that was prevented.")
+        ruling("2005-10-01", "All creatures that share a color are affected, even your own.")
+        ruling("2005-10-01", "A creature “shares a color” with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on.")
+        ruling("2005-10-01", "If it targets a colorless creature, it doesn’t affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures.")
+        ruling("2005-10-01", "You check which creatures share a color with the target when the spell resolves.")
+        ruling("2005-10-01", "Only one creature is targeted. If that creature leaves the battlefield or otherwise becomes an illegal target, the entire spell doesn’t resolve. No other creatures are affected.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BrightflameScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BrightflameScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.*
+import com.wingedsheep.mtg.sets.definitions.drk.cards.BloodOfTheMartyr
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class BrightflameScenarioTest : FunSpec({
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + listOf(Brightflame, Watchwolf, LightOfSanction, GhostsOfTheInnocent, Phytohydra, BloodOfTheMartyr))
+        initMirrorMatch(Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    fun GameTestDriver.cast(target: EntityId, x: Int) {
+        giveMana(player1, Color.RED, x + 2)
+        giveMana(player1, Color.WHITE, 2)
+        castXSpell(player1, putCardInHand(player1, "Brightflame"), x, listOf(target)).error shouldBe null
+    }
+
+    fun GameTestDriver.resolve() {
+        var passes = 0
+        while (stackSize > 0 && passes++ < 20) bothPass()
+        stackSize shouldBe 0
+    }
+
+    fun GameTestDriver.damage(id: EntityId) = state.getEntity(id)?.get<DamageComponent>()?.amount ?: 0
+
+    test("radiance counts each matching creature once across both players and both colors") {
+        val d = driver()
+        val target = d.putCreatureOnBattlefield(d.player2, "Watchwolf")
+        val green = d.putCreatureOnBattlefield(d.player1, "Centaur Courser")
+        val white = d.putCreatureOnBattlefield(d.player2, "Savannah Lions")
+        val red = d.putCreatureOnBattlefield(d.player2, "Goblin Guide")
+        d.cast(target, 1)
+        d.resolve()
+        d.getLifeTotal(d.player1) shouldBe 23
+        d.damage(target) shouldBe 1
+        d.damage(green) shouldBe 1
+        d.getGraveyard(d.player2).contains(white) shouldBe true
+        d.damage(red) shouldBe 0
+    }
+
+    test("a colorless target is damaged without affecting other colorless creatures") {
+        val d = driver()
+        val target = d.putCreatureOnBattlefield(d.player2, "Artifact Creature")
+        val other = d.putCreatureOnBattlefield(d.player1, "Artifact Creature")
+        d.cast(target, 1)
+        d.resolve()
+        d.getLifeTotal(d.player1) shouldBe 21
+        d.damage(target) shouldBe 1
+        d.damage(other) shouldBe 0
+    }
+
+    test("damage beyond lethal still counts fully toward life gain") {
+        val d = driver()
+        val target = d.putCreatureOnBattlefield(d.player2, "Watchwolf")
+        d.putCreatureOnBattlefield(d.player1, "Centaur Courser")
+        d.cast(target, 5)
+        d.resolve()
+        d.getLifeTotal(d.player1) shouldBe 30
+    }
+
+    test("prevented damage is excluded from life gain") {
+        val d = driver()
+        val target = d.putCreatureOnBattlefield(d.player2, "Watchwolf")
+        val protected = d.putCreatureOnBattlefield(d.player1, "Centaur Courser")
+        d.putPermanentOnBattlefield(d.player1, "Light of Sanction")
+        d.cast(target, 2)
+        d.resolve()
+        d.damage(protected) shouldBe 0
+        d.damage(target) shouldBe 2
+        d.getLifeTotal(d.player1) shouldBe 22
+    }
+
+    test("damage replacement changes the amount gained") {
+        val d = driver()
+        val target = d.putCreatureOnBattlefield(d.player2, "Ghosts of the Innocent")
+        d.cast(target, 3)
+        d.resolve()
+        d.damage(target) shouldBe 1
+        d.getLifeTotal(d.player1) shouldBe 21
+    }
+
+    test("damage replaced with counters is not damage dealt") {
+        val d = driver()
+        val target = d.putCreatureOnBattlefield(d.player2, "Phytohydra")
+        d.cast(target, 3)
+        d.resolve()
+        d.damage(target) shouldBe 0
+        d.getLifeTotal(d.player1) shouldBe 20
+    }
+
+    test("life gain survives multiple damage redirection decisions") {
+        val d = driver()
+        val target = d.putCreatureOnBattlefield(d.player2, "Watchwolf")
+        val other = d.putCreatureOnBattlefield(d.player1, "Centaur Courser")
+        d.giveMana(d.player1, Color.WHITE, 3)
+        d.castSpell(d.player1, d.putCardInHand(d.player1, "Blood of the Martyr")).error shouldBe null
+        d.resolve()
+        d.cast(target, 2)
+        d.bothPass()
+        (d.pendingDecision is YesNoDecision) shouldBe true
+        d.submitYesNo(d.player1, false).error shouldBe null
+        (d.pendingDecision is YesNoDecision) shouldBe true
+        d.submitYesNo(d.player1, true).error shouldBe null
+        if (d.stackSize > 0) d.resolve()
+        d.damage(target) shouldBe 2
+        d.damage(other) shouldBe 0
+        // Two damage is redirected to the caster; all four damage was still dealt by Brightflame.
+        d.getLifeTotal(d.player1) shouldBe 22
+    }
+
+    test("X zero deals no damage and gains no life") {
+        val d = driver()
+        val target = d.putCreatureOnBattlefield(d.player2, "Watchwolf")
+        d.cast(target, 0)
+        d.resolve()
+        d.damage(target) shouldBe 0
+        d.getLifeTotal(d.player1) shouldBe 20
+    }
+
+    test("an illegal sole target prevents all damage and life gain") {
+        val d = driver()
+        val target = d.putCreatureOnBattlefield(d.player2, "Watchwolf")
+        val other = d.putCreatureOnBattlefield(d.player1, "Centaur Courser")
+        d.cast(target, 2)
+        d.moveToGraveyard(target)
+        d.resolve()
+        d.damage(other) shouldBe 0
+        d.getLifeTotal(d.player1) shouldBe 20
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -1410,6 +1410,128 @@
     ]
 }
 
+// Brightflame
+{
+    "name": "Brightflame",
+    "manaCost": "{X}{R}{R}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Radiance — Brightflame deals X damage to target creature and each other creature that shares a color with it. You gain life equal to the damage dealt this way.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "StoreNumber",
+                    "name": "number0",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "DamageDealtThisTurn"
+                    }
+                },
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "SharesColorWith",
+                                    "entity": "Target"
+                                }
+                            ]
+                        },
+                        "excludeChosenTargets": true
+                    },
+                    "storeAs": "gathered1"
+                },
+                {
+                    "type": "DealDamage",
+                    "amount": "XValue",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Collection",
+                        "collection": "gathered1"
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": "XValue",
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Subtract",
+                        "left": {
+                            "type": "EntityProperty",
+                            "entity": "Source",
+                            "numericProperty": "DamageDealtThisTurn"
+                        },
+                        "right": {
+                            "type": "VariableReference",
+                            "variableName": "number0"
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "rarity": "RARE",
+        "artist": "Dave Dorman",
+        "flavorText": "\"Let the pyres of the unbelievers light our way.\"\n—Razia",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9a3acf27-5d07-48e6-8e19-a2e6d4cd49d1.jpg?1783943626",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "You gain life equal to the total damage dealt by Brightflame to all creatures. You don’t gain life for any damage that was prevented."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "All creatures that share a color are affected, even your own."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "A creature “shares a color” with any creature that is at least one of its colors. For example, a green-white creature shares a color with creatures that are green, white, green-white, red-white, black-green, and so on."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "If it targets a colorless creature, it doesn’t affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "You check which creatures share a color with the target when the spell resolves."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "Only one creature is targeted. If that creature leaves the battlefield or otherwise becomes an illegal target, the entire spell doesn’t resolve. No other creatures are affected."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Caregiver
 {
     "name": "Caregiver",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
@@ -54,6 +54,13 @@ internal fun BridgeBuilder.damageLifeAndCards() {
     composed("PreventDamage", "PreventDamageShield (prevent damage to recipient)",
         composes = listOf("PreventDamageShield"))
     composed("GainLifeForEach", "GainLife + DynamicAmount", composes = listOf("GainLife"))
+    // Requires a before/after baseline around the matching damage action. The emitter leaves
+    // this amount unresolved until it can bind that action's scope, rather than using printed X.
+    composed(
+        "TheAmountOfDamageDealtThisWay",
+        "StoreNumber + Subtract(EntityProperty(source, DamageDealtThisTurn), baseline)",
+        composes = listOf("StoreNumber", "EntityProperty", "Subtract")
+    )
     effect("GainLife", "GainLife")
     effect("LoseLife", "LoseLife")
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -491,6 +491,7 @@ val engineSerializersModule = SerializersModule {
         subclass(WasDealtDamageThisTurnComponent::class)
         subclass(DamageUnpreventableThisTurnComponent::class)
         subclass(HasDealtDamageComponent::class)
+        subclass(DamageDealtThisTurnComponent::class)
         subclass(HasBecomeTappedComponent::class)
         subclass(HasDealtCombatDamageToPlayerComponent::class)
         subclass(DealtCombatDamageToPlayersThisTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -1385,6 +1385,11 @@ class DynamicAmountEvaluator(
                 entity.get<CardComponent>()?.manaCost?.coloredSymbolCount(property.colors.toSet()) ?: 0
             }
 
+            is EntityNumericProperty.DamageDealtThisTurn -> state.getEntity(entityId)
+                ?.get<com.wingedsheep.engine.state.components.battlefield.DamageDealtThisTurnComponent>()
+                ?.takeIf { it.turnNumber == state.turnNumber && it.sourceObject == state.objectRef(entityId) }
+                ?.amount ?: 0
+
             // Excess damage (CR 120.4a) marked on the creature: max(0, marked − toughness).
             // Amount-valued twin of the TargetMarkedDamageExceedsToughness condition — read it after
             // a deal-damage step in the same composite (Hell to Pay's "excess damage dealt this

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -33,6 +33,7 @@ import com.wingedsheep.engine.state.components.battlefield.DamageSourceLki
 import com.wingedsheep.engine.state.components.battlefield.DamagedBySourcesThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.DamageUnpreventableThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.HasDealtDamageComponent
+import com.wingedsheep.engine.state.components.battlefield.DamageDealtThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.WasDealtDamageThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
 import com.wingedsheep.engine.state.components.stack.SpellGrantedKeywordsComponent
@@ -518,15 +519,7 @@ object DamageUtils {
             }
         }
 
-        // Mark source as having dealt damage. Sits below every recipient branch (player /
-        // planeswalker / battle / creature, wither included), so one stamp covers all noncombat damage
-        // — the effect executors, fight, and the combat continuation resumer all reach here. The turn
-        // stamp is what `StatePredicate.HasDealtDamage(thisTurnOnly = true)` reads.
-        if (sourceId != null && sourceId in newState.getBattlefield()) {
-            newState = newState.updateEntity(sourceId) { container ->
-                container.with(HasDealtDamageComponent(newState.turnNumber))
-            }
-        }
+        newState = trackDamageDealt(newState, sourceId, effectiveAmount)
         // Record the source on its controller's per-turn set of damage sources. Unlike the stamp
         // above this is not battlefield-only: a resolving burn spell is a source that dealt damage
         // just as much as a creature is (Case of the Burning Masks).
@@ -996,6 +989,25 @@ object DamageUtils {
             container.with(existing.with(counterType, placedByController))
         }
         return newState to first
+    }
+
+    /** Record actual damage for a battlefield source or a resolving spell, bound to its object identity. */
+    fun trackDamageDealt(state: GameState, sourceId: EntityId?, amount: Int): GameState {
+        if (sourceId == null || amount <= 0) return state
+        // An ability can deal damage using a source that has already left. Do not stamp the
+        // new card in its owner's graveyard with the old battlefield object's damage history.
+        val onBattlefield = sourceId in state.getBattlefield()
+        if (!onBattlefield && sourceId !in state.stack) return state
+        val sourceObject = state.objectRef(sourceId) ?: return state
+        return state.updateEntity(sourceId) { container ->
+            val previous = container.get<DamageDealtThisTurnComponent>()
+            val priorAmount = previous?.takeIf {
+                it.turnNumber == state.turnNumber && it.sourceObject == sourceObject
+            }?.amount ?: 0
+            val updated = container.with(DamageDealtThisTurnComponent(state.turnNumber, priorAmount + amount, sourceObject))
+            // Preserve the existing permanent-only lifetime marker's semantics.
+            if (onBattlefield) updated.with(HasDealtDamageComponent(state.turnNumber)) else updated
+        }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -491,6 +491,7 @@ object ZoneMovementUtils {
             .without<DamageDealtToCreaturesThisTurnComponent>()
             .without<WasDealtDamageThisTurnComponent>()
             .without<HasDealtDamageComponent>()
+            .without<com.wingedsheep.engine.state.components.battlefield.DamageDealtThisTurnComponent>()
             // The number chosen as it entered (Nameless Race) belongs to *this* object; one
             // that leaves and returns chooses afresh as it enters (CR 400.7).
             .without<com.wingedsheep.engine.state.components.battlefield.EnteredWithValueComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -15,7 +15,6 @@ import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.DamageComponent
 import com.wingedsheep.engine.state.components.battlefield.DealtCombatDamageToPlayersThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.HasDealtCombatDamageToPlayerComponent
-import com.wingedsheep.engine.state.components.battlefield.HasDealtDamageComponent
 import com.wingedsheep.engine.state.components.battlefield.WasDealtDamageThisTurnComponent
 import com.wingedsheep.engine.state.components.player.WasDealtCombatDamageByLegendaryCreatureThisTurnComponent
 import com.wingedsheep.engine.state.components.player.CombatDamageReceivedThisTurnComponent
@@ -1044,11 +1043,12 @@ internal class CombatDamageManager(
         newState = DamageUtils.trackDamageReceivedByPlayer(newState, targetId, effectiveAmount, sourceId)
 
         // Track combat damage: source dealt damage + dealt combat damage to player
+        newState = DamageUtils.trackDamageDealt(newState, sourceId, effectiveAmount)
         if (sourceId in newState.getBattlefield()) {
             newState = newState.updateEntity(sourceId) { container ->
                 val priorRecipients = container.get<DealtCombatDamageToPlayersThisTurnComponent>()
                     ?.playerIds ?: emptySet()
-                container.with(HasDealtDamageComponent(newState.turnNumber))
+                container
                     .with(HasDealtCombatDamageToPlayerComponent)
                     .with(DealtCombatDamageToPlayersThisTurnComponent(priorRecipients + targetId))
             }
@@ -1157,11 +1157,7 @@ internal class CombatDamageManager(
             }
         }
 
-        if (sourceId in newState.getBattlefield()) {
-            newState = newState.updateEntity(sourceId) { container ->
-                container.with(HasDealtDamageComponent(newState.turnNumber))
-            }
-        }
+        newState = DamageUtils.trackDamageDealt(newState, sourceId, amount)
         // Combat damage counts toward "sources you controlled dealt damage this turn" too.
         newState = DamageUtils.trackDamageSourceForController(newState, sourceId)
         // Planeswalkers (not battles) join the source's "dealt damage to this game" memory, the
@@ -1267,11 +1263,12 @@ internal class CombatDamageManager(
             newState = newState.withLifeTotal(targetId, newLife)
             newState = DamageUtils.trackDamageReceivedByPlayer(newState, targetId, amount, sourceId)
             // Track combat damage: source dealt damage + dealt combat damage to player
+            newState = DamageUtils.trackDamageDealt(newState, sourceId, amount)
             if (sourceId in newState.getBattlefield()) {
                 newState = newState.updateEntity(sourceId) { container ->
                     val priorRecipients = container.get<DealtCombatDamageToPlayersThisTurnComponent>()
                         ?.playerIds ?: emptySet()
-                    container.with(HasDealtDamageComponent(newState.turnNumber))
+                    container
                         .with(HasDealtCombatDamageToPlayerComponent)
                         .with(DealtCombatDamageToPlayersThisTurnComponent(priorRecipients + targetId))
                 }
@@ -1388,11 +1385,7 @@ internal class CombatDamageManager(
                 container.with(WasDealtDamageThisTurnComponent)
             }
             // Track that source dealt damage
-            if (sourceId in newState.getBattlefield()) {
-                newState = newState.updateEntity(sourceId) { container ->
-                    container.with(HasDealtDamageComponent(newState.turnNumber))
-                }
-            }
+            newState = DamageUtils.trackDamageDealt(newState, sourceId, amount)
             // Combat damage counts toward "sources you controlled dealt damage this turn" too.
             newState = DamageUtils.trackDamageSourceForController(newState, sourceId)
             newState = DamageUtils.trackDamageDealtToCreature(newState, sourceId, targetId)
@@ -1462,19 +1455,9 @@ internal class CombatDamageManager(
         val newLife = attackerControllerLife - originalAmount
         var newState = state.withLifeTotal(attackerController, newLife)
         newState = DamageUtils.trackDamageReceivedByPlayer(newState, attackerController, originalAmount, sourceId)
-        // Reflection makes the attacking creature the source of damage dealt to its own controller
-        // (CR 120.1 — the object that deals the damage is its source), so this emits a second
-        // `DamageDealtEvent` for the same creature and stamps it alongside, keeping the invariant
-        // "every damage-dealing path records its source" true function-locally rather than by
-        // inheritance from the caller. Today it is belt-and-braces: the only caller is
-        // `applyDamageToPlayer`, which stamps the same creature under the same battlefield guard
-        // before it gets here, so removing this line changes no current behaviour. It earns its keep
-        // if reflection is ever reached from a path that doesn't stamp first.
-        if (sourceId in newState.getBattlefield()) {
-            newState = newState.updateEntity(sourceId) { container ->
-                container.with(HasDealtDamageComponent(newState.turnNumber))
-            }
-        }
+        // Reflection is an additional damage event from the attacking creature, so it adds
+        // its full amount to the same source's damage history.
+        newState = DamageUtils.trackDamageDealt(newState, sourceId, originalAmount)
         val sourceName = state.getEntity(sourceId)?.get<CardComponent>()?.name ?: "Creature"
         events.add(DamageDealtEvent(sourceId, attackerController, originalAmount, true,
             sourceName = sourceName, targetName = "Player", targetIsPlayer = true))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -1296,6 +1296,14 @@ data object DamageUnpreventableThisTurnComponent : Component
 @Serializable
 data class HasDealtDamageComponent(val lastDealtDamageTurn: Int) : Component
 
+/** Actual damage total, scoped to a turn and object incarnation, including resolving spells. */
+@Serializable
+data class DamageDealtThisTurnComponent(
+    val turnNumber: Int,
+    val amount: Int,
+    val sourceObject: com.wingedsheep.engine.state.ObjectRef
+) : Component
+
 /**
  * The players and planeswalkers this permanent has dealt damage to **this game** — the memory
  * behind The Fallen ("this creature deals 1 damage to each opponent and planeswalker it has dealt

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DamageDealtThisTurnTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DamageDealtThisTurnTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.engineSerializersModule
+import com.wingedsheep.engine.state.Component
+import com.wingedsheep.engine.state.components.battlefield.DamageDealtThisTurnComponent
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class DamageDealtThisTurnTest : FunSpec({
+    fun driver() = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+    fun GameTestDriver.dealt(source: EntityId): Int = DynamicAmountEvaluator().evaluate(
+        state,
+        DynamicAmount.EntityProperty(EntityReference.Source, EntityNumericProperty.DamageDealtThisTurn),
+        EffectContext(sourceId = source, controllerId = player1)
+    )
+
+    test("actual damage accumulates across recipients without mutating the previous state") {
+        val d = driver()
+        val source = d.putCreatureOnBattlefield(d.player1, "Centaur Courser")
+        val victim = d.putCreatureOnBattlefield(d.player2, "Centaur Courser")
+        val before = d.state
+        d.replaceState(DamageUtils.dealDamageToTarget(d.state, victim, 2, source).state)
+        d.replaceState(DamageUtils.dealDamageToTarget(d.state, d.player2, 3, source).state)
+        d.dealt(source) shouldBe 5
+        val json = Json { serializersModule = engineSerializersModule }
+        val tracker: Component = d.state.getEntity(source)!!.get<DamageDealtThisTurnComponent>()!!
+        json.decodeFromString<Component>(json.encodeToString(tracker)) shouldBe tracker
+        val after = d.state
+        d.replaceState(before)
+        d.dealt(source) shouldBe 0
+        d.replaceState(after.copy(turnNumber = after.turnNumber + 1))
+        d.dealt(source) shouldBe 0
+        d.replaceState(DamageUtils.dealDamageToTarget(d.state, d.player2, 1, source).state)
+        d.dealt(source) shouldBe 1
+    }
+
+    test("changing zones clears the object's damage history") {
+        val d = driver()
+        val source = d.putCreatureOnBattlefield(d.player1, "Centaur Courser")
+        d.replaceState(DamageUtils.dealDamageToTarget(d.state, d.player2, 2, source).state)
+        d.dealt(source) shouldBe 2
+        d.moveToGraveyard(source)
+        d.dealt(source) shouldBe 0
+        // A pending ability's departed source must not mark the new card in the graveyard.
+        d.replaceState(DamageUtils.dealDamageToTarget(d.state, d.player2, 1, source).state)
+        d.dealt(source) shouldBe 0
+    }
+
+    test("combat damage contributes to the same total as noncombat damage") {
+        val d = driver()
+        val source = d.putCreatureOnBattlefield(d.player1, "Centaur Courser")
+        d.removeSummoningSickness(source)
+        d.replaceState(DamageUtils.dealDamageToTarget(d.state, d.player2, 1, source).state)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(d.player1, listOf(source), d.player2).error shouldBe null
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareBlockers(d.player2, emptyMap()).error shouldBe null
+        d.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        d.dealt(source) shouldBe 4
+    }
+    test("trample counts damage to the blocker and player exactly once") {
+        val d = driver()
+        val source = d.putCreatureOnBattlefield(d.player1, "Trample Beast")
+        val blocker = d.putCreatureOnBattlefield(d.player2, "Centaur Courser")
+        d.removeSummoningSickness(source)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(d.player1, listOf(source), d.player2).error shouldBe null
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareBlockers(d.player2, mapOf(blocker to listOf(source))).error shouldBe null
+        d.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        d.dealt(source) shouldBe 5
+        d.getLifeTotal(d.player2) shouldBe 18
+    }
+
+})


### PR DESCRIPTION
Brightflame now damages its target and the other creatures sharing its colors, then gains life equal to the damage actually dealt. Prevention, damage replacement, excess damage, colorless targets, and resolution-time redirection are covered.

Adds `EntityNumericProperty.DamageDealtThisTurn`, backed by a separate tracker scoped to the turn and object identity. Brightflame snapshots that value before dealing damage and gains the difference afterward. Combat and noncombat damage use the same accumulator; the existing lifetime damage marker keeps its behavior.

Includes the RAV definition and snapshot, SDK reference, coverage bridge entry, backlog update, and `manual-scenarios/cards/b/brightflame.json`. The card uses the existing X-cost, targeting, and redirection UI. The manual scenario has not been played in the browser.

Validation:
- Full `just test` passes.
- Nine Brightflame scenarios, four damage-tracker tests, and the existing damage-marker regression suite pass.
- Scryfall fields, image URL, and earliest-printing check pass; only Brightflame was added to the snapshot.
- RAV Assay differential: 103 compared, zero divergences. Brightflame is not yet covered by the grammar; the new numeric property is available for a future Assay grammar update.
