### PR TITLE
Add Spawnbroker with dependent trigger targeting

### DIFF
--- a/backlog/sets/ravnica-city-of-guilds/cards.md
+++ b/backlog/sets/ravnica-city-of-guilds/cards.md
@@ -2,11 +2,11 @@
 
 **Set Size:** 291 cards
 **Release Date:** October 7, 2005
-**Implemented:** 273 / 291
+**Implemented:** 274 / 291
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 37    | 33   |
-| Blue       | 39    | 35   |
+| Blue       | 39    | 36   |
 | Black      | 37    | 35   |
 | Red        | 39    | 38   |
 | Green      | 37    | 37   |
@@ -85,7 +85,7 @@
 - [ ] Quickchange
 - [x] Remand
 - [x] Snapping Drake
-- [ ] Spawnbroker
+- [x] Spawnbroker
 - [x] Stasis Cell
 - [x] Surveilling Sprite
 - [x] Tattered Drake

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2117,6 +2117,13 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   the condition fails — so a pump that wears off, a re-tap, or a re-acquired source never
   re-grabs the creature.
 - `ExchangeControlEffect(target1, target2)` — swap control of two permanents.
+  Triggered abilities with mandatory single-permanent target slots may compare a later target to an
+  earlier one using `EntityReference.Target(index)` (Spawnbroker: `powerAtMostEntity(Target(0))`).
+  The engine asks for these targets sequentially, offers only choices that can complete the remaining
+  slots, and rechecks the relationship against projected characteristics at resolution. The optional
+  exchange remains a resolution-time consent choice. This selection path does not support optional
+  or multiple-object slots.
+
 - `GainControlByRankEffect(metric, target?, direction?, tieBreak?)` — rank the players still in the
   game by a `PlayerRankMetric` and hand the target to whoever sits at one end. Three independent
   axes, so a new card in this family usually needs no new effect: **what** is ranked (`metric` —

--- a/e2e-scenarios/tests/rav/spawnbroker.spec.ts
+++ b/e2e-scenarios/tests/rav/spawnbroker.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '../../fixtures/scenarioFixture'
+import { PLAYER_BATTLEFIELD, OPPONENT_BATTLEFIELD, cardByName } from '../../helpers/selectors'
+
+test('Spawnbroker chooses dependent targets and offers the exchange', async ({ createGame }) => {
+  test.setTimeout(120_000)
+  const { player1, player2 } = await createGame({
+    player1: {
+      hand: ['Spawnbroker'],
+      battlefield: [{ name: 'Island' }, { name: 'Island' }, { name: 'Island' }, { name: 'Grizzly Bears' }],
+      library: ['Island', 'Island'],
+    },
+    player2: {
+      battlefield: [{ name: 'Llanowar Elves' }, { name: 'Hill Giant' }],
+      library: ['Forest', 'Forest'],
+    },
+    phase: 'PRECOMBAT_MAIN',
+    activePlayer: 1,
+  })
+  const p1 = player1.gamePage
+  await p1.clickCard('Spawnbroker')
+  await p1.selectAction('Cast')
+  await expect(player1.page.getByText('creature you control', { exact: true })).toBeVisible()
+  await p1.selectTarget('Grizzly Bears')
+  await p1.confirmTargets()
+  await p1.selectTarget('Llanowar Elves')
+  await p1.confirmTargets()
+  // The opponent gets a response window after both targets have been announced.
+  await player2.gamePage.pass()
+  await p1.answerYes()
+  await expect(player1.page.locator(PLAYER_BATTLEFIELD).locator(cardByName('Llanowar Elves'))).toBeVisible()
+  await expect(player1.page.locator(OPPONENT_BATTLEFIELD).locator(cardByName('Grizzly Bears'))).toBeVisible()
+  await expect(player2.page.locator(PLAYER_BATTLEFIELD).locator(cardByName('Grizzly Bears'))).toBeVisible()
+})

--- a/manual-scenarios/cards/s/spawnbroker.json
+++ b/manual-scenarios/cards/s/spawnbroker.json
@@ -1,0 +1,55 @@
+{
+  "player1Name": "Spawnbroker",
+  "player2Name": "Trading partner",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Spawnbroker",
+      "Giant Growth"
+    ],
+    "battlefield": [
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Grizzly Bears"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Island",
+      "Island",
+      "Island"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {
+        "name": "Llanowar Elves"
+      },
+      {
+        "name": "Hill Giant"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Spawnbroker.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Spawnbroker.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+val Spawnbroker = card("Spawnbroker") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature enters, you may exchange control of target creature you control and target creature with power less than or equal to that creature's power an opponent controls."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        description = "You may exchange control of the two targeted creatures."
+        val yours = target("creature you control", Targets.CreatureYouControl)
+        val theirs = target(
+            "opponent's creature with power no greater than your chosen creature",
+            TargetCreature(filter = Targets.Unified.creature {
+                opponentControls().powerAtMostEntity(EntityReference.Target(0))
+            })
+        )
+        effect = Effects.ExchangeControl(yours, theirs)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "65"
+        artist = "Wayne England"
+        flavorText = "\"The trick isn't setting up the bad trade. It's making each side think it got the better deal.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ce1e4aa6-b06d-4b87-9912-a4c403e8d7c6.jpg?1783943680"
+        ruling("2005-10-01", "If either target becomes illegal (say, if a creature’s power has changed such that the creature you control now has less power than the other creature), then the exchange won’t happen.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SpawnbrokerScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SpawnbrokerScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.Spawnbroker
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+
+class SpawnbrokerScenarioTest : FunSpec({
+    val cards = TestCards.all + Spawnbroker
+    fun driver(): GameTestDriver = GameTestDriver().also {
+        it.registerCards(cards)
+        it.initMirrorMatch(Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        it.passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+    fun GameTestDriver.castBroker(): EntityId {
+        val card = putCardInHand(player1, "Spawnbroker")
+        giveMana(player1, Color.BLUE, 3)
+        castSpell(player1, card).error shouldBe null
+        bothPass().error shouldBe null
+        state.pendingDecision shouldNotBe null
+        return card
+    }
+    fun GameTestDriver.legalTargets(): List<EntityId> =
+        (state.pendingDecision as ChooseTargetsDecision).legalTargets.values.flatten()
+    fun GameTestDriver.resolveExchange(accept: Boolean = true) {
+        bothPass().error shouldBe null
+        (state.pendingDecision is YesNoDecision) shouldBe true
+        submitYesNo(player1, accept).error shouldBe null
+    }
+    fun GameTestDriver.controller(id: EntityId) = state.projectedState.getController(id)
+
+    test("equal power can be exchanged and choices are restricted by the first target") {
+        val d = driver()
+        val yours = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        val theirs = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        val larger = d.putCreatureOnBattlefield(d.player2, "Hill Giant")
+        val broker = d.castBroker()
+        d.legalTargets() shouldContain yours
+        d.legalTargets() shouldNotContain broker
+        d.submitTargetSelection(d.player1, listOf(yours)).error shouldBe null
+        d.legalTargets() shouldBe listOf(theirs)
+        d.submitTargetSelection(d.player1, listOf(larger)).isSuccess shouldBe false
+        d.submitTargetSelection(d.player1, listOf(theirs)).error shouldBe null
+        d.resolveExchange()
+        d.controller(yours) shouldBe d.player2
+        d.controller(theirs) shouldBe d.player1
+    }
+
+    test("the exchange may be declined after choosing both targets") {
+        val d = driver()
+        val theirs = d.putCreatureOnBattlefield(d.player2, "Llanowar Elves")
+        val broker = d.castBroker()
+        d.submitTargetSelection(d.player1, listOf(broker)).error shouldBe null
+        d.submitTargetSelection(d.player1, listOf(theirs)).error shouldBe null
+        d.resolveExchange(accept = false)
+        d.controller(broker) shouldBe d.player1
+        d.controller(theirs) shouldBe d.player2
+    }
+
+    test("a power increase in response prevents the whole exchange") {
+        val d = driver()
+        val yours = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        val theirs = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        d.castBroker()
+        d.submitTargetSelection(d.player1, listOf(yours)).error shouldBe null
+        d.submitTargetSelection(d.player1, listOf(theirs)).error shouldBe null
+        val growth = d.putCardInHand(d.player1, "Giant Growth")
+        d.giveMana(d.player1, Color.GREEN)
+        d.castSpell(d.player1, growth, listOf(theirs)).error shouldBe null
+        d.bothPass().error shouldBe null
+        // One target remains legal, so the optional effect still resolves, but cannot exchange.
+        d.resolveExchange()
+        d.controller(yours) shouldBe d.player1
+        d.controller(theirs) shouldBe d.player2
+    }
+
+    test("a projected power bonus qualifies a creature while choosing targets") {
+        val d = driver()
+        val yours = d.putCreatureOnBattlefield(d.player1, "Llanowar Elves")
+        val growth = d.putCardInHand(d.player1, "Giant Growth")
+        d.giveMana(d.player1, Color.GREEN)
+        d.castSpell(d.player1, growth, listOf(yours)).error shouldBe null
+        d.bothPass().error shouldBe null
+        val theirs = d.putCreatureOnBattlefield(d.player2, "Hill Giant")
+        d.castBroker()
+        d.legalTargets() shouldContain yours
+        d.submitTargetSelection(d.player1, listOf(yours)).error shouldBe null
+        d.legalTargets() shouldContain theirs
+        d.submitTargetSelection(d.player1, listOf(theirs)).error shouldBe null
+        d.resolveExchange()
+        d.controller(yours) shouldBe d.player2
+        d.controller(theirs) shouldBe d.player1
+    }
+
+    test("removing either target prevents the exchange without failing resolution") {
+        for (removeYours in listOf(true, false)) {
+            val d = driver()
+            val yours = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+            val theirs = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+            d.castBroker()
+            d.submitTargetSelection(d.player1, listOf(yours)).error shouldBe null
+            d.submitTargetSelection(d.player1, listOf(theirs)).error shouldBe null
+            val bounce = d.putCardInHand(d.player1, "Unsummon")
+            d.giveMana(d.player1, Color.BLUE)
+            d.castSpell(d.player1, bounce, listOf(if (removeYours) yours else theirs)).error shouldBe null
+            d.bothPass().error shouldBe null
+            d.resolveExchange()
+            d.controller(if (removeYours) theirs else yours) shouldBe if (removeYours) d.player2 else d.player1
+            d.state.stack shouldBe emptyList()
+        }
+    }
+
+    test("the exchange survives its source leaving when both targets remain legal") {
+        val d = driver()
+        val yours = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        val theirs = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        val broker = d.castBroker()
+        d.submitTargetSelection(d.player1, listOf(yours)).error shouldBe null
+        d.submitTargetSelection(d.player1, listOf(theirs)).error shouldBe null
+        val bounce = d.putCardInHand(d.player1, "Unsummon")
+        d.giveMana(d.player1, Color.BLUE)
+        d.castSpell(d.player1, bounce, listOf(broker)).error shouldBe null
+        d.bothPass().error shouldBe null
+        d.resolveExchange()
+        d.controller(yours) shouldBe d.player2
+        d.controller(theirs) shouldBe d.player1
+    }
+
+    test("no trigger is put on the stack if no legal pair exists") {
+        val d = driver()
+        d.putCreatureOnBattlefield(d.player2, "Hill Giant")
+        val card = d.putCardInHand(d.player1, "Spawnbroker")
+        d.giveMana(d.player1, Color.BLUE, 3)
+        d.castSpell(d.player1, card).error shouldBe null
+        d.bothPass().error shouldBe null
+        d.state.pendingDecision shouldBe null
+        d.state.stack shouldBe emptyList()
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -13216,6 +13216,87 @@
     ]
 }
 
+// Spawnbroker
+{
+    "name": "Spawnbroker",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "When this creature enters, you may exchange control of target creature you control and target creature with power less than or equal to that creature's power an opponent controls.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ExchangeControl",
+                        "target1": {
+                            "type": "BoundVariable",
+                            "name": "creature you control"
+                        },
+                        "target2": {
+                            "type": "BoundVariable",
+                            "name": "opponent's creature with power no greater than your chosen creature"
+                        }
+                    },
+                    "descriptionOverride": "You may exchange control of the two targeted creatures."
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "creature you control"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "PowerAtMostEntity",
+                                        "reference": "Target"
+                                    }
+                                ],
+                                "controllerPredicate": "ControlledByOpponent"
+                            }
+                        },
+                        "id": "opponent's creature with power no greater than your chosen creature"
+                    }
+                ],
+                "descriptionOverride": "You may exchange control of the two targeted creatures."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "RARE",
+        "artist": "Wayne England",
+        "flavorText": "\"The trick isn't setting up the bad trade. It's making each side think it got the better deal.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce1e4aa6-b06d-4b87-9912-a4c403e8d7c6.jpg?1783943680",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "If either target becomes illegal (say, if a creature’s power has changed such that the creature you control now has less power than the other creature), then the exchange won’t happen."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Stasis Cell
 {
     "name": "Stasis Cell",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -59,6 +59,8 @@ data class TriggeredAbilityContinuation(
     val triggeringPlayerId: EntityId? = null,
     val elseEffect: Effect? = null,
     val targetRequirements: List<TargetRequirement> = emptyList(),
+    /** Non-null while dependent targets are being chosen, one requirement at a time. */
+    val sequentialTargets: List<EntityId>? = null,
     val triggerCounterCount: Int? = null,
     val triggerTotalCounterCount: Int? = null,
     val triggerLastKnownCounters: Map<String, Int>? = null,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.event
 
+import com.wingedsheep.engine.handlers.DependentTargetSelection
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.TargetFinder
@@ -328,6 +329,12 @@ class TriggerProcessor(
 
         val targetRequirement = ability.targetRequirement
 
+        // Dependent target slots must be announced together before the ability goes on the
+        // stack. Preserve any consent gate for resolution, after opponents can respond.
+        if (targetRequirement != null && DependentTargetSelection.isRequired(ability.allTargetRequirements)) {
+            return processTargetedTrigger(currentState, trigger, targetRequirement)
+        }
+
         // If the effect is a MayPayManaEffect AND has targets, ask payment first, then targets.
         // This reverses the old flow where targets were chosen before the pay question.
         if (targetRequirement != null && ability.effect.asOptionalManaPayment() != null) {
@@ -627,10 +634,27 @@ class TriggerProcessor(
         // the ability triggers. Only TargetObject carries dynamicMaxCount today.
         val allRequirements = ability.allTargetRequirements.map { snapshotDynamicCount(state, trigger, it) }
 
+        val sequential = DependentTargetSelection.isRequired(allRequirements)
+        val targetingContext = com.wingedsheep.engine.handlers.PredicateContext(
+            controllerId = trigger.controllerId,
+            sourceId = trigger.sourceId,
+            triggeringEntityId = trigger.triggerContext.triggeringEntityId,
+            triggeringPlayerId = trigger.triggerContext.triggeringPlayerId,
+            xValue = trigger.triggerContext.xValue,
+            storedCollections = trigger.carriedPipeline?.storedCollections ?: emptyMap(),
+            chosenValues = trigger.carriedPipeline?.chosenValues ?: emptyMap(),
+            storedStringLists = trigger.carriedPipeline?.storedStringLists ?: emptyMap(),
+            storedSubtypeGroups = trigger.carriedPipeline?.storedSubtypeGroups ?: emptyMap(),
+        )
+        val visibleRequirements = if (sequential) allRequirements.take(1) else allRequirements
         // Find legal targets for each requirement
         val allLegalTargets = mutableMapOf<Int, List<EntityId>>()
-        for ((index, req) in allRequirements.withIndex()) {
-            val legalTargets = targetFinder.findLegalTargets(
+        for ((index, req) in visibleRequirements.withIndex()) {
+            val legalTargets = if (sequential) {
+                DependentTargetSelection.legalNext(
+                    state, allRequirements, emptyList(), targetingContext
+                )
+            } else targetFinder.findLegalTargets(
                 state = state,
                 requirement = req,
                 controllerId = trigger.controllerId,
@@ -639,25 +663,14 @@ class TriggerProcessor(
                 // Carry the triggering player so "target … that player controls" filters
                 // (ControllerPredicate.ControlledByReferencedPlayer over Player.TriggeringPlayer)
                 // resolve at legality time — Fear of Burning Alive's delirium payoff.
-                pipelineContext = com.wingedsheep.engine.handlers.PredicateContext(
-                    controllerId = trigger.controllerId,
-                    triggeringEntityId = trigger.triggerContext.triggeringEntityId,
-                    triggeringPlayerId = trigger.triggerContext.triggeringPlayerId,
-                    // See the note on the other findLegalTargets call sites: an X-relative target
-                    // filter needs the triggering event's X bound to match anything.
-                    xValue = trigger.triggerContext.xValue,
-                    storedCollections = trigger.carriedPipeline?.storedCollections ?: emptyMap(),
-                    chosenValues = trigger.carriedPipeline?.chosenValues ?: emptyMap(),
-                    storedStringLists = trigger.carriedPipeline?.storedStringLists ?: emptyMap(),
-                    storedSubtypeGroups = trigger.carriedPipeline?.storedSubtypeGroups ?: emptyMap(),
-                ),
+                pipelineContext = targetingContext,
             )
             allLegalTargets[index] = legalTargets
         }
 
         // If no legal targets exist for any required requirement, the ability is not put on the stack
         // (Rule 603.3d). This applies regardless of whether the ability is optional ("you may").
-        for ((index, req) in allRequirements.withIndex()) {
+        for ((index, req) in visibleRequirements.withIndex()) {
             val legalTargets = allLegalTargets[index] ?: emptyList()
             if (legalTargets.isEmpty() && req.effectiveMinCount > 0) {
                 // The else branch is in one of two places, and both are the same printed clause.
@@ -720,7 +733,7 @@ class TriggerProcessor(
         // from the stack when there is no legal one (the loop above) rather than resolve targetless.
         // Consent is now a gate on the effect, answered on its own — either before this method runs
         // (`processMayThenTargetTrigger`) or as the ability resolves.
-        val requirementInfos = allRequirements.mapIndexed { index, req ->
+        val requirementInfos = visibleRequirements.mapIndexed { index, req ->
             // "Any number of target ..." (unlimited) caps at however many legal targets exist,
             // mirroring the cast-time path (TargetEnumerationUtils). Using req.count (always 1
             // for an unlimited requirement) would wrongly clamp the decision to a single target.
@@ -805,6 +818,7 @@ class TriggerProcessor(
                 triggeringPlayerId = trigger.triggerContext.triggeringPlayerId,
                 elseEffect = ability.elseEffect,
                 targetRequirements = allRequirements,
+                sequentialTargets = if (sequential) emptyList() else null,
                 triggerCounterCount = trigger.triggerContext.counterCount,
                 triggerTotalCounterCount = trigger.triggerContext.totalCounterCount,
                 triggerLastKnownCounters = trigger.triggerContext.lastKnownCounters,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DependentTargetSelection.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DependentTargetSelection.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.handlers
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.targets.TargetRequirement
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/** Select mandatory single-object targets in order when a filter reads an earlier target. */
+object DependentTargetSelection {
+    fun isRequired(requirements: List<TargetRequirement>): Boolean = requirements.any {
+        it is TargetObject && referencesTarget(it.filter.baseFilter)
+    }
+
+    private fun referencesTarget(filter: GameObjectFilter): Boolean =
+        filter.cardPredicates.any(::referencesTarget) || filter.anyOf.any(::referencesTarget)
+
+    private fun referencesTarget(predicate: CardPredicate): Boolean = when (predicate) {
+        is CardPredicate.And -> predicate.predicates.any(::referencesTarget)
+        is CardPredicate.Or -> predicate.predicates.any(::referencesTarget)
+        is CardPredicate.Not -> referencesTarget(predicate.predicate)
+        else -> (when (predicate) {
+            is CardPredicate.PowerAtMostEntity -> predicate.reference
+            is CardPredicate.PowerLessThanEntity -> predicate.reference
+            is CardPredicate.PowerGreaterThanEntity -> predicate.reference
+            is CardPredicate.ManaValueAtMostEntity -> predicate.reference
+            is CardPredicate.SharesColorWith -> predicate.entity
+            is CardPredicate.SharesCardTypeWith -> predicate.entity
+            is CardPredicate.SharesCreatureTypeWith -> predicate.entity
+            is CardPredicate.SharesManaValueWith -> predicate.entity
+            is CardPredicate.SharesNameWith -> predicate.entity
+            else -> null
+        }) is EntityReference.Target
+    }
+
+    /**
+     * Exclude choices that cannot complete the remaining requirements. Search stops at the first
+     * completion; no Cartesian product is allocated. Ordinary independent targets never use this path.
+     * No priority passes between these decisions, so the prefix remains on the same battlefield.
+     */
+    fun legalNext(
+        state: GameState,
+        requirements: List<TargetRequirement>,
+        chosen: List<EntityId>,
+        context: PredicateContext,
+    ): List<EntityId> {
+        require(requirements.all { it is TargetObject && it.filter.zone == Zone.BATTLEFIELD &&
+            it.count == 1 && it.effectiveMinCount == 1 && !it.unlimited }) {
+            "Dependent target selection requires mandatory single-permanent target slots"
+        }
+        val finder = TargetFinder()
+        fun candidates(prefix: List<EntityId>): List<EntityId> = finder.findLegalTargets(
+            state, requirements[prefix.size], context.controllerId,
+            sourceId = context.sourceId,
+            targetingSourceType = TargetingSourceType.ABILITY,
+            triggeringEntityId = context.triggeringEntityId,
+            pipelineContext = context.copy(targets = prefix.map { ChosenTarget.Permanent(it) }),
+        )
+        fun canComplete(prefix: List<EntityId>): Boolean =
+            prefix.size == requirements.size || candidates(prefix).any { canComplete(prefix + it) }
+        return candidates(chosen).filter { canComplete(chosen + it) }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -53,6 +53,46 @@ class EffectAndTriggerContinuationResumer(
             return ExecutionResult.error(state, "Expected target selection response for triggered ability")
         }
 
+        continuation.sequentialTargets?.let { prefix ->
+            val selected = response.selectedTargets[0]?.singleOrNull()
+                ?: return ExecutionResult.error(state, "Choose one target")
+            val chosen = prefix + selected
+            if (chosen.size < continuation.targetRequirements.size) {
+                val pipeline = continuation.carriedPipeline
+                val context = com.wingedsheep.engine.handlers.PredicateContext(
+                    controllerId = continuation.controllerId,
+                    sourceId = continuation.sourceId,
+                    triggeringEntityId = continuation.triggeringEntityId,
+                    triggeringPlayerId = continuation.triggeringPlayerId,
+                    xValue = continuation.xValue,
+                    storedCollections = pipeline?.storedCollections ?: emptyMap(),
+                    chosenValues = pipeline?.chosenValues ?: emptyMap(),
+                    storedStringLists = pipeline?.storedStringLists ?: emptyMap(),
+                    storedSubtypeGroups = pipeline?.storedSubtypeGroups ?: emptyMap(),
+                )
+                val legal = com.wingedsheep.engine.handlers.DependentTargetSelection.legalNext(
+                    state, continuation.targetRequirements, chosen, context
+                )
+                return com.wingedsheep.engine.handlers.DecisionHandler().createTargetDecision(
+                    state, continuation.controllerId, continuation.sourceId, continuation.sourceName,
+                    requirements = listOf(TargetRequirementInfo(
+                        index = 0,
+                        description = continuation.targetRequirements[chosen.size].description,
+                        minTargets = 1,
+                        maxTargets = 1,
+                    )),
+                    legalTargets = mapOf(0 to legal),
+                    effectHint = continuation.description,
+                    answer = continuation.copy(sequentialTargets = chosen),
+                )
+            }
+            return resumeTriggeredAbility(
+                state, continuation.copy(sequentialTargets = null),
+                response.copy(selectedTargets = chosen.mapIndexed { index, id -> index to listOf(id) }.toMap()),
+                checkForMore,
+            )
+        }
+
         // Build the chosen-targets list in requirement-slot order, keeping it PARALLEL to the
         // requirements that actually received a target. A declined "up to one" slot (empty list)
         // drops out of BOTH lists together, so a later target never shifts forward into an earlier

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2671,7 +2671,7 @@ class StackResolver(
         // targets it carries are the stored ones — legality is 608.2b's business, not the context's.
         val resolvedTargets2 = targetsComponent?.targets ?: emptyList()
         val targetReqs = targetsComponent?.targetRequirements ?: emptyList()
-        val context = EffectContext.forTriggeredAbility(
+        var context = EffectContext.forTriggeredAbility(
             abilityComponent,
             targets = resolvedTargets2,
             targetRequirements = targetReqs
@@ -2736,6 +2736,15 @@ class StackResolver(
                     )
                 )
             }
+            val aligned = buildAlignedValidated(targetsComponent.targets, validTargets)
+            context = context.copy(
+                targets = validTargets,
+                alignedTargets = aligned,
+                pipeline = context.pipeline.copy(
+                    namedTargets = EffectContext.buildNamedTargets(targetReqs, aligned) +
+                        (abilityComponent.carriedPipeline?.namedTargets ?: emptyMap()),
+                ),
+            )
         }
 
         // Execute the effect
@@ -3404,6 +3413,7 @@ class StackResolver(
             triggeringEntityId = triggeringEntityId,
             triggeringPlayerId = triggeringPlayerId,
             storedCollections = storedCollections,
+            targets = targets,
         )
 
         return targets.filterIndexed { index, target ->

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DependentTargetSelectionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DependentTargetSelectionTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.DependentTargetSelection
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.EntityReference
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class DependentTargetSelectionTest : FunSpec({
+    val cards = TestCards.all
+    fun driver() = GameTestDriver().also {
+        it.registerCards(cards)
+        it.initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true)
+    }
+
+    test("a paused dependent selection preserves its chosen prefix through serialization") {
+        val d = driver()
+        val chosen = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        val frame = com.wingedsheep.engine.core.TriggeredAbilityContinuation(
+            sourceId = chosen,
+            sourceName = "Test source",
+            controllerId = d.player1,
+            effect = com.wingedsheep.sdk.dsl.Effects.DrawCards(1),
+            description = "Test dependent targets",
+            sequentialTargets = listOf(chosen),
+        )
+        val json = kotlinx.serialization.json.Json {
+            serializersModule = com.wingedsheep.engine.core.engineSerializersModule
+            allowStructuredMapKeys = true
+        }
+        val serializer = com.wingedsheep.engine.core.TriggeredAbilityContinuation.serializer()
+        json.decodeFromString(serializer, json.encodeToString(serializer, frame)) shouldBe frame
+    }
+
+    test("a color-relative filter offers only first choices with a compatible partner") {
+        val d = driver()
+        val green = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        d.putCreatureOnBattlefield(d.player1, "Hill Giant")
+        val partner = d.putCreatureOnBattlefield(d.player2, "Llanowar Elves")
+        val requirements = listOf(
+            TargetCreature(filter = TargetFilter.CreatureYouControl),
+            TargetCreature(filter = TargetFilter(com.wingedsheep.sdk.scripting.GameObjectFilter.Creature.opponentControls().sharingColorWith(EntityReference.Target(0)))),
+        )
+        val context = PredicateContext(controllerId = d.player1)
+        DependentTargetSelection.isRequired(requirements) shouldBe true
+        DependentTargetSelection.legalNext(d.state, requirements, emptyList(), context) shouldBe listOf(green)
+        DependentTargetSelection.legalNext(d.state, requirements, listOf(green), context) shouldBe listOf(partner)
+    }
+
+    test("lookahead checks all remaining slots rather than only the next slot") {
+        val d = driver()
+        val small = d.putCreatureOnBattlefield(d.player1, "Llanowar Elves")
+        val large = d.putCreatureOnBattlefield(d.player1, "Hill Giant")
+        val middle = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        val requirements = listOf(
+            TargetCreature(filter = TargetFilter.CreatureYouControl),
+            TargetCreature(filter = TargetFilter.CreatureOpponentControls.powerLessThanEntity(EntityReference.Target(0))),
+            TargetCreature(filter = TargetFilter.CreatureYouControl.powerLessThanEntity(EntityReference.Target(1))),
+        )
+        val context = PredicateContext(controllerId = d.player1)
+        DependentTargetSelection.legalNext(d.state, requirements, emptyList(), context) shouldBe listOf(large)
+        DependentTargetSelection.legalNext(d.state, requirements, listOf(large), context) shouldBe listOf(middle)
+        DependentTargetSelection.legalNext(d.state, requirements, listOf(large, middle), context) shouldBe listOf(small)
+    }
+})


### PR DESCRIPTION
Add Spawnbroker to Ravnica: City of Guilds, with sequential target selection: choose your creature, then an opposing creature whose projected power is no greater. The exchange remains optional on resolution and fails completely if either target becomes illegal.

- Add reusable support for mandatory single-permanent trigger targets whose filters reference earlier targets, including lookahead that excludes choices with no legal completion.
- Preserve only validated targets when resolving triggered abilities, keeping positional and named target references aligned.
- Add the card, its Scryfall ruling, a manual scenario, scenario and engine tests, a browser test, and the Ravnica backlog/snapshot updates.

Validation:
- Seven Spawnbroker scenarios pass: equality, projected power, invalid responses, decline, power changes in response, either target leaving, source leaving, and no legal pair.
- Three generic targeting tests pass, covering color relationships, three-slot lookahead, and continuation serialization.
- Card snapshot update changes only Spawnbroker; canonical-printing and Scryfall field/image checks pass.
- Assay RAV differential: 103 compared, zero divergences. Spawnbroker is declined by the current grammar; no new SDK type or emitter mapping was introduced.
- Full `just test` gate passes (17,003 tests in the reports, zero failures/errors; 24 skipped).
- Browser scenario passes against the isolated server/client, verifying both target selections, the opponent response window, optional exchange, and changed control from both seats.

The initial baseline build hit an unrelated FreeForAllLobbyTest timeout in “an AI seated in a premade-decks pod is dealt a deck, the way a quick game rolls one” (expected 4 players, got null). The final full test run passes that same test. No lobby code is changed here.
