### PR TITLE
Add Twinning Glass with spell-face selection support

### DIFF
--- a/backlog/sets/lorwyn/cards.md
+++ b/backlog/sets/lorwyn/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 cards
 **Release Date:** October 12, 2007
-**Implemented:** 279 / 286
+**Implemented:** 280 / 286
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 49    | 43   |
@@ -294,7 +294,7 @@
 - [x] Springleaf Drum
 - [x] Thorn of Amethyst
 - [x] Thousand-Year Elixir
-- [ ] Twinning Glass
+- [x] Twinning Glass
 - [x] Wanderer's Twig
 
 ### Land

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5085,6 +5085,26 @@ fall back to base data). Use `projected.isCreature(entityId)` rather than `cardC
 
 ---
 
+### Cast-name history filters
+
+`GameObjectFilter.sharesNameWithSpellCastThisTurn()` adds
+`StatePredicate.SharesNameWithSpellCastThisTurn`: the candidate shares at least one name with a spell
+cast by any player this turn. Reads cast-time history, so resolution, countering, and later zone changes
+do not erase eligibility; nameless and face-down spells never match. History resets on turn change.
+Used by **Twinning Glass**, composing hand gathering, an optional `SelectionMode.ChooseSpell` selection, and
+`Effects.CastFromCollectionWithoutPayingCost` for a cast during ability resolution.
+
+`SelectionMode.ChooseSpell` selects zero or one spell from a collection. Unlike a card selection, its
+filter tests each castable face separately: a matching Adventure, Omen, split half, or modal back face
+can qualify without the primary face qualifying. Preparation spells are excluded. The ordinary card
+picker chooses the physical card; if several faces qualify, the existing option picker chooses the
+spell name. The selection carries its face alongside the selected collection through continuations;
+`CastFromCollectionWithoutPayingCost` consumes that choice for targeting, permission, and casting.
+Spell eligibility uses the face filter; card-selection budget restrictions and the legacy
+`matchChosenCreatureType` flag are rejected in this mode. Declining creates no cast permission. The normal cast handler still enforces targets and additional
+costs, and records the chosen face's name in turn history.
+
+
 ## 8. Triggered abilities (`Triggers.*`)
 
 `triggeredAbility { trigger; effect; target?; triggerZone?/triggerZones?; interveningIf?; triggerRestriction?; optional?; elseEffect?; checkOnNextState?; dealsDamageBeforeResolve?; controlledByTriggeringEntityController?; oncePerTurn?; effectOncePerTurn?; triggersOnce? }`.

--- a/e2e-scenarios/tests/lorwyn/twinning-glass.spec.ts
+++ b/e2e-scenarios/tests/lorwyn/twinning-glass.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '../../fixtures/scenarioFixture'
+import { PLAYER_BATTLEFIELD, cardByName } from '../../helpers/selectors'
+
+test('Twinning Glass offers both matching spell faces and casts the chosen creature on the opponent turn', async ({ createGame }) => {
+  test.setTimeout(90_000)
+  const { player1, player2 } = await createGame({
+    player1: {
+      hand: ['Mosswood Dreadknight', 'Island'],
+      battlefield: [{ name: 'Twinning Glass' }, { name: 'Mountain' }],
+      library: ['Island', 'Island', 'Island'],
+    },
+    player2: {
+      hand: ['Mosswood Dreadknight', 'Mosswood Dreadknight'],
+      battlefield: ['Forest', 'Swamp', 'Swamp', 'Swamp'].map(name => ({ name })),
+      library: ['Island', 'Island', 'Island'],
+    },
+    phase: 'PRECOMBAT_MAIN',
+    activePlayer: 2,
+    priorityPlayer: 2,
+  })
+  const p1 = player1.gamePage
+  const p2 = player2.gamePage
+
+  await p2.selectCardInHand('Mosswood Dreadknight')
+  await p2.selectAction('Cast Mosswood Dreadknight')
+  await expect(player1.page.getByText('Mosswood Dreadknight', { exact: true }).first()).toBeVisible()
+  await p1.pass()
+  await p2.expectOnBattlefield('Mosswood Dreadknight')
+  await p2.selectCardInHand('Mosswood Dreadknight')
+  await p2.selectAction('Cast Dread Whispers')
+  await expect(player1.page.getByText('Dread Whispers', { exact: true }).first()).toBeVisible()
+  await p1.pass()
+  await p2.expectLifeTotal(player2.playerId, 19)
+  await p2.pass()
+
+  await p1.clickCard('Twinning Glass')
+  await p1.selectAction('Cast a spell with a name already cast this turn for free')
+  await p2.resolveStack('Twinning Glass ability')
+  await p1.selectCardInDecision('Mosswood Dreadknight')
+  await p1.confirmSelection()
+  await expect(player1.page.getByRole('button', { name: /^Mosswood Dreadknight \(1\)$/ })).toBeVisible()
+  await expect(player1.page.getByRole('button', { name: /^Dread Whispers \(1\)$/ })).toBeVisible()
+  await p1.screenshot('Both previously cast spell names are offered')
+  await p1.selectOption('Mosswood Dreadknight')
+  await expect(player1.page.locator(PLAYER_BATTLEFIELD).locator(cardByName('Mosswood Dreadknight'))).toBeVisible()
+  await p1.expectHandSize(1)
+  await p1.expectTapped('Twinning Glass')
+  await p1.screenshot('Creature cast for free during the opponent turn')
+})

--- a/manual-scenarios/cards/t/twinning-glass.json
+++ b/manual-scenarios/cards/t/twinning-glass.json
@@ -1,0 +1,48 @@
+{
+  "player1Name": "Glass player",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Lightning Bolt",
+      "Lightning Bolt",
+      "Grizzly Bears",
+      "Island"
+    ],
+    "battlefield": [
+      {
+        "name": "Twinning Glass"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Mountain",
+      "Mountain",
+      "Mountain"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": [
+      "Island",
+      "Island",
+      "Island"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -441,6 +441,13 @@ sealed interface CardDestination {
 sealed interface SelectionMode {
     val description: String
 
+    /** Choose at most one spell, testing the filter against the face that will be cast. */
+    @SerialName("ChooseSpell")
+    @Serializable
+    data object ChooseSpell : SelectionMode {
+        override val description: String = "choose up to one spell"
+    }
+
     /**
      * Player must choose exactly N cards.
      *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -949,6 +949,11 @@ data class GameObjectFilter(
         statePredicates = statePredicates + StatePredicate.WasDealtDamageThisTurn
     )
 
+    /** Matches names recorded when a spell was cast this turn, regardless of its caster or current zone. */
+    fun sharesNameWithSpellCastThisTurn() = copy(
+        statePredicates = statePredicates + StatePredicate.SharesNameWithSpellCastThisTurn
+    )
+
     /**
      * Must have **dealt** damage this turn — the active voice, and the mirror of
      * [wasDealtDamageThisTurn]. Combat and noncombat damage both count, to any recipient. Used by

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -360,6 +360,13 @@ sealed interface StatePredicate {
     // Damage History (History)
     // =============================================================================
 
+    /** Shares a name with a spell cast by any player during the current turn. */
+    @SerialName("SharesNameWithSpellCastThisTurn")
+    @Serializable
+    data object SharesNameWithSpellCastThisTurn : History {
+        override val description: String = "with the same name as a spell cast this turn"
+    }
+
     /** Has been dealt damage this turn */
     @SerialName("WasDealtDamageThisTurn")
     @Serializable

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/SpellNameHistorySerializationTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/SpellNameHistorySerializationTest.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.sdk.serialization
+
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class SpellNameHistorySerializationTest : FunSpec({
+    test("spell selection mode round-trips") {
+        val mode: com.wingedsheep.sdk.scripting.effects.SelectionMode = com.wingedsheep.sdk.scripting.effects.SelectionMode.ChooseSpell
+        val json = CardSerialization.json
+        val serializer = com.wingedsheep.sdk.scripting.effects.SelectionMode.serializer()
+        json.decodeFromString(serializer, json.encodeToString(serializer, mode)) shouldBe mode
+    }
+    test("cast-name history composes with a nonland filter and round-trips") {
+        val filter = GameObjectFilter.Nonland.sharesNameWithSpellCastThisTurn()
+        val encoded = CardSerialization.json.encodeToString(GameObjectFilter.serializer(), filter)
+        CardSerialization.json.decodeFromString(GameObjectFilter.serializer(), encoded) shouldBe filter
+    }
+})

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/TwinningGlass.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/TwinningGlass.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+
+val TwinningGlass = card("Twinning Glass") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{1}, {T}: You may cast a spell from your hand without paying its mana cost if it has the same name as a spell that was cast this turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Effects.Composite(
+            GatherCardsEffect(CardSource.FromZone(Zone.HAND, Player.You), "hand"),
+            SelectFromCollectionEffect(
+                from = "hand",
+                selection = SelectionMode.ChooseSpell,
+                filter = GameObjectFilter.Nonland.sharesNameWithSpellCastThisTurn(),
+                storeSelected = "spellToCast",
+                showAllCards = true,
+                prompt = "You may cast a spell with the same name as a spell cast this turn",
+                selectedLabel = "Cast for free"
+            ),
+            Effects.CastFromCollectionWithoutPayingCost("spellToCast")
+        )
+        description = "{1}, {T}: Cast a spell with a name already cast this turn for free"
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "264"
+        artist = "Franz Vohwinkel"
+        flavorText = "It takes two to craft a mirror: a practiced metalsmith to silver one side and her own hazy reflection to polish the other."
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0138c42-77ea-45f0-b2ca-cda03f3f50d1.jpg?1783942850"
+        ruling("2007-10-01", "Activating Twinning Glass's ability allows you to cast a single card from your hand as it resolves. It doesn't create a continuous effect, and it doesn't let you cast multiple cards for free.")
+        ruling("2007-10-01", "It doesn't matter who cast the first spell.")
+        ruling("2007-10-01", "You can't pay any alternative costs (such as those from evoke or morph) when casting the card. On the other hand, if the card has additional costs (such as those from kicker or buyback), you may pay those.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TwinningGlassScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TwinningGlassScenarioTest.kt
@@ -1,0 +1,180 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.CastSpellRecord
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.TwinningGlass
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import io.kotest.matchers.shouldBe
+
+class TwinningGlassScenarioTest : ScenarioTestBase() {
+    init {
+        fun setup(): TestGame = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Twinning Glass")
+            .withLandsOnBattlefield(1, "Mountain", 2)
+            .withCardInHand(1, "Lightning Bolt")
+            .withCardInHand(1, "Lightning Bolt")
+            .withCardInHand(1, "Grizzly Bears")
+            .withCardInHand(1, "Island")
+            .withCardInHand(1, "Jennifer Walters")
+            .withCardInHand(1, "Disenchant")
+            .withCardInHand(2, "Disenchant")
+            .withCardOnBattlefield(2, "Sol Ring")
+            .withLandsOnBattlefield(2, "Plains", 2)
+            .withCardInHand(1, "Mosswood Dreadknight")
+            .withCardInHand(1, "Pain // Suffering")
+            .withCardInLibrary(1, "Mountain")
+            .withCardInLibrary(1, "Mountain")
+            .withCardInLibrary(2, "Island")
+            .withCardInLibrary(2, "Island")
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+
+        fun activate(game: TestGame) {
+            game.execute(ActivateAbility(
+                playerId = game.player1Id,
+                sourceId = game.findPermanent("Twinning Glass")!!,
+                abilityId = TwinningGlass.script.activatedAbilities.single().id
+            )).error shouldBe null
+            game.resolveStack()
+        }
+
+        test("casts exactly one matching spell for free and asks for its targets") {
+            val game = setup()
+            game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+            game.resolveStack()
+            activate(game)
+            val bolt = game.findCardsInHand(1, "Lightning Bolt").single()
+            (game.state.pendingDecision is SelectCardsDecision) shouldBe true
+            game.selectCards(listOf(bolt)).error shouldBe null
+            game.selectTargets(listOf(game.player2Id)).error shouldBe null
+            game.resolveStack()
+            game.getLifeTotal(2) shouldBe 14
+            game.isInHand(1, "Lightning Bolt") shouldBe false
+            game.isInHand(1, "Grizzly Bears") shouldBe true
+            game.state.getEntity(game.findPermanent("Twinning Glass")!!)!!.has<com.wingedsheep.engine.state.components.battlefield.TappedComponent>() shouldBe true
+        }
+
+        test("opponent's cast qualifies and a creature can be cast during combat") {
+            val game = setup()
+            game.state = game.state.copy(spellsCastThisTurnByPlayer = mapOf(
+                game.player2Id to listOf(CastSpellRecord(
+                    TypeLine.parse("Creature — Bear"), 2, emptySet(), false, name = "Grizzly Bears"
+                ))
+            ))
+            game.advanceToPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+            activate(game)
+            game.selectCards(listOf(game.findCardsInHand(1, "Grizzly Bears").single())).error shouldBe null
+            game.resolveStack()
+            game.findPermanent("Grizzly Bears")?.let { game.state.projectedState.getController(it) } shouldBe game.player1Id
+            game.isInHand(1, "Lightning Bolt") shouldBe true
+        }
+
+        test("unmatched spells and lands cannot be selected") {
+            val game = setup()
+            game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+            game.resolveStack()
+            activate(game)
+            game.selectCards(listOf(game.findCardsInHand(1, "Grizzly Bears").single())).isSuccess shouldBe false
+            game.selectCards(listOf(game.findCardsInHand(1, "Island").single())).isSuccess shouldBe false
+            game.selectCards(emptyList()).error shouldBe null
+            game.resolveStack()
+            game.isInHand(1, "Lightning Bolt") shouldBe true
+        }
+
+        test("may activate without a matching spell and decline without gaining later permission") {
+            val game = setup()
+            activate(game)
+            if (game.state.pendingDecision is SelectCardsDecision) game.selectCards(emptyList()).error shouldBe null
+            game.resolveStack()
+            game.state.pendingDecision shouldBe null
+            game.findCardsInHand(1, "Lightning Bolt").size shouldBe 2
+            game.isInHand(1, "Grizzly Bears") shouldBe true
+        }
+
+        test("matches an Adventure spell name and casts that face rather than the creature") {
+            val game = setup()
+            game.state = game.state.copy(spellsCastThisTurnByPlayer = mapOf(
+                game.player2Id to listOf(CastSpellRecord(
+                    TypeLine.parse("Sorcery"), 2, emptySet(), false, name = "Dread Whispers"
+                ))
+            ))
+            activate(game)
+            val knight = game.findCardsInHand(1, "Mosswood Dreadknight").single()
+            game.selectCards(listOf(knight)).error shouldBe null
+            game.resolveStack()
+            game.getLifeTotal(1) shouldBe 19
+            game.findPermanent("Mosswood Dreadknight") shouldBe null
+            game.state.spellsCastThisTurnByPlayer[game.player1Id]!!.last().name shouldBe "Dread Whispers"
+        }
+
+        test("a split card casts only the matching half with that half's targets") {
+            val game = setup()
+            game.state = game.state.copy(spellsCastThisTurnByPlayer = mapOf(
+                game.player2Id to listOf(CastSpellRecord(
+                    TypeLine.parse("Sorcery"), 4, emptySet(), false, name = "Suffering"
+                ))
+            ))
+            val mountain = game.findPermanent("Mountain")!!
+            activate(game)
+            game.selectCards(listOf(game.findCardsInHand(1, "Pain // Suffering").single())).error shouldBe null
+            game.selectTargets(listOf(mountain)).error shouldBe null
+            game.resolveStack()
+            game.isInGraveyard(1, "Mountain") shouldBe true
+            game.state.spellsCastThisTurnByPlayer[game.player1Id]!!.last().name shouldBe "Suffering"
+        }
+
+        test("offers a face choice only when multiple spell faces match") {
+            val game = setup()
+            game.state = game.state.copy(spellsCastThisTurnByPlayer = mapOf(
+                game.player2Id to listOf("Mosswood Dreadknight", "Dread Whispers").map { name ->
+                    CastSpellRecord(TypeLine.parse("Sorcery"), 2, emptySet(), false, name = name)
+                }
+            ))
+            activate(game)
+            game.selectCards(listOf(game.findCardsInHand(1, "Mosswood Dreadknight").single())).error shouldBe null
+            val decision = game.state.pendingDecision as com.wingedsheep.engine.core.ChooseOptionDecision
+            decision.options shouldBe listOf("Mosswood Dreadknight", "Dread Whispers")
+            game.execute(com.wingedsheep.engine.core.SubmitDecision(
+                game.player1Id, com.wingedsheep.engine.core.OptionChosenResponse(decision.id, 0)
+            )).error shouldBe null
+            game.resolveStack()
+            game.getLifeTotal(1) shouldBe 20
+            (game.findPermanent("Mosswood Dreadknight") != null) shouldBe true
+        }
+
+        test("a modal permanent back face qualifies independently of its front") {
+            val game = setup()
+            game.state = game.state.copy(spellsCastThisTurnByPlayer = mapOf(
+                game.player2Id to listOf(CastSpellRecord(
+                    TypeLine.parse("Creature"), 6, emptySet(), false, name = "The Sensational She-Hulk"
+                ))
+            ))
+            activate(game)
+            game.selectCards(listOf(game.findCardsInHand(1, "Jennifer Walters").single())).error shouldBe null
+            game.resolveStack()
+            game.state.spellsCastThisTurnByPlayer[game.player1Id]!!.last().name shouldBe "The Sensational She-Hulk"
+        }
+
+        test("resolves after the Glass leaves and counts a spell cast in response") {
+            val game = setup()
+            val glass = game.findPermanent("Twinning Glass")!!
+            game.execute(ActivateAbility(game.player1Id, glass, TwinningGlass.script.activatedAbilities.single().id)).error shouldBe null
+            game.passPriority()
+            game.castSpell(2, "Disenchant", glass).error shouldBe null
+            game.resolveStack()
+            game.isInGraveyard(1, "Twinning Glass") shouldBe true
+            game.selectCards(listOf(game.findCardsInHand(1, "Disenchant").single())).error shouldBe null
+            game.selectTargets(listOf(game.findPermanent("Sol Ring")!!)).error shouldBe null
+            game.resolveStack()
+            game.isInGraveyard(2, "Sol Ring") shouldBe true
+            game.state.pendingDecision shouldBe null
+            game.state.spellsCastThisTurnByPlayer[game.player2Id]!!.last().name shouldBe "Disenchant"
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -17118,6 +17118,91 @@
     ]
 }
 
+// Twinning Glass
+{
+    "name": "Twinning Glass",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, {T}: You may cast a spell from your hand without paying its mana cost if it has the same name as a spell that was cast this turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": "ChooseSpell",
+                            "filter": {
+                                "cardPredicates": [
+                                    "IsNonland"
+                                ],
+                                "statePredicates": [
+                                    "SharesNameWithSpellCastThisTurn"
+                                ]
+                            },
+                            "storeSelected": "spellToCast",
+                            "prompt": "You may cast a spell with the same name as a spell cast this turn",
+                            "selectedLabel": "Cast for free",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "CastFromCollectionWithoutPayingCost",
+                            "from": "spellToCast"
+                        }
+                    ]
+                },
+                "descriptionOverride": "{1}, {T}: Cast a spell with a name already cast this turn for free"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "264",
+        "rarity": "RARE",
+        "artist": "Franz Vohwinkel",
+        "flavorText": "It takes two to craft a mirror: a practiced metalsmith to silver one side and her own hazy reflection to polish the other.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0138c42-77ea-45f0-b2ca-cda03f3f50d1.jpg?1783942850",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "Activating Twinning Glass's ability allows you to cast a single card from your hand as it resolves. It doesn't create a continuous effect, and it doesn't let you cast multiple cards for free."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "It doesn't matter who cast the first spell."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "You can't pay any alternative costs (such as those from evoke or morph) when casting the card. On the other hand, if the card has additional costs (such as those from kicker or buyback), you may pay those."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Veteran of the Depths
 {
     "name": "Veteran of the Depths",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
@@ -3,6 +3,8 @@ package com.wingedsheep.tooling.coverage.bridge
 /** Mana, counters, control, and combat/untap-state effects. Mostly the "universal" verbs that Portal
  *  never exercised but every later set does — each line lifts recall on every set at once. */
 internal fun BridgeBuilder.manaCountersAndState() {
+    supported("SharesANameWithASpellCastThisTurn", "GameObjectFilter.sharesNameWithSpellCastThisTurn; cast-time names from all players")
+
     // AddMana's exact Effect depends on the produced symbol — colorless ({C}) serialises as
     // AddColorlessMana, "any color" as AddManaOfChoice, a fixed colour as AddMana — and the capability
     // scorer can't see the symbol arg, so name the whole mana family the action can lower to.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -479,6 +479,8 @@ class BeginningPhaseManager(
         container: ComponentContainer
     ): Boolean = when (predicate) {
         // Graveyard-only predicates; untap filters never see a card with the marker.
+        // Cast history is cleared before the turn's untap step.
+        StatePredicate.SharesNameWithSpellCastThisTurn -> false
         StatePredicate.PutIntoGraveyardThisTurn -> false
         StatePredicate.PutIntoGraveyardFromBattlefieldThisTurn -> false
         // No granter context in untap filtering — granter-relative exclusion is resolution-time only.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/LibraryAndZoneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/LibraryAndZoneContinuations.kt
@@ -29,6 +29,11 @@ data class SelectFromCollectionContinuation(
     val storeSelected: String,
     val storeRemainder: String?,
     val storedCollections: Map<String, List<EntityId>> = emptyMap(),
+    /** Castable face indices (-1 is primary, -2 is a modal permanent back) for a spell selection. */
+    @kotlinx.serialization.EncodeDefault(kotlinx.serialization.EncodeDefault.Mode.NEVER)
+    val spellFaces: Map<EntityId, List<Int>>? = null,
+    @kotlinx.serialization.EncodeDefault(kotlinx.serialization.EncodeDefault.Mode.NEVER)
+    val selectedSpellCard: EntityId? = null,
     /**
      * Restrictions that tightened the selection bounds. The resumer uses these
      * to normalize the player's response: e.g. [SelectionRestriction.OnePerCardType]
@@ -373,6 +378,8 @@ data class CastFromCollectionTargetsContinuation(
     val storeCastTo: String? = null,
     val grantedPermissionId: EntityId? = null,
     val onCastFailure: FreeCastFallback = FreeCastFallback.LEAVE,
+    @kotlinx.serialization.EncodeDefault(kotlinx.serialization.EncodeDefault.Mode.NEVER)
+    val faceIndex: Int? = null,
 ) : AnswerContinuation
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -2130,6 +2130,12 @@ class TriggerMatcher(
         /** The permanent whose triggered ability is being gated — the "source" of `createdBySource()`. */
         sourceId: EntityId
     ): Boolean = when (predicate) {
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.SharesNameWithSpellCastThisTurn -> {
+            if (event.fromZone == Zone.BATTLEFIELD)
+                com.wingedsheep.engine.handlers.predicates.sharesNameWithSpellCastThisTurn(state, event.lastKnown?.name)
+            else matchesStatePredicateForTrigger(predicate, state, event.entityId)
+        }
+
         // "the token" — this source's own token, not any token (Dance of Many, Tetravus). A token is
         // swept out of existence before this gate runs (CR 704.5d), so the creator stamp is read
         // from the event's last-known info, with a live read for a permanent that is still around
@@ -2247,6 +2253,12 @@ class TriggerMatcher(
         state: GameState,
         entityId: EntityId
     ): Boolean = when (predicate) {
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.SharesNameWithSpellCastThisTurn ->
+            com.wingedsheep.engine.handlers.predicates.sharesNameWithSpellCastThisTurn(
+                state, state.projectedState.getName(entityId)
+                    ?: state.getEntity(entityId)?.get<CardComponent>()?.name
+            )
+
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsFaceDown -> {
             val entity = state.getEntity(entityId) ?: return false
             entity.has<FaceDownComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PipelineState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PipelineState.kt
@@ -34,6 +34,9 @@ data class PipelineState(
     companion object {
         val EMPTY = PipelineState()
 
+        /** Reserved metadata published by ChooseSpell alongside its selected card collection. */
+        fun spellFaceKey(collection: String): String = "$collection:spellFace"
+
         /**
          * Pipeline collection name under which a batch trigger seeds the entities it captured
          * (the matching permanents in a `PermanentsEnteredEvent` batch). Aliases the SDK-side

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1564,6 +1564,11 @@ class PredicateEvaluator {
             StatePredicate.BecameTappedOnlyOnceThisTurn ->
                 becameTappedOnlyOnceThisTurn(container, state.turnNumber)
 
+            StatePredicate.SharesNameWithSpellCastThisTurn ->
+                com.wingedsheep.engine.handlers.predicates.sharesNameWithSpellCastThisTurn(
+                    state, projected.getName(entityId) ?: container.get<CardComponent>()?.name
+                )
+
             // Damage state
             StatePredicate.WasDealtDamageThisTurn -> {
                 container.has<WasDealtDamageThisTurnComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -3590,7 +3590,10 @@ class CastSpellHandler(
                 castFromZone = stackResolver.findCastFromZone(currentState, action.cardId, action.playerId),
                 // Face-down casts hide the card's identity; a face-up cast records the name so
                 // name predicates ("the first Otter spell other than Alania") can match history.
-                name = if (action.castFaceDown) null else (transformedFace?.name ?: cardComponent.name),
+                name = if (action.castFaceDown) null else (
+                    action.faceIndex?.let { cardDef?.cardFaces?.getOrNull(it)?.name }
+                        ?: transformedFace?.name ?: cardComponent.name
+                ),
             )
             val existing = currentState.spellsCastThisTurnByPlayer[action.playerId] ?: emptyList()
             currentState = currentState.copy(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
@@ -396,12 +396,63 @@ class LibraryAndZoneContinuationResumer(
         return checkForMore(newState, events)
     }
 
+    private fun resumeSpellSelection(
+        state: GameState,
+        continuation: SelectFromCollectionContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        val selected = continuation.selectedSpellCard ?: (response as? CardsSelectedResponse)?.selectedCards?.singleOrNull()
+        if (selected == null) {
+            if (response !is CardsSelectedResponse || response.selectedCards.isNotEmpty())
+                return ExecutionResult.error(state, "Choose at most one spell")
+            val collections = mutableMapOf(continuation.storeSelected to emptyList<EntityId>())
+            continuation.storeRemainder?.let { collections[it] = continuation.allCards }
+            return checkForMore(exposeCollectionsToNextFrame(state, collections), emptyList())
+        }
+        val faces = continuation.spellFaces?.get(selected)
+            ?: return ExecutionResult.error(state, "That card has no matching spell face")
+        val chosenFace = if (continuation.selectedSpellCard != null) {
+            val index = (response as? OptionChosenResponse)?.optionIndex
+                ?: return ExecutionResult.error(state, "Expected a spell face choice")
+            faces.getOrNull(index) ?: return ExecutionResult.error(state, "Invalid spell face")
+        } else if (faces.size == 1) faces.single() else {
+            val card = state.getEntity(selected)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                ?: return ExecutionResult.error(state, "Selected card is missing")
+            val definition = services.cardRegistry.getCard(card.cardDefinitionId)
+            return state.suspendForDecision(
+                { id -> ChooseOptionDecision(
+                    id = id, playerId = continuation.playerId, prompt = "Choose which spell to cast",
+                    context = DecisionContext(sourceId = continuation.sourceId, sourceName = continuation.sourceName, phase = DecisionPhase.RESOLUTION),
+                    options = faces.map {
+                        when (it) {
+                            -1 -> card.name
+                            -2 -> definition!!.backFace!!.name
+                            else -> definition!!.cardFaces[it].name
+                        }
+                    },
+                    optionCardIds = faces.indices.associateWith { listOf(selected) }
+                ) },
+                continuation.copy(selectedSpellCard = selected)
+            )
+        }
+        val collections = mutableMapOf(continuation.storeSelected to listOf(selected))
+        continuation.storeRemainder?.let { collections[it] = continuation.allCards - selected }
+        return checkForMore(exposeCollectionsToNextFrame(
+            state, collections,
+            numbers = mapOf(com.wingedsheep.engine.handlers.PipelineState.spellFaceKey(continuation.storeSelected) to chosenFace)
+        ), emptyList())
+    }
+
     fun resumeSelectFromCollection(
         state: GameState,
         continuation: SelectFromCollectionContinuation,
         response: DecisionResponse,
         checkForMore: CheckForMore
     ): ExecutionResult {
+        if (continuation.spellFaces != null) {
+            return resumeSpellSelection(state, continuation, response, checkForMore)
+        }
         if (response !is CardsSelectedResponse) {
             return ExecutionResult.error(state, "Expected card selection response for SelectFromCollection")
         }
@@ -1142,7 +1193,7 @@ class LibraryAndZoneContinuationResumer(
         val stateForCast = state.copy(priorityPlayerId = continuation.casterId)
         val castResult = castSpellHandler.execute(
             stateForCast,
-            CastSpell(continuation.casterId, continuation.cardId, chosenTargets),
+            CastSpell(continuation.casterId, continuation.cardId, chosenTargets, faceIndex = continuation.faceIndex),
         )
 
         if (castResult.error != null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CastFromCollectionWithoutPayingCostExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CastFromCollectionWithoutPayingCostExecutor.kt
@@ -71,6 +71,11 @@ class CastFromCollectionWithoutPayingCostExecutor(
         val cards: List<EntityId> = context.pipeline.storedCollections[effect.from].orEmpty()
         if (cards.isEmpty()) return EffectResult.success(state)
         val cardId = cards.first()
+        val chosenFace = context.pipeline.storedNumbers[
+            com.wingedsheep.engine.handlers.PipelineState.spellFaceKey(effect.from)
+        ]
+        val faceIndex = chosenFace?.takeIf { it >= 0 }
+        val castTransformed = effect.castTransformed || chosenFace == -2
         // `Chooser.Controller` (the default) is `context.controllerId`; the only other value a
         // printed card needs is `SourceController`, which survives the per-iteration controller
         // swap `ForEachPlayerEffect` performs (Jetsam casts from each opponent's graveyard, but
@@ -86,7 +91,7 @@ class CastFromCollectionWithoutPayingCostExecutor(
         // or a single-faced card that became a copy of a transforming one — simply isn't cast, and
         // per the CR 310.12b ruling it stays where it is (in exile, for the Siege defeat trigger)
         // rather than being cast front face up.
-        if (effect.castTransformed && !hasBackFace(state, cardId)) {
+        if (castTransformed && !hasBackFace(state, cardId)) {
             return EffectResult.success(state)
         }
 
@@ -94,7 +99,8 @@ class CastFromCollectionWithoutPayingCostExecutor(
         // would follow the card out of exile and stay live until end-of-turn cleanup.
         val prep = prepareTargetSelection(
             state, cardId, controllerId, cardRegistry, targetFinder, effect.storeCastTo,
-            castTransformed = effect.castTransformed,
+            castTransformed = castTransformed,
+            faceIndex = faceIndex,
         )
         if (prep is TargetPrep.NoLegalTargets) {
             // CR 601.2c — if no legal targets exist for a required slot, the cast can't
@@ -111,8 +117,9 @@ class CastFromCollectionWithoutPayingCostExecutor(
             controllerId = controllerId,
             sourceId = context.sourceId,
             withoutPayingCost = !effect.payManaCost,
-            castTransformed = effect.castTransformed,
+            castTransformed = castTransformed,
             insteadOfGraveyard = effect.insteadOfGraveyard,
+            faceIndex = faceIndex,
         )
 
         if (prep is TargetPrep.NeedsTargets) {
@@ -123,7 +130,7 @@ class CastFromCollectionWithoutPayingCostExecutor(
         }
 
         // No targets needed (or modal — CastSpellHandler will handle per-mode targets).
-        return invokeCast(newState, controllerId, cardId, permId, emptyList(), effect.storeCastTo)
+        return invokeCast(newState, controllerId, cardId, permId, emptyList(), effect.storeCastTo, faceIndex)
     }
 
     /** True when [cardId]'s definition has a back face to be cast transformed as. */
@@ -139,11 +146,12 @@ class CastFromCollectionWithoutPayingCostExecutor(
         grantedPermissionId: EntityId,
         targets: List<com.wingedsheep.engine.state.components.stack.ChosenTarget>,
         storeCastTo: String?,
+        faceIndex: Int?,
     ): EffectResult {
         val stateForCast = state.copy(priorityPlayerId = casterId)
         val castResult = castSpellHandlerProvider().execute(
             stateForCast,
-            CastSpell(casterId, cardId, targets),
+            CastSpell(casterId, cardId, targets, faceIndex = faceIndex),
         )
 
         if (castResult.error != null) {
@@ -210,6 +218,7 @@ class CastFromCollectionWithoutPayingCostExecutor(
             withoutPayingCost: Boolean = true,
             castTransformed: Boolean = false,
             insteadOfGraveyard: AfterResolveDestination? = null,
+            faceIndex: Int? = null,
         ): Pair<EntityId, GameState> {
             var stamped = if (!withoutPayingCost) state else state.updateEntity(cardId) { container ->
                 container.with(PlayWithoutPayingCostComponent(controllerId = controllerId))
@@ -231,6 +240,7 @@ class CastFromCollectionWithoutPayingCostExecutor(
                     controllerId = controllerId,
                     sourceId = sourceId,
                     castTransformed = castTransformed,
+                    castFaceIndex = faceIndex,
                     timestamp = stateWithPerm.timestamp,
                 )
             )
@@ -277,14 +287,17 @@ class CastFromCollectionWithoutPayingCostExecutor(
             targetFinder: TargetFinder,
             storeCastTo: String? = null,
             castTransformed: Boolean = false,
+            faceIndex: Int? = null,
         ): TargetPrep {
             val cardComponent = state.getEntity(cardId)?.get<CardComponent>()
             val printedDef = cardComponent?.let { cardRegistry.getCard(it.cardDefinitionId) }
             val cardDef = if (castTransformed) printedDef?.backFace ?: printedDef else printedDef
-            val isModalSpell = cardDef?.script?.spellEffect is ModalEffect
+            val selectedFace = faceIndex?.let { printedDef?.cardFaces?.getOrNull(it) }
+            val script = selectedFace?.script ?: cardDef?.script
+            val isModalSpell = script?.spellEffect is ModalEffect
             val targetRequirements = buildList {
-                addAll(cardDef?.script?.targetRequirements.orEmpty())
-                cardDef?.script?.auraTarget?.let { add(it) }
+                addAll(script?.targetRequirements.orEmpty())
+                script?.auraTarget?.let { add(it) }
             }
             if (isModalSpell || targetRequirements.isEmpty()) {
                 return TargetPrep.NotNeeded
@@ -315,7 +328,7 @@ class CastFromCollectionWithoutPayingCostExecutor(
 
             // Name the face being cast — a transformed cast prompts for "Deluge of the Dead",
             // not for the front face the player exiled.
-            val cardName = (if (castTransformed) cardDef?.name else null) ?: cardComponent?.name ?: "spell"
+            val cardName = selectedFace?.name ?: (if (castTransformed) cardDef?.name else null) ?: cardComponent?.name ?: "spell"
             val question = { decisionId: String -> ChooseTargetsDecision(
                 id = decisionId,
                 playerId = casterId,
@@ -333,6 +346,7 @@ class CastFromCollectionWithoutPayingCostExecutor(
                 cardId = cardId,
                 casterId = casterId,
                 storeCastTo = storeCastTo,
+                faceIndex = faceIndex,
             )
             return TargetPrep.NeedsTargets(question, continuation)
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
@@ -69,6 +69,25 @@ class SelectFromCollectionExecutor(
             return EffectResult.success(state).copy(updatedCollections = collections)
         }
 
+        if (effect.selection == SelectionMode.ChooseSpell) {
+            require(effect.restrictions.isEmpty() && !effect.matchChosenCreatureType) {
+                "ChooseSpell expresses eligibility through its face filter, not card-selection restrictions"
+            }
+            val faces = spellFaces(state, cards, effect, context)
+            val chooser = when (val outcome = ChooserResolution.resolve(state, effect.chooser, context, cards)) {
+                is ChooserResolution.Outcome.Resolved -> outcome.playerId
+                is ChooserResolution.Outcome.NeedsOpponentPick -> return ChooserResolution.pauseForOpponentPick(
+                    state, outcome.opponents, effect, context, prompt = "Choose which opponent chooses the spell"
+                )
+                is ChooserResolution.Outcome.Unresolvable -> return EffectResult.error(state, outcome.reason)
+            }
+            return createDecision(
+                state, context, effect, faces.keys.toList(), 0, minOf(1, faces.size), decidingPlayerId = chooser,
+                allCards = cards, nonSelectableCards = if (effect.showAllCards) cards - faces.keys else emptyList(),
+                spellFaces = faces
+            )
+        }
+
         // Apply filter to narrow selectable cards (e.g., "creature card" for Animal Magnetism)
         var eligibleCards = if (effect.filter != GameObjectFilter.Any) {
             val predicateContext = PredicateContext.fromEffectContext(context)
@@ -138,6 +157,7 @@ class SelectFromCollectionExecutor(
         val restrictionCeiling = restrictionCeiling(effect.restrictions, state, context, eligibleCards, controllerPermanentColors)
 
         return when (val selection = effect.selection) {
+            SelectionMode.ChooseSpell -> error("Spell selection is handled before card filtering")
             is SelectionMode.All -> {
                 // Auto-select all eligible, no decision needed
                 val collections = mutableMapOf(effect.storeSelected to eligibleCards)
@@ -396,6 +416,41 @@ class SelectFromCollectionExecutor(
         return ceiling
     }
 
+    private fun spellFaces(
+        state: GameState, cards: List<EntityId>, effect: SelectFromCollectionEffect, context: EffectContext
+    ): Map<EntityId, List<Int>> = buildMap {
+        val predicateContext = PredicateContext.fromEffectContext(context)
+        for (id in cards) {
+            if (id in state.getBattlefield()) continue
+            val card = state.getEntity(id)?.get<CardComponent>() ?: continue
+            val definition = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            val faces = buildList {
+                // A split card's combined characteristics are not a castable face.
+                if (!definition.isSplit) add(-1 to card)
+                if (definition.layout == com.wingedsheep.sdk.model.CardLayout.MODAL_DFC) {
+                    definition.backFace?.let { face ->
+                        add(-2 to card.copy(
+                            name = face.name, typeLine = face.typeLine, manaCost = face.manaCost,
+                            oracleText = face.oracleText, baseStats = face.creatureStats,
+                            baseKeywords = face.keywords, colors = face.colors
+                        ))
+                    }
+                }
+                if (!definition.isPreparation) definition.cardFaces.forEachIndexed { index, face ->
+                    add(index to card.copy(
+                        name = face.name, typeLine = face.typeLine, manaCost = face.manaCost,
+                        oracleText = face.oracleText, baseKeywords = face.keywords, colors = face.manaCost.colors
+                    ))
+                }
+            }.filter { (_, face) -> !face.typeLine.isLand }.filter { (_, face) ->
+                val candidateState = if (face === card) state else state.updateEntity(id) { it.with(face) }
+                // The candidate is outside the battlefield; its face overlay changes no projected permanent.
+                predicateEvaluator.matches(candidateState, state.projectedState, id, effect.filter, predicateContext)
+            }.map { it.first }
+            if (faces.isNotEmpty()) put(id, faces)
+        }
+    }
+
     /**
      * @param cards The cards presented as selectable options in the decision
      * @param allCards The full collection for remainder computation (defaults to [cards]).
@@ -413,7 +468,8 @@ class SelectFromCollectionExecutor(
         allCards: List<EntityId> = cards,
         nonSelectableCards: List<EntityId> = emptyList(),
         controllerPermanentColors: Set<com.wingedsheep.sdk.core.Color>? = null,
-        conditionalMinimums: List<ConditionalSelectionMinimum> = emptyList()
+        conditionalMinimums: List<ConditionalSelectionMinimum> = emptyList(),
+        spellFaces: Map<EntityId, List<Int>>? = null
     ): EffectResult {
         val playerId = decidingPlayerId ?: context.controllerId
         val sourceName = context.sourceId?.let { sourceId ->
@@ -495,7 +551,8 @@ class SelectFromCollectionExecutor(
             storeSelected = effect.storeSelected,
             storeRemainder = effect.storeRemainder,
             storedCollections = context.pipeline.storedCollections,
-            restrictions = effect.restrictions
+            restrictions = effect.restrictions,
+            spellFaces = spellFaces
         )
 
         return EffectResult.from(state.suspendForDecision(decision, continuation))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/predicates/SpellNameHistory.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/predicates/SpellNameHistory.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.engine.handlers.predicates
+
+import com.wingedsheep.engine.state.GameState
+
+/** Cast-time names survive resolution, countering, and later zone changes. Nameless spells never match. */
+internal fun sharesNameWithSpellCastThisTurn(state: GameState, name: String?): Boolean {
+    if (name.isNullOrBlank()) return false
+    return state.spellsCastThisTurnByPlayer.values.any { records ->
+        records.any { record ->
+            !record.isFaceDown && !record.name.isNullOrBlank() &&
+                (record.name == name || (
+                    (" // " in name || " // " in record.name) &&
+                        record.name.split(" // ").any { it in name.split(" // ") }
+                ))
+        }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -527,6 +527,10 @@ internal class AffectsFilterResolver {
         // that has become tapped for the first time this turn" resolves during projection.
         StatePredicate.BecameTappedOnlyOnceThisTurn ->
             becameTappedOnlyOnceThisTurn(container, state.turnNumber)
+        StatePredicate.SharesNameWithSpellCastThisTurn ->
+            com.wingedsheep.engine.handlers.predicates.sharesNameWithSpellCastThisTurn(
+                state, projectedValues[entityId]?.name ?: container.get<CardComponent>()?.name
+            )
         StatePredicate.WasDealtDamageThisTurn -> container.has<WasDealtDamageThisTurnComponent>()
         // Damage history — plain per-entity state with no source-relative half, so a group static
         // gated on "each creature that dealt damage this turn" resolves during projection and gives

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/predicates/SpellNameHistoryTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/predicates/SpellNameHistoryTest.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.engine.handlers.predicates
+
+import com.wingedsheep.engine.state.CastSpellRecord
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class SpellNameHistoryTest : FunSpec({
+    fun history(name: String?, faceDown: Boolean = false) = GameState(
+        spellsCastThisTurnByPlayer = mapOf(EntityId("caster") to listOf(
+            CastSpellRecord(TypeLine.parse("Instant"), 1, emptySet(), faceDown, name = name)
+        ))
+    )
+
+    test("matches recorded names without requiring the spell to remain in a zone") {
+        sharesNameWithSpellCastThisTurn(history("Lightning Bolt"), "Lightning Bolt") shouldBe true
+        sharesNameWithSpellCastThisTurn(history("Lightning Bolt"), "Shock") shouldBe false
+    }
+    test("nameless and face-down spells never establish a matching name") {
+        sharesNameWithSpellCastThisTurn(history(null), null) shouldBe false
+        sharesNameWithSpellCastThisTurn(history(""), "") shouldBe false
+        sharesNameWithSpellCastThisTurn(history("Lightning Bolt", true), "Lightning Bolt") shouldBe false
+    }
+    test("multiple names match if at least one is shared") {
+        sharesNameWithSpellCastThisTurn(history("Fire"), "Fire // Ice") shouldBe true
+        sharesNameWithSpellCastThisTurn(history("Fire // Ice"), "Ice") shouldBe true
+        sharesNameWithSpellCastThisTurn(history("Fire"), "Ice") shouldBe false
+    }
+    test("clearing turn history removes eligibility") {
+        val state = history("Lightning Bolt")
+        sharesNameWithSpellCastThisTurn(state.copy(spellsCastThisTurnByPlayer = emptyMap()), "Lightning Bolt") shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpellSelectionRemainderTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpellSelectionRemainderTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import io.kotest.matchers.shouldBe
+
+class SpellSelectionRemainderTest : ScenarioTestBase() {
+    private val selectionSpell = card("Spell Selection Test") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        spell {
+            effect = Effects.Composite(
+                GatherCardsEffect(CardSource.FromZone(Zone.HAND), "hand"),
+                SelectFromCollectionEffect(
+                    from = "hand",
+                    selection = SelectionMode.ChooseSpell,
+                    filter = GameObjectFilter.Nonland,
+                    storeSelected = "selected",
+                    storeRemainder = "rest"
+                ),
+                MoveCollectionEffect("rest", CardDestination.ToZone(Zone.EXILE))
+            )
+        }
+    }
+
+    init {
+        cardRegistry.register(selectionSpell)
+
+        fun setup() = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardInHand(1, "Spell Selection Test")
+            .withCardInHand(1, "Grizzly Bears")
+            .withCardInHand(1, "Island")
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+
+        test("declining publishes all cards, including nonspells, to the remainder") {
+            val game = setup()
+            game.castSpell(1, "Spell Selection Test").error shouldBe null
+            game.resolveStack()
+            (game.state.pendingDecision is SelectCardsDecision) shouldBe true
+            game.selectCards(emptyList()).error shouldBe null
+            game.resolveStack()
+            game.isInExile(1, "Grizzly Bears") shouldBe true
+            game.isInExile(1, "Island") shouldBe true
+            game.state.getHand(game.player1Id).size shouldBe 0
+        }
+
+        test("selecting a spell excludes only that card from the remainder") {
+            val game = setup()
+            game.castSpell(1, "Spell Selection Test").error shouldBe null
+            game.resolveStack()
+            val bear = game.findCardsInHand(1, "Grizzly Bears").single()
+            game.selectCards(listOf(bear)).error shouldBe null
+            game.resolveStack()
+            game.isInHand(1, "Grizzly Bears") shouldBe true
+            game.isInExile(1, "Island") shouldBe true
+        }
+    }
+}


### PR DESCRIPTION
Add Twinning Glass to Lorwyn. Its activated ability lets its controller cast one matching spell from hand for free during resolution, using names of spells cast by either player this turn. Eligibility survives resolution, countering, and the Glass leaving the battlefield.

The card needs reusable engine support, so this PR contains one card:

- Add `SharesNameWithSpellCastThisTurn` and the corresponding filter facade, reading existing turn history.
- Add optional `SelectionMode.ChooseSpell` to filter individual spell faces, then use the existing card and option decisions. Carry the chosen face into free-cast targeting and permissions.
- Record the chosen Adventure/split spell name in cast history. Preserve existing serialized continuation shapes when new fields are unused.
- Include the card snapshot, SDK reference, backlog update, manual scenario, and focused card, mechanic, and serialization tests.

Verification:

- Full `just test`: passed, including nine Twinning Glass scenarios, cast-name history tests, selection/remainder regressions, serialization, and existing suspension traces.
- `just e2e-test twinning-glass`: passed against isolated backend/client servers; verifies both matching Adventure faces and an off-turn creature cast.
- `just rebless-cards`: only Twinning Glass added to the LRW snapshot.
- Scryfall metadata, rulings, image, and earliest-printing placement checked.

Existing tooling limitations:

- `just coverage-verify LRW` compiles all 86 emitted drafts, but fails on 26 gameplay-tree mismatches, one suspected golden drift, and one capability mismatch in existing cards. Twinning Glass is not emitted and remains SCAFFOLD. These generator findings are outside this PR.
- `just assay-differential --set LRW`: 108 of 111 compared cards agree. The three existing differences are equivalent composite-static folds in Boggart Sprite-Chaser and Kithkin Greatheart, and a composite-static fold plus aura-target identifier normalization in Epic Proportions. Assay declines Twinning Glass; it does not independently validate this card yet. The new vocabulary is `SharesNameWithSpellCastThisTurn` and `SelectionMode.ChooseSpell`.
