### PR TITLE
Draft: allow a lobby to draft with no pick time limit

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/BoosterDraftHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/BoosterDraftHandler.kt
@@ -154,7 +154,7 @@ class BoosterDraftHandler(
         // Derive pick number from this player's pool growth since the round started —
         // booster sizes vary by strategy (15-card classic, 13-card Play Booster, 20-card commander).
         val pickNumber = (playerState.cardPool.size - playerState.poolSizeAtRoundStart) / lobby.picksPerRound + 1
-        val timeRemaining = lobby.playerTimeRemaining[playerId] ?: lobby.pickTimeSeconds
+        val timeRemaining = if (lobby.hasPickTimer) lobby.playerTimeRemaining[playerId] ?: lobby.pickTimeSeconds else null
 
         ctx.sender.send(ws, ServerMessage.DraftPackReceived(
             packNumber = lobby.currentPackNumber,
@@ -177,7 +177,7 @@ class BoosterDraftHandler(
                     packNumber = lobby.currentPackNumber,
                     pickNumber = 1,  // Fresh pack round always starts at pick 1
                     cards = pack.map { cardToSealedCardInfo(it) },
-                    timeRemainingSeconds = lobby.pickTimeSeconds,
+                    timeRemainingSeconds = lobby.pickTimeSeconds.takeIf { lobby.hasPickTimer },
                     passDirection = lobby.getPassDirection().name,
                     picksPerRound = minOf(lobby.picksPerRound, pack.size),
                     pickedCards = playerState.cardPool.map { cardToSealedCardInfo(it) },
@@ -219,6 +219,8 @@ class BoosterDraftHandler(
      */
     private fun startPlayerTimer(lobby: TournamentLobby, playerId: EntityId) {
         cancelPlayerTimer(lobby, playerId)
+        // No time limit: never start a job, so the pick is never auto-made for the player.
+        if (!lobby.hasPickTimer) return
         lobby.playerTimeRemaining[playerId] = lobby.pickTimeSeconds
 
         val job = ctx.draftScope.launch {
@@ -276,7 +278,7 @@ class BoosterDraftHandler(
             packNumber = lobby.currentPackNumber,
             pickNumber = pickNumber,
             cards = pack?.map { cardToSealedCardInfo(it) } ?: emptyList(),
-            timeRemainingSeconds = lobby.playerTimeRemaining[identity.playerId] ?: lobby.pickTimeSeconds,
+            timeRemainingSeconds = if (lobby.hasPickTimer) lobby.playerTimeRemaining[identity.playerId] ?: lobby.pickTimeSeconds else null,
             passDirection = lobby.getPassDirection().name,
             picksPerRound = if (pack != null) minOf(lobby.picksPerRound, pack.size) else lobby.picksPerRound,
             pickedCards = playerState.cardPool.map { cardToSealedCardInfo(it) },

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GridDraftHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GridDraftHandler.kt
@@ -161,7 +161,7 @@ class GridDraftHandler(
                     totalPickedByOthers = otherPickCounts,
                     pickedCardsByOthers = otherPickedCards,
                     lastAction = if (lastPickerPlayerId == null || lastPickerPlayerId in sameGroupPlayerIds) lastAction else null,
-                    timeRemainingSeconds = lobby.pickTimeSeconds,
+                    timeRemainingSeconds = lobby.pickTimeSeconds.takeIf { lobby.hasPickTimer },
                     availableSelections = if (playerId == activePlayer) availableSelections else emptyList(),
                     playerOrder = playerOrderNames,
                     currentPickerIndex = group.activePlayerIndex,
@@ -173,8 +173,13 @@ class GridDraftHandler(
     }
 
     fun startGridDraftTimer(lobby: TournamentLobby) {
-        lobby.pickTimeRemaining = lobby.pickTimeSeconds
         lobby.pickTimerJob?.cancel()
+        // No time limit: never start a job, so the pick is never auto-made for the player.
+        if (!lobby.hasPickTimer) {
+            lobby.pickTimerJob = null
+            return
+        }
+        lobby.pickTimeRemaining = lobby.pickTimeSeconds
 
         lobby.pickTimerJob = ctx.draftScope.launch {
             var remaining = lobby.pickTimeSeconds

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -725,7 +725,7 @@ class LobbyHandler(
             boosterCount = boosterCount,
             boosterDistribution = TournamentLobby.calculateDefaultDistribution(codes, boosterCount),
             maxPlayers = maxPlayers,
-            pickTimeSeconds = message.pickTimeSeconds.coerceIn(15, 120),
+            pickTimeSeconds = TournamentLobby.clampPickTimeSeconds(message.pickTimeSeconds, 120),
             picksPerRound = initialPicksPerRound,
             isPublic = message.isPublic,
             // Commander formats enable Chaos boosters by default — 20-card commander packs
@@ -2617,7 +2617,7 @@ class LobbyHandler(
             }
         }
         message.gamesPerMatch?.let { lobby.gamesPerMatch = it.coerceIn(1, 5) }
-        message.pickTimeSeconds?.let { lobby.pickTimeSeconds = it.coerceIn(15, 180) }
+        message.pickTimeSeconds?.let { lobby.pickTimeSeconds = TournamentLobby.clampPickTimeSeconds(it, 180) }
         message.picksPerRound?.let { lobby.picksPerRound = it.coerceIn(1, 2) }
         message.isPublic?.let { lobby.isPublic = it }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/WinstonDraftHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/WinstonDraftHandler.kt
@@ -152,15 +152,20 @@ class WinstonDraftHandler(
                 knownOpponentCards = knownOpponentCards,
                 unknownOpponentCardCount = unknownOpponentCardCount,
                 lastAction = lastAction,
-                timeRemainingSeconds = lobby.pickTimeRemaining,
+                timeRemainingSeconds = lobby.pickTimeRemaining.takeIf { lobby.hasPickTimer },
                 lastPickedCards = lastPicked
             ))
         }
     }
 
     fun startWinstonTimer(lobby: TournamentLobby) {
-        lobby.pickTimeRemaining = lobby.pickTimeSeconds
         lobby.pickTimerJob?.cancel()
+        // No time limit: never start a job, so the turn is never auto-taken for the player.
+        if (!lobby.hasPickTimer) {
+            lobby.pickTimerJob = null
+            return
+        }
+        lobby.pickTimeRemaining = lobby.pickTimeSeconds
 
         lobby.pickTimerJob = ctx.draftScope.launch {
             var remaining = lobby.pickTimeSeconds

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
@@ -300,7 +300,7 @@ class TournamentLobby(
     var boosterCount: Int = 6,        // Sealed: boosters in pool, Draft: packs per player (usually 3)
     var boosterDistribution: Map<String, Int> = emptyMap(),  // Per-set booster counts (e.g., {"ONS": 2, "LGN": 2, "SCG": 2})
     var maxPlayers: Int = 8,
-    var pickTimeSeconds: Int = 45,    // Draft only
+    var pickTimeSeconds: Int = 45,    // Draft only; 0 = no time limit (see [hasPickTimer])
     var picksPerRound: Int = 1,       // Draft only: cards to pick each round (1 or 2); 2 is the default for new Draft / Commander Draft lobbies (see LobbyHandler.handleCreateTournamentLobby)
     var gamesPerMatch: Int = 3,
     var isPublic: Boolean = false,
@@ -739,6 +739,15 @@ class TournamentLobby(
     /** Seconds remaining on current pick timer (used by Winston/Grid draft) */
     @Volatile
     var pickTimeRemaining: Int = 0
+
+    /**
+     * Whether this draft runs a pick timer at all. A [pickTimeSeconds] of `0` means "no time
+     * limit": no timer job is started and no auto-pick ever fires, so players take as long as
+     * they like. Wire messages carry `null` rather than a second count in that case, so the
+     * client can't read an unlimited pick as "0 seconds left".
+     */
+    val hasPickTimer: Boolean
+        get() = pickTimeSeconds > 0
 
     /** Per-player timer jobs for booster draft (async pack passing). */
     val playerTimerJobs: ConcurrentHashMap<EntityId, Job> = ConcurrentHashMap()
@@ -2116,6 +2125,23 @@ class TournamentLobby(
     }
 
     companion object {
+        /**
+         * Sentinel [pickTimeSeconds] value meaning "no time limit": the draft runs no pick timer
+         * at all, so nothing is ever auto-picked and players take as long as they like. Kept as a
+         * value of the existing field rather than a separate flag so persistence, the lobby
+         * settings message and the recipe format all carry it for free.
+         */
+        const val NO_PICK_TIME_LIMIT = 0
+
+        /**
+         * Clamp a client-supplied pick time. Exactly [NO_PICK_TIME_LIMIT] is the untimed setting
+         * and survives untouched - clamping it up to the floor would silently re-arm the timer.
+         * Every other value is pinned into a usable window so a client can't ask for a one-second
+         * or week-long timer.
+         */
+        fun clampPickTimeSeconds(requested: Int, max: Int): Int =
+            if (requested == NO_PICK_TIME_LIMIT) NO_PICK_TIME_LIMIT else requested.coerceIn(15, max)
+
         /**
          * Sentinel set code for a deferred "Random Set" pick. A host can add one or more random
          * slots to a lobby's pool; each stays hidden (displayed as [RANDOM_SET_NAME]) until the

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -593,7 +593,8 @@ sealed interface ServerMessage {
         val packNumber: Int,           // 1, 2, or 3
         val pickNumber: Int,           // 1-15
         val cards: List<SealedCardInfo>,
-        val timeRemainingSeconds: Int,
+        /** Seconds left to pick, or `null` when the draft has no time limit. */
+        val timeRemainingSeconds: Int?,
         val passDirection: String,     // "LEFT" or "RIGHT"
         val picksPerRound: Int = 1,    // Cards to pick this round (1 or 2)
         val pickedCards: List<SealedCardInfo> = emptyList(),  // Cards already picked (for reconnect)
@@ -668,8 +669,8 @@ sealed interface ServerMessage {
         val unknownOpponentCardCount: Int = 0,
         /** Description of the last action */
         val lastAction: String? = null,
-        /** Seconds remaining on the turn timer */
-        val timeRemainingSeconds: Int = 0,
+        /** Seconds remaining on the turn timer, or `null` when there is no time limit. */
+        val timeRemainingSeconds: Int? = 0,
         /** Cards from the last opponent pick (empty if no pick yet or it was your pick) */
         val lastPickedCards: List<SealedCardInfo> = emptyList()
     ) : ServerMessage
@@ -695,7 +696,8 @@ sealed interface ServerMessage {
         /** Other players' picked cards: playerName -> cards */
         val pickedCardsByOthers: Map<String, List<SealedCardInfo>> = emptyMap(),
         val lastAction: String?,
-        val timeRemainingSeconds: Int,
+        /** Seconds left to pick, or `null` when the draft has no time limit. */
+        val timeRemainingSeconds: Int?,
         /** Available row/column selections (e.g., ["ROW_0", "COL_1"]) */
         val availableSelections: List<String>,
         /** Player names in pick order */

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/lobby/DraftPickTimeLimitTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/lobby/DraftPickTimeLimitTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.gameserver.lobby
+
+import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.gameserver.persistence.restoreTournamentLobby
+import com.wingedsheep.gameserver.persistence.toPersistent
+import com.wingedsheep.gameserver.session.PlayerIdentity
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The draft "no time limit" setting. [TournamentLobby.NO_PICK_TIME_LIMIT] is a value of the
+ * existing `pickTimeSeconds` field rather than a separate flag, so the thing worth pinning is
+ * that every layer that touches that field treats `0` as the sentinel rather than as an
+ * out-of-range duration to be clamped back up into a live timer.
+ */
+class DraftPickTimeLimitTest : FunSpec({
+    val forest = CardDefinition.basicLand("Forest", Subtype.FOREST)
+    val generator = BoosterGenerator(
+        mapOf(
+            "TST" to BoosterGenerator.SetConfig(
+                setCode = "TST",
+                setName = "Test",
+                cards = emptyList(),
+                basicLands = listOf(forest),
+            )
+        )
+    )
+
+    fun lobby(pickTimeSeconds: Int): TournamentLobby {
+        val lobby = TournamentLobby(
+            setCodes = listOf("TST"),
+            setNames = listOf("Test"),
+            boosterGenerator = generator,
+            format = TournamentFormat.DRAFT,
+            pickTimeSeconds = pickTimeSeconds,
+        )
+        lobby.addPlayer(PlayerIdentity(playerId = EntityId("host"), playerName = "Host"))
+        return lobby
+    }
+
+    test("a pick time of zero means the draft runs no timer") {
+        lobby(TournamentLobby.NO_PICK_TIME_LIMIT).hasPickTimer shouldBe false
+    }
+
+    test("any real duration still runs a timer") {
+        lobby(45).hasPickTimer shouldBe true
+        lobby(1).hasPickTimer shouldBe true
+    }
+
+    test("the clamp lets the untimed sentinel through but pins every real duration") {
+        // The whole point: clamping 0 up to the 15s floor would silently re-arm the timer on a
+        // draft the host deliberately made untimed.
+        TournamentLobby.clampPickTimeSeconds(0, 120) shouldBe TournamentLobby.NO_PICK_TIME_LIMIT
+        TournamentLobby.clampPickTimeSeconds(45, 120) shouldBe 45
+        TournamentLobby.clampPickTimeSeconds(5, 120) shouldBe 15
+        TournamentLobby.clampPickTimeSeconds(9999, 120) shouldBe 120
+        // A negative is a malformed duration, not the sentinel — it clamps to the floor.
+        TournamentLobby.clampPickTimeSeconds(-5, 120) shouldBe 15
+    }
+
+    test("the untimed setting survives a lobby restart") {
+        val lobby = lobby(TournamentLobby.NO_PICK_TIME_LIMIT)
+        val registry = CardRegistry().also { it.register(listOf(forest)) }
+
+        val (restored, _) = restoreTournamentLobby(lobby.toPersistent(), registry, generator)
+
+        restored.pickTimeSeconds shouldBe TournamentLobby.NO_PICK_TIME_LIMIT
+        restored.hasPickTimer shouldBe false
+    }
+
+    test("the broadcast lobby settings carry the untimed setting") {
+        lobby(TournamentLobby.NO_PICK_TIME_LIMIT)
+            .buildLobbyUpdate(EntityId("host")).settings.pickTimeSeconds shouldBe
+            TournamentLobby.NO_PICK_TIME_LIMIT
+    }
+})

--- a/web-client/src/components/draft/DraftPickOverlay.tsx
+++ b/web-client/src/components/draft/DraftPickOverlay.tsx
@@ -113,6 +113,7 @@ function DraftPicker({ draftState, settings }: { draftState: DraftState; setting
 
   // Auto-submit selected cards when timer expires (before server auto-picks first N)
   useEffect(() => {
+    // `timeRemaining === null` is the no-time-limit draft — never auto-submit there.
     if (draftState.timeRemaining === 0 && draftState.currentPack.length > 0) {
       // Fill remaining slots with unselected cards from the pack
       const picks = [...selectedCards]
@@ -130,8 +131,8 @@ function DraftPicker({ draftState, settings }: { draftState: DraftState; setting
     }
   }, [draftState.timeRemaining, draftState.currentPack, selectedCards, picksRequired, makePick])
 
-  // Timer warning threshold
-  const timerWarning = draftState.timeRemaining <= 10
+  // Timer warning threshold. An untimed draft never warns.
+  const timerWarning = draftState.timeRemaining !== null && draftState.timeRemaining <= 10
 
   // Group picked cards by color for sidebar, with counts for duplicates
   const pickedByColor = useMemo(() => {
@@ -689,7 +690,8 @@ function PackStackIcon({ count }: { count: number }) {
   )
 }
 
-function Timer({ seconds, warning }: { seconds: number; warning: boolean }) {
+/** The pick clock. `seconds === null` is an untimed draft, shown as an infinity badge. */
+function Timer({ seconds, warning }: { seconds: number | null; warning: boolean }) {
   const [pulse, setPulse] = useState(false)
 
   useEffect(() => {
@@ -722,8 +724,9 @@ function Timer({ seconds, warning }: { seconds: number; warning: boolean }) {
         textAlign: 'center',
         transition: 'background-color 0.2s',
       }}
+      title={seconds === null ? 'No time limit — take as long as you like' : undefined}
     >
-      {formatTime(seconds)}
+      {seconds === null ? '\u221e' : formatTime(seconds)}
     </div>
   )
 }

--- a/web-client/src/components/draft/GridDraftOverlay.tsx
+++ b/web-client/src/components/draft/GridDraftOverlay.tsx
@@ -236,7 +236,8 @@ function GridDrafter({ gridState, settings }: { gridState: GridDraftState; setti
     setDisplayGridNumber(gridState.gridNumber)
   }, [gridState.grid, gridState.gridNumber, gridState.lastPickedCards, displayGridNumber])
 
-  const timerWarning = gridState.timeRemaining <= 10
+  // An untimed draft (gridState.timeRemaining === null) never warns.
+  const timerWarning = gridState.timeRemaining !== null && gridState.timeRemaining <= 10
   const isMobile = responsive.isMobile
 
   const availableSet = useMemo(
@@ -367,8 +368,9 @@ function GridDrafter({ gridState, settings }: { gridState: GridDraftState; setti
             color: timerWarning ? '#e94560' : 'rgba(255,255,255,0.7)',
             fontVariantNumeric: 'tabular-nums',
             animation: timerWarning ? 'pulse 1s infinite' : undefined,
-          }}>
-            {gridState.timeRemaining}s
+          }}
+          title={gridState.timeRemaining === null ? 'No time limit — take as long as you like' : undefined}>
+            {gridState.timeRemaining === null ? '\u221e' : `${gridState.timeRemaining}s`}
           </div>
 
           {/* Deck remaining */}

--- a/web-client/src/components/draft/WinstonDraftOverlay.tsx
+++ b/web-client/src/components/draft/WinstonDraftOverlay.tsx
@@ -79,7 +79,8 @@ function WinstonDrafter({ winstonState, settings }: { winstonState: WinstonDraft
     }
   }, [resetDfcFlip])
 
-  const timerWarning = winstonState.timeRemaining <= 10
+  // An untimed draft (winstonState.timeRemaining === null) never warns.
+  const timerWarning = winstonState.timeRemaining !== null && winstonState.timeRemaining <= 10
 
   // Group picked cards by color for sidebar
   const pickedByColor = useMemo(() => {
@@ -165,8 +166,9 @@ function WinstonDrafter({ winstonState, settings }: { winstonState: WinstonDraft
             color: timerWarning ? '#e94560' : 'rgba(255,255,255,0.7)',
             fontVariantNumeric: 'tabular-nums',
             animation: timerWarning ? 'pulse 1s infinite' : undefined,
-          }}>
-            {winstonState.timeRemaining}s
+          }}
+          title={winstonState.timeRemaining === null ? 'No time limit — take as long as you like' : undefined}>
+            {winstonState.timeRemaining === null ? '\u221e' : `${winstonState.timeRemaining}s`}
           </div>
 
           {/* Deck remaining */}

--- a/web-client/src/components/lobby/TournamentLobbySettings.tsx
+++ b/web-client/src/components/lobby/TournamentLobbySettings.tsx
@@ -21,6 +21,7 @@ import { SettingsLabel } from '../ui/SettingsLabel'
 import { COMMANDER_PRESETS, effectiveCommanderPreset } from './axes'
 import type { UnifiedLobbyView } from './lobbyViewModel'
 import type { GroupId } from './settingsGroups'
+import { PICK_TIME_OPTIONS, pickTimeLabel } from './pickTime'
 import styles from '../ui/GameUI.module.css'
 
 /**
@@ -363,13 +364,13 @@ export function TournamentLobbySettings({
       {/* Draft timing and pick size. */}
       {group === 'CARDS' && isAnyDraft && (
         <div className={styles.settingsRow}>
-          <span className={styles.settingsLabel}>{isWinston ? 'Turn timer (seconds)' : 'Pick timer (seconds)'}</span>
+          <span className={styles.settingsLabel}>{isWinston ? 'Turn timer' : 'Pick timer'}</span>
           <select
             value={s.pickTimeSeconds}
             onChange={(e) => updateLobbySettings({ pickTimeSeconds: Number(e.target.value) })}
             className={styles.settingsSelect}
           >
-            {[30, 45, 60, 90, 120].map((n) => <option key={n} value={n}>{n}s</option>)}
+            {PICK_TIME_OPTIONS.map((n) => <option key={n} value={n}>{pickTimeLabel(n)}</option>)}
           </select>
         </div>
       )}

--- a/web-client/src/components/lobby/lobbyRecipe.test.ts
+++ b/web-client/src/components/lobby/lobbyRecipe.test.ts
@@ -217,6 +217,13 @@ describe('validateRecipe', () => {
     expect(out?.recipe.settings.gamesPerMatch).toBe(5)
   })
 
+  it('lets a pick time of exactly 0 through as the no-time-limit setting', () => {
+    // 0 is a sentinel, not an out-of-range duration: clamping it up to 10s would silently
+    // re-arm the pick timer on an untimed draft.
+    const out = validateRecipe({ ...base, settings: { pickTimeSeconds: 0 } }, ctx)
+    expect(out?.recipe.settings.pickTimeSeconds).toBe(0)
+  })
+
   it('discards settings of the wrong type rather than forwarding them', () => {
     const out = validateRecipe({
       ...base,

--- a/web-client/src/components/lobby/lobbyRecipe.ts
+++ b/web-client/src/components/lobby/lobbyRecipe.ts
@@ -57,6 +57,7 @@ import {
   type Selection,
 } from './modeMatrix'
 import type { UnifiedLobbyView } from './lobbyViewModel'
+import { NO_PICK_TIME_LIMIT } from './pickTime'
 
 /**
  * Bumped when the stored shape changes incompatibly. Unknown versions are **dropped on read, never
@@ -403,7 +404,13 @@ function trimSettings(
   }
 
   if (raw.boosterCount !== undefined) out.boosterCount = clampInt(raw.boosterCount, 1, 16, 6)
-  if (raw.pickTimeSeconds !== undefined) out.pickTimeSeconds = clampInt(raw.pickTimeSeconds, 10, 300, 45)
+  // Exactly 0 is the "no time limit" sentinel and survives the clamp; everything else is
+  // pinned to a usable window.
+  if (raw.pickTimeSeconds !== undefined) {
+    out.pickTimeSeconds = raw.pickTimeSeconds === NO_PICK_TIME_LIMIT
+      ? NO_PICK_TIME_LIMIT
+      : clampInt(raw.pickTimeSeconds, 10, 300, 45)
+  }
   if (raw.picksPerRound !== undefined) out.picksPerRound = clampInt(raw.picksPerRound, 1, 2, 1)
   if (raw.gamesPerMatch !== undefined) out.gamesPerMatch = clampInt(raw.gamesPerMatch, 1, 5, 1)
   if (raw.deckSizeMin !== undefined) out.deckSizeMin = clampInt(raw.deckSizeMin, 40, 100, 60)

--- a/web-client/src/components/lobby/lobbyViewModel.ts
+++ b/web-client/src/components/lobby/lobbyViewModel.ts
@@ -28,6 +28,7 @@ import {
   type CardsKind,
 } from './axes'
 import type { GroupId } from './settingsGroups'
+import { pickTimePhrase } from './pickTime'
 
 /** Which server implementation is backing this lobby. */
 export type LobbyKind = 'QUICK' | 'TOURNAMENT'
@@ -500,12 +501,12 @@ function tournamentSubtitle(lobbyState: LobbyState): string {
     const pool = (() => {
       switch (s.format) {
         case 'GRID_DRAFT':
-          return `Grid Draft · ${s.boosterCount} boosters · ${s.pickTimeSeconds}s per pick`
+          return `Grid Draft · ${s.boosterCount} boosters · ${pickTimePhrase(s.pickTimeSeconds, 'pick')}`
         case 'WINSTON_DRAFT':
-          return `Winston Draft · ${distText ?? `${s.boosterCount} boosters`} · ${s.pickTimeSeconds}s per turn`
+          return `Winston Draft · ${distText ?? `${s.boosterCount} boosters`} · ${pickTimePhrase(s.pickTimeSeconds, 'turn')}`
         case 'COMMANDER_DRAFT':
         case 'DRAFT':
-          return `${distText ?? `${s.boosterCount} packs`} · ${s.pickTimeSeconds}s per pick${pick2}`
+          return `${distText ?? `${s.boosterCount} packs`} · ${pickTimePhrase(s.pickTimeSeconds, 'pick')}${pick2}`
         case 'COMMANDER_SEALED':
           return `${distText ?? `${s.boosterCount} packs`}`
         case 'PREMADE_DECKS':

--- a/web-client/src/components/lobby/pickTime.test.ts
+++ b/web-client/src/components/lobby/pickTime.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { NO_PICK_TIME_LIMIT, PICK_TIME_OPTIONS, pickTimeChip, pickTimeLabel, pickTimePhrase } from './pickTime'
+
+describe('pick timer settings', () => {
+  it('offers the untimed option last, after the real durations', () => {
+    expect(PICK_TIME_OPTIONS).toContain(NO_PICK_TIME_LIMIT)
+    expect(PICK_TIME_OPTIONS[PICK_TIME_OPTIONS.length - 1]).toBe(NO_PICK_TIME_LIMIT)
+    // Every other option is a usable duration — a stray 0 elsewhere would render as "No limit".
+    expect(PICK_TIME_OPTIONS.slice(0, -1).every((n) => n > 0)).toBe(true)
+  })
+
+  it('names the untimed setting rather than showing it as zero seconds', () => {
+    expect(pickTimeLabel(NO_PICK_TIME_LIMIT)).toBe('No limit')
+    expect(pickTimeChip(NO_PICK_TIME_LIMIT)).toBe('no timer')
+    expect(pickTimePhrase(NO_PICK_TIME_LIMIT, 'pick')).toBe('no pick timer')
+    expect(pickTimePhrase(NO_PICK_TIME_LIMIT, 'turn')).toBe('no turn timer')
+  })
+
+  it('renders a real duration as seconds', () => {
+    expect(pickTimeLabel(45)).toBe('45s')
+    expect(pickTimeChip(45)).toBe('45s')
+    expect(pickTimePhrase(45, 'pick')).toBe('45s per pick')
+    expect(pickTimePhrase(90, 'turn')).toBe('90s per turn')
+  })
+})

--- a/web-client/src/components/lobby/pickTime.ts
+++ b/web-client/src/components/lobby/pickTime.ts
@@ -1,0 +1,29 @@
+/**
+ * The draft pick timer, and its "no time limit" setting.
+ *
+ * A `pickTimeSeconds` of exactly {@link NO_PICK_TIME_LIMIT} means the draft runs no timer at
+ * all: the server never starts a countdown and never auto-picks, so players take as long as
+ * they like. On the wire that shows up as a `null` `timeRemainingSeconds` rather than a `0`,
+ * so no client can read an untimed pick as "out of time".
+ */
+
+/** Sentinel `pickTimeSeconds` value meaning the draft has no pick timer. */
+export const NO_PICK_TIME_LIMIT = 0
+
+/** Pick-timer choices offered in lobby settings, in menu order. */
+export const PICK_TIME_OPTIONS: readonly number[] = [30, 45, 60, 90, 120, NO_PICK_TIME_LIMIT]
+
+/** Menu label for one option — `"45s"`, or `"No limit"` for the untimed setting. */
+export function pickTimeLabel(seconds: number): string {
+  return seconds === NO_PICK_TIME_LIMIT ? 'No limit' : `${seconds}s`
+}
+
+/** Compact summary-chip text — `"45s"`, or `"no timer"` for the untimed setting. */
+export function pickTimeChip(seconds: number): string {
+  return seconds === NO_PICK_TIME_LIMIT ? 'no timer' : `${seconds}s`
+}
+
+/** Sentence fragment — `"45s per pick"`, or `"no pick timer"` for the untimed setting. */
+export function pickTimePhrase(seconds: number, unit: 'pick' | 'turn'): string {
+  return seconds === NO_PICK_TIME_LIMIT ? `no ${unit} timer` : `${seconds}s per ${unit}`
+}

--- a/web-client/src/components/lobby/settingsGroups.ts
+++ b/web-client/src/components/lobby/settingsGroups.ts
@@ -53,6 +53,7 @@ import {
   tableTopicId,
 } from './axes'
 import type { UnifiedLobbyView } from './lobbyViewModel'
+import { pickTimeChip } from './pickTime'
 
 export type GroupId = 'CARDS' | 'RULES' | 'TABLE' | 'EVENT' | 'LOBBY'
 
@@ -97,7 +98,7 @@ export function groupSummary(id: GroupId, view: UnifiedLobbyView, lobbyState: Lo
         else if (s.setCodes.length > 0) parts.push(s.setNames.join(' + ') || s.setCodes.join(' + '))
         else if (s.format !== 'PREMADE_DECKS') parts.push('no sets yet')
         if (usesBoosters(s.format)) parts.push(`${s.boosterCount} ${countsPacks(s.format) ? 'packs' : 'boosters'}`)
-        if (isAnyDraft(s.format)) parts.push(`${s.pickTimeSeconds}s`)
+        if (isAnyDraft(s.format)) parts.push(pickTimeChip(s.pickTimeSeconds))
         if (s.picksPerRound === 2) parts.push('pick 2')
         if (s.bannedCardNames.length > 0) parts.push(`${s.bannedCardNames.length} banned`)
       }

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -580,7 +580,8 @@ export interface DraftState {
   packNumber: number
   pickNumber: number
   pickedCards: readonly SealedCardInfo[]
-  timeRemaining: number
+  /** Seconds left to pick, or `null` when the draft has no time limit. */
+  timeRemaining: number | null
   passDirection: 'LEFT' | 'RIGHT'
   picksPerRound: number
   queuedPacks: number
@@ -608,7 +609,8 @@ export interface WinstonDraftState {
   knownOpponentCards: readonly SealedCardInfo[]
   unknownOpponentCardCount: number
   lastAction: string | null
-  timeRemaining: number
+  /** Seconds left to pick, or `null` when the draft has no time limit. */
+  timeRemaining: number | null
   lastPickedCards: readonly SealedCardInfo[]
 }
 
@@ -625,7 +627,8 @@ export interface GridDraftState {
   pickedCardsByOthers: Record<string, readonly SealedCardInfo[]>
   lastPickedCards: readonly SealedCardInfo[]
   lastAction: string | null
-  timeRemaining: number
+  /** Seconds left to pick, or `null` when the draft has no time limit. */
+  timeRemaining: number | null
   availableSelections: readonly string[]
   playerOrder: readonly string[]
   currentPickerIndex: number

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1547,7 +1547,8 @@ export interface DraftPackReceivedMessage {
   readonly packNumber: number
   readonly pickNumber: number
   readonly cards: readonly SealedCardInfo[]
-  readonly timeRemainingSeconds: number
+  /** Seconds left to pick, or `null` when the draft has no time limit. */
+  readonly timeRemainingSeconds: number | null
   readonly passDirection: 'LEFT' | 'RIGHT'
   readonly picksPerRound: number  // Cards to pick this round (1 or 2)
   readonly pickedCards?: readonly SealedCardInfo[]  // Cards already picked (for reconnect)
@@ -1610,7 +1611,8 @@ export interface WinstonDraftStateMessage {
   readonly knownOpponentCards: readonly SealedCardInfo[]
   readonly unknownOpponentCardCount: number
   readonly lastAction: string | null
-  readonly timeRemainingSeconds: number
+  /** Seconds left to pick, or `null` when the draft has no time limit. */
+  readonly timeRemainingSeconds: number | null
   readonly lastPickedCards: readonly SealedCardInfo[]
 }
 
@@ -1632,7 +1634,8 @@ export interface GridDraftStateMessage {
   readonly totalPickedByOthers: Record<string, number>
   readonly pickedCardsByOthers: Record<string, readonly SealedCardInfo[]>
   readonly lastAction: string | null
-  readonly timeRemainingSeconds: number
+  /** Seconds left to pick, or `null` when the draft has no time limit. */
+  readonly timeRemainingSeconds: number | null
   /** Available row/column selections (e.g., ["ROW_0", "COL_1"]) */
   readonly availableSelections: readonly string[]
   /** Player names in pick order */


### PR DESCRIPTION
Adds **"No limit"** to the pick/turn timer setting on every draft format — booster, Commander, Winston and Grid. The host picks it in lobby settings like any other duration; the draft then runs no countdown at all and nothing is ever auto-picked, so players take as long as they like.

## The shape

**One field, not a new flag.** `TournamentLobby.NO_PICK_TIME_LIMIT == 0` is a value of the existing `pickTimeSeconds`, so persistence, the lobby settings message and the shareable lobby recipe carry the setting for free — no new column, no new wire field, no new axis in the settings UI.

**The two clamps disagreed.** The field was pinned `15..120` on create and `15..180` on update. Both now go through one `TournamentLobby.clampPickTimeSeconds`, which lets the sentinel through untouched and still pins every real duration. Clamping `0` up to the 15s floor would have silently re-armed the timer on a draft the host deliberately made untimed — a negative is still a malformed duration and still clamps to the floor.

**`timeRemainingSeconds` goes nullable on the wire.** This is the load-bearing half. `DraftPickOverlay` auto-submits the player's selection the moment `timeRemaining` hits `0`, so an untimed draft encoded as `0` would have picked the whole pack instantly on every client. `null` reads as "no clock" everywhere instead — shown as an ∞ badge with a tooltip, and it never trips the 10-second warning styling. Making it nullable is also what made the TS compiler point at every read site rather than leaving one to be found by hand.

Server-side, no timer job is started at all for an untimed draft, in all three handlers — so there is no auto-pick coroutine in existence to fire.

## Trade-off worth knowing

With no timer, a human who disconnects mid-draft stalls their table until they return or leave the lobby; the timer previously auto-picked for them. That is inherent to the setting rather than a bug in it. AI seats are unaffected — they pick from their own callbacks, not the clock.

## Verification

- `just test-server` — green, including the new `DraftPickTimeLimitTest` (5/5: the no-timer gate, the clamp's sentinel-vs-duration split, persistence round-trip, and the broadcast settings payload).
- `npm run typecheck` and `npm run test` in `web-client` — green, 822 tests across 57 files, including the new `pickTime.test.ts` and a `lobbyRecipe` case pinning that a recipe's `pickTimeSeconds: 0` is not clamped back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSMBkNeAf4UFSmsFbuBAmU
