### PR TITLE
Add Crown of Convergence with library-top references

### DIFF
--- a/backlog/sets/ravnica-city-of-guilds/cards.md
+++ b/backlog/sets/ravnica-city-of-guilds/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 291 cards
 **Release Date:** October 7, 2005
-**Implemented:** 274 / 291
+**Implemented:** 275 / 291
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 37    | 33   |
@@ -11,7 +11,7 @@
 | Red        | 39    | 38   |
 | Green      | 37    | 37   |
 | Multicolor | 64    | 57   |
-| Artifact   | 21    | 17   |
+| Artifact   | 21    | 18   |
 | Land       | 17    | 17   |
 
 > Verify status anytime with `scripts/card-status --set RAV` (and `--list`). That command's count is authoritative — keep this file's `Implemented:` line in sync (`just fix-backlog`) as boxes are checked. The set's mechanics are catalogued in [`mechanics.md`](mechanics.md).
@@ -288,7 +288,7 @@
 - [x] Boros Signet
 - [x] Bottled Cloister
 - [x] Cloudstone Curio
-- [ ] Crown of Convergence
+- [x] Crown of Convergence
 - [x] Cyclopean Snare
 - [x] Dimir Signet
 - [x] Glass Golem

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -13470,3 +13470,24 @@ resolution executor is introduced. The existing Yes/No decision belongs to the
 drawing player, and its source identifies the public graveyard card. The client
 keyword label is `DREDGE`. The mtgish emitter preserves the numeric argument through
 `KeywordAbility.dredge(N)`; unsupported numeric shapes remain scaffolded.
+
+### Live library-top references
+
+`EntityReference.LibraryTop(player = Player.You)` reads the current top card of the named
+player's library for relational filters and dynamic amounts. `EffectTarget.LibraryTop(player)`
+is the matching effect/condition target: compose `Conditions.EntityMatches` with any card filter,
+or pass it to an ordinary zone-moving effect. Both resolve at evaluation time and return no entity
+for an empty library; they never use last-known information or reveal the card by themselves.
+Single-player `Player` references use the normal player resolver; group references resolve to no entity.
+During filter and condition projection, the source controller comes from the intermediate projection.
+
+Crown of Convergence combines `RevealTopOfLibrary`, a creature-card condition, `ModifyStats` with
+`sharingColorWith(EntityReference.LibraryTop())`, and `PutOnBottomOfLibrary`. The bonus follows
+changes to the top card, control, and projected creature colors, and never grants more than +1/+1
+for sharing multiple colors. A colorless card shares no colors.
+
+Continuous group filters also support `SharesColorWith(reference)`, including inside `And`, `Or`,
+and `Not`. They delegate that relational comparison to the shared predicate evaluator with an
+intermediate projection, preserving colorless results instead of falling back to printed colors.
+Public library-reveal statics follow projected control, so stealing a reveal source switches which
+player's top card is visible.

--- a/manual-scenarios/cards/c/crown-of-convergence.json
+++ b/manual-scenarios/cards/c/crown-of-convergence.json
@@ -1,0 +1,68 @@
+{
+  "player1Name": "Crown controller",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {
+        "name": "Crown of Convergence"
+      },
+      {
+        "name": "Watchwolf"
+      },
+      {
+        "name": "Courier Hawk"
+      },
+      {
+        "name": "Glass Golem"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Watchwolf",
+      "Glass Golem",
+      "Giant Growth",
+      "Courier Hawk",
+      "Forest"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Disenchant"
+    ],
+    "battlefield": [
+      {
+        "name": "Watchwolf"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/EntityMatchesCondition.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/EntityMatchesCondition.kt
@@ -38,6 +38,7 @@ import kotlinx.serialization.Serializable
  * - [EffectTarget.DiscardedAsCost] — a card discarded to pay this spell's additional discard cost;
  *   **resolution-only**, matched against that card's graveyard characteristics (CR 608.2), where it
  *   lives by the time the spell resolves (Grab the Prize, via `Conditions.DiscardedCardMatches`).
+ * - [EffectTarget.LibraryTop] — the current library top; dual-mode, false for an empty library.
  * - [EffectTarget.LinkedExiledCard] — a card exiled with the source (its imprint / "exiled with
  *   this" pile); **dual-mode**, matched against that card's printed characteristics in exile. This
  *   is what lets a [com.wingedsheep.sdk.scripting.ConditionalStaticAbility] be gated on the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/EffectTarget.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/EffectTarget.kt
@@ -14,6 +14,13 @@ import kotlinx.serialization.Serializable
 sealed interface EffectTarget {
     val description: String
 
+    /** The current top card of a player's library; absent when that library is empty. */
+    @SerialName("LibraryTop")
+    @Serializable
+    data class LibraryTop(val player: Player = Player.You) : EffectTarget {
+        override val description: String = "the top card of ${player.possessive} library"
+    }
+
     /** The controller of the source ability */
     @SerialName("Controller")
     @Serializable

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityReference.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityReference.kt
@@ -22,6 +22,13 @@ sealed interface EntityReference {
         override val description: String = "it"
     }
 
+    /** The current top card of a player's library; absent when that library is empty. */
+    @SerialName("LibraryTop")
+    @Serializable
+    data class LibraryTop(val player: Player = Player.You) : EntityReference {
+        override val description: String = "the top card of ${player.possessive} library"
+    }
+
     /** A cast-time target by index. */
     @SerialName("Target")
     @Serializable

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -1218,6 +1218,7 @@ object CardLinter {
         "ContextTarget",
         "TriggeringEntity",
         "DiscardedAsCost",
+        "LibraryTop",
         "LinkedExiledCard",
     )
 

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/LibraryTopSerializationTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/LibraryTopSerializationTest.kt
@@ -1,0 +1,27 @@
+package com.wingedsheep.sdk.serialization
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Condition
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.EntityReference
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+
+class LibraryTopSerializationTest : FunSpec({
+    test("library-top references compose with filters, conditions, and zone effects") {
+        val reference: EntityReference = EntityReference.LibraryTop(Player.AnOpponent)
+        val json = CardSerialization.json
+        json.decodeFromString<EntityReference>(json.encodeToString(reference)) shouldBe reference
+        val condition = Conditions.EntityMatches(EffectTarget.LibraryTop(),
+            GameObjectFilter.Creature.sharingColorWith(reference))
+        json.decodeFromString<Condition>(json.encodeToString(condition)) shouldBe condition
+        val effect = Effects.PutOnBottomOfLibrary(EffectTarget.LibraryTop(Player.AnOpponent))
+        json.decodeFromString<Effect>(json.encodeToString(effect)) shouldBe effect
+    }
+})

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/CrownOfConvergence.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/CrownOfConvergence.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.RevealTopOfLibrary
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+val CrownOfConvergence = card("Crown of Convergence") {
+    manaCost = "{2}"
+    colorIdentity = "GW"
+    typeLine = "Artifact"
+    oracleText = "Play with the top card of your library revealed.\nAs long as the top card of your library is a creature card, creatures you control that share a color with that card get +1/+1.\n{G}{W}: Put the top card of your library on the bottom of your library."
+
+    staticAbility { ability = RevealTopOfLibrary }
+
+    staticAbility {
+        condition = Conditions.EntityMatches(EffectTarget.LibraryTop(), GameObjectFilter.Creature)
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl()
+                .sharingColorWith(EntityReference.LibraryTop()))
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{G}{W}")
+        effect = Effects.PutOnBottomOfLibrary(EffectTarget.LibraryTop())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "258"
+        artist = "Jen Page"
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c1b9f8c8-2927-4746-a540-dd3853b9a00e.jpg?1783943600"
+        ruling("2013-04-15", "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities.")
+        ruling("2013-04-15", "If the top card of your library changes while you're casting a spell, playing a land, or activating an ability, the new top card won't be revealed until you finish doing so.")
+        ruling("2013-04-15", "When playing with the top card of your library revealed, if an effect tells you to draw several cards, reveal each one before you draw it.")
+        ruling("2005-10-01", "A colorless creature on top of your library never gives a bonus, and a colorless creature on the battlefield never gets a bonus.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CrownOfConvergenceScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CrownOfConvergenceScenarioTest.kt
@@ -1,0 +1,157 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.effects.permanent.types.ChangeColorExecutor
+import com.wingedsheep.engine.handlers.effects.permanent.control.GainControlExecutor
+import com.wingedsheep.sdk.scripting.effects.ChangeColorEffect
+import com.wingedsheep.sdk.scripting.effects.GainControlEffect
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.ClientStateTransformer
+import com.wingedsheep.mtg.sets.definitions.rav.cards.CrownOfConvergence
+import com.wingedsheep.mtg.sets.definitions.rav.cards.Watchwolf
+import com.wingedsheep.mtg.sets.definitions.rav.cards.CourierHawk
+import com.wingedsheep.mtg.sets.definitions.rav.cards.GlassGolem
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.EntityReference
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+
+class CrownOfConvergenceScenarioTest : FunSpec({
+    fun driver() = GameTestDriver().apply {
+        registerCards(TestCards.all + listOf(CrownOfConvergence, Watchwolf, CourierHawk, GlassGolem))
+        initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("multicolor top gives one bonus to each matching creature you control") {
+        val d = driver()
+        d.putCreatureOnBattlefield(d.player1, "Crown of Convergence")
+        val wolf = d.putCreatureOnBattlefield(d.player1, "Watchwolf")
+        val hawk = d.putCreatureOnBattlefield(d.player1, "Courier Hawk")
+        val golem = d.putCreatureOnBattlefield(d.player1, "Glass Golem")
+        val enemy = d.putCreatureOnBattlefield(d.player2, "Watchwolf")
+        d.putCardOnTopOfLibrary(d.player1, "Watchwolf")
+        d.state.projectedState.getPower(wolf) shouldBe 4
+        d.state.projectedState.getToughness(wolf) shouldBe 4
+        d.state.projectedState.getPower(hawk) shouldBe 2
+        d.state.projectedState.getPower(golem) shouldBe 6
+        d.state.projectedState.getPower(enemy) shouldBe 3
+    }
+
+    test("noncreature and colorless tops give no bonus and changing top updates immediately") {
+        val d = driver()
+        d.putCreatureOnBattlefield(d.player1, "Crown of Convergence")
+        val wolf = d.putCreatureOnBattlefield(d.player1, "Watchwolf")
+        val golem = d.putCreatureOnBattlefield(d.player1, "Glass Golem")
+        d.putCardOnTopOfLibrary(d.player1, "Giant Growth")
+        d.state.projectedState.getPower(wolf) shouldBe 3
+        d.putCardOnTopOfLibrary(d.player1, "Watchwolf")
+        d.state.projectedState.getPower(wolf) shouldBe 4
+        d.putCardOnTopOfLibrary(d.player1, "Glass Golem")
+        d.state.projectedState.getPower(wolf) shouldBe 3
+        d.state.projectedState.getPower(golem) shouldBe 6
+    }
+
+    test("activation moves the resolution-time top to bottom even after Crown leaves") {
+        val d = driver()
+        val crown = d.putCreatureOnBattlefield(d.player1, "Crown of Convergence")
+        val original = d.putCardOnTopOfLibrary(d.player1, "Watchwolf")
+        d.giveMana(d.player1, Color.GREEN)
+        d.giveMana(d.player1, Color.WHITE)
+        d.submitSuccess(ActivateAbility(d.player1, crown, CrownOfConvergence.activatedAbilities.single().id))
+        val newTop = d.putCardOnTopOfLibrary(d.player1, "Courier Hawk")
+        d.moveToGraveyard(crown)
+        d.bothPass()
+        d.state.getLibrary(d.player1).last() shouldBe newTop
+        d.state.getLibrary(d.player1).first() shouldBe original
+    }
+
+    test("empty library has no matching card and activation still resolves") {
+        val d = driver()
+        val crown = d.putCreatureOnBattlefield(d.player1, "Crown of Convergence")
+        val wolf = d.putCreatureOnBattlefield(d.player1, "Watchwolf")
+        d.replaceState(d.state.copy(zones = d.state.zones + (ZoneKey(d.player1, Zone.LIBRARY) to emptyList())))
+        d.state.projectedState.getPower(wolf) shouldBe 3
+        val ctx = EffectContext(controllerId = d.player1, sourceId = crown)
+        TargetResolutionUtils.resolveEntityReference(EntityReference.LibraryTop(), ctx, d.state) shouldBe null
+        d.giveMana(d.player1, Color.GREEN)
+        d.giveMana(d.player1, Color.WHITE)
+        d.submitSuccess(ActivateAbility(d.player1, crown, CrownOfConvergence.activatedAbilities.single().id))
+        d.bothPass()
+        d.state.getLibrary(d.player1) shouldBe emptyList()
+    }
+
+    test("top card is public to both seats and reveal ends when Crown leaves") {
+        val d = driver()
+        val crown = d.putCreatureOnBattlefield(d.player1, "Crown of Convergence")
+        val top = d.putCardOnTopOfLibrary(d.player1, "Watchwolf")
+        val hidden = d.putCardOnTopOfLibrary(d.player2, "Courier Hawk")
+        val transformer = ClientStateTransformer(cardRegistry = d.cardRegistry)
+        for (viewer in listOf(d.player1, d.player2)) {
+            val view = transformer.transform(d.state, viewingPlayerId = viewer)
+            view.cards.keys shouldContain top
+            view.cards.keys shouldNotContain hidden
+        }
+        d.moveToGraveyard(crown)
+        transformer.transform(d.state, viewingPlayerId = d.player2).cards.keys shouldNotContain top
+    }
+
+    test("the bonus reads projected colors and stops when Crown leaves") {
+        val d = driver()
+        val crown = d.putCreatureOnBattlefield(d.player1, "Crown of Convergence")
+        val hawk = d.putCreatureOnBattlefield(d.player1, "Courier Hawk")
+        d.putCardOnTopOfLibrary(d.player1, "Watchwolf")
+        d.state.projectedState.getPower(hawk) shouldBe 2
+        val context = EffectContext(controllerId = d.player1, sourceId = crown)
+        d.replaceState(ChangeColorExecutor().execute(d.state,
+            ChangeColorEffect(target = EffectTarget.SpecificEntity(hawk), colors = setOf("BLUE")), context).state)
+        d.state.projectedState.getPower(hawk) shouldBe 1
+        d.replaceState(ChangeColorExecutor().execute(d.state,
+            ChangeColorEffect(target = EffectTarget.SpecificEntity(hawk), colors = setOf("GREEN")), context).state)
+        d.state.projectedState.getPower(hawk) shouldBe 2
+        d.moveToGraveyard(crown)
+        d.state.projectedState.getPower(hawk) shouldBe 1
+    }
+
+    test("stealing Crown switches both the library reference and the creatures receiving the bonus") {
+        val d = driver()
+        val crown = d.putCreatureOnBattlefield(d.player1, "Crown of Convergence")
+        val mine = d.putCreatureOnBattlefield(d.player1, "Watchwolf")
+        val theirs = d.putCreatureOnBattlefield(d.player2, "Courier Hawk")
+        val oldTop = d.putCardOnTopOfLibrary(d.player1, "Glass Golem")
+        val top = d.putCardOnTopOfLibrary(d.player2, "Watchwolf")
+        d.replaceState(GainControlExecutor().execute(d.state,
+            GainControlEffect(target = EffectTarget.SpecificEntity(crown)),
+            EffectContext(sourceId = null, controllerId = d.player2)).state)
+        d.state.projectedState.getPower(mine) shouldBe 3
+        d.state.projectedState.getPower(theirs) shouldBe 2
+        ClientStateTransformer(cardRegistry = d.cardRegistry)
+            .transform(d.state, viewingPlayerId = d.player1).cards.keys shouldContain top
+        ClientStateTransformer(cardRegistry = d.cardRegistry)
+            .transform(d.state, viewingPlayerId = d.player2).cards.keys shouldNotContain oldTop
+    }
+
+    test("player-relative references and conditions read the same live card at resolution") {
+        val d = driver()
+        val top = d.putCardOnTopOfLibrary(d.player2, "Watchwolf")
+        val ctx = EffectContext(sourceId = null, controllerId = d.player1)
+        TargetResolutionUtils.resolveEntityReference(EntityReference.LibraryTop(Player.AnOpponent), ctx, d.state) shouldBe top
+        TargetResolutionUtils.resolveTarget(EffectTarget.LibraryTop(Player.AnOpponent), ctx, d.state) shouldBe top
+        ConditionEvaluator().evaluate(d.state,
+            Conditions.EntityMatches(EffectTarget.LibraryTop(Player.AnOpponent), GameObjectFilter.Creature), ctx) shouldBe true
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -2926,6 +2926,90 @@
     ]
 }
 
+// Crown of Convergence
+{
+    "name": "Crown of Convergence",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "Play with the top card of your library revealed.\nAs long as the top card of your library is a creature card, creatures you control that share a color with that card get +1/+1.\n{G}{W}: Put the top card of your library on the bottom of your library.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "LibraryTop",
+                    "destination": "Library",
+                    "placement": "Bottom"
+                }
+            }
+        ],
+        "staticAbilities": [
+            "RevealTopOfLibrary",
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "SharesColorWith",
+                                    "entity": "LibraryTop"
+                                }
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        }
+                    }
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "LibraryTop",
+                    "filter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "258",
+        "rarity": "RARE",
+        "artist": "Jen Page",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c1b9f8c8-2927-4746-a540-dd3853b9a00e.jpg?1783943600",
+        "rulings": [
+            {
+                "date": "2013-04-15",
+                "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
+            },
+            {
+                "date": "2013-04-15",
+                "text": "If the top card of your library changes while you're casting a spell, playing a land, or activating an ability, the new top card won't be revealed until you finish doing so."
+            },
+            {
+                "date": "2013-04-15",
+                "text": "When playing with the top card of your library revealed, if an effect tells you to draw several cards, reveal each one before you draw it."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "A colorless creature on top of your library never gives a bonus, and a colorless creature on the battlefield never gets a bonus."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Cyclopean Snare
 {
     "name": "Cyclopean Snare",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -856,6 +856,21 @@ class ConditionEvaluator(
             (ctx as? Resolution)?.let {
                 evaluateDiscardedCardFilterMatch(state, condition.filter, entity.index, it.effectContext)
             } ?: false
+        is EffectTarget.LibraryTop -> {
+            val controllerId = ctx.controllerId
+            val context = when (ctx) {
+                is Resolution -> ctx.effectContext
+                is Projection -> controllerId?.let { EffectContext(controllerId = it, sourceId = ctx.sourceId) }
+            }
+            context?.let {
+                val projected = ctx.projectedStateFor(state)
+                val cardId = com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
+                    .resolveLibraryTop(entity.player, it, state, projected)
+                cardId != null && PredicateEvaluator().matches(
+                    state, projected, cardId, condition.filter, PredicateContext.fromEffectContext(it)
+                )
+            } ?: false
+        }
         is EffectTarget.LinkedExiledCard ->
             evaluateLinkedExiledCardFilterMatch(state, condition.filter, entity.index, ctx)
         else -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -627,19 +627,19 @@ class PredicateEvaluator {
                 cmc >= predicate.min
             }
             is CardPredicate.ManaValueAtMostEntity -> {
-                val refEntityId = resolveEntityReference(state, predicate.reference, context) ?: return false
+                val refEntityId = resolveEntityReference(state, predicate.reference, context, projected) ?: return false
                 val refManaValue = state.getEntity(refEntityId)?.get<CardComponent>()?.manaValue ?: return false
                 val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
                 cmc <= refManaValue
             }
             is CardPredicate.ManaValueAtMostEntityManaSpent -> {
-                val refEntityId = resolveEntityReference(state, predicate.reference, context) ?: return false
+                val refEntityId = resolveEntityReference(state, predicate.reference, context, projected) ?: return false
                 val manaSpent = ManaSpentReader.totalSpent(state, refEntityId)
                 val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
                 cmc <= manaSpent
             }
             is CardPredicate.ManaValueAtMostColorsSpent -> {
-                val refEntityId = resolveEntityReference(state, predicate.reference, context) ?: return false
+                val refEntityId = resolveEntityReference(state, predicate.reference, context, projected) ?: return false
                 val colorsSpent = ManaSpentReader.distinctColorsSpent(state, refEntityId)
                 val cmc = if (projectedValues?.isFaceDown == true) 0 else card.manaValue
                 cmc <= colorsSpent
@@ -765,7 +765,7 @@ class PredicateEvaluator {
             }
 
             is CardPredicate.PowerGreaterThanEntity -> {
-                val refEntityId = resolveEntityReference(state, predicate.reference, context) ?: return false
+                val refEntityId = resolveEntityReference(state, predicate.reference, context, projected) ?: return false
                 val refContainer = state.getEntity(refEntityId) ?: return false
                 // Prefer projected power for the reference (layer effects, +1/+1 counters, etc.);
                 // fall back to its base printed power when projection has no entry (e.g., off-battlefield).
@@ -777,7 +777,7 @@ class PredicateEvaluator {
             }
 
             is CardPredicate.PowerAtMostEntity -> {
-                val refEntityId = resolveEntityReference(state, predicate.reference, context) ?: return false
+                val refEntityId = resolveEntityReference(state, predicate.reference, context, projected) ?: return false
                 val refContainer = state.getEntity(refEntityId) ?: return false
                 val refPower = state.projectedState.getPower(refEntityId)
                     ?: refContainer.get<CardComponent>()?.baseStats?.basePower
@@ -787,7 +787,7 @@ class PredicateEvaluator {
             }
 
             is CardPredicate.PowerLessThanEntity -> {
-                val refEntityId = resolveEntityReference(state, predicate.reference, context) ?: return false
+                val refEntityId = resolveEntityReference(state, predicate.reference, context, projected) ?: return false
                 val refContainer = state.getEntity(refEntityId) ?: return false
                 val refPower = state.projectedState.getPower(refEntityId)
                     ?: refContainer.get<CardComponent>()?.baseStats?.basePower
@@ -860,7 +860,7 @@ class PredicateEvaluator {
             }
 
             is CardPredicate.SharesCreatureTypeWith -> {
-                val referenceId = resolveEntityReference(state, predicate.entity, context) ?: return false
+                val referenceId = resolveEntityReference(state, predicate.entity, context, projected) ?: return false
                 val referenceSubtypes = projected.getSubtypes(referenceId).ifEmpty {
                     state.getEntity(referenceId)?.get<CardComponent>()?.typeLine?.subtypes?.map { it.value }?.toSet()
                         ?: emptySet()
@@ -873,7 +873,7 @@ class PredicateEvaluator {
             }
 
             is CardPredicate.SharesCardTypeWith -> {
-                val referenceId = resolveEntityReference(state, predicate.entity, context) ?: return false
+                val referenceId = resolveEntityReference(state, predicate.entity, context, projected) ?: return false
                 val referenceTypes = cardTypesOf(state, projected, referenceId, null)
                 if (referenceTypes.isEmpty()) return false
                 val entityTypes = cardTypesOf(state, projected, entityId, projectedValues?.types)
@@ -918,7 +918,7 @@ class PredicateEvaluator {
             }
 
             is CardPredicate.SharesNameWith -> {
-                val referenceId = resolveEntityReference(state, predicate.entity, context) ?: return false
+                val referenceId = resolveEntityReference(state, predicate.entity, context, projected) ?: return false
                 // Projected first so a renamed permanent (Layer 3, CR 613.1c) compares under its
                 // new name; base card data second so a reference with no projection entry — an
                 // Imprint pile's exiled card — still has a name to compare.
@@ -942,17 +942,16 @@ class PredicateEvaluator {
             }
 
             is CardPredicate.SharesColorWith -> {
-                val referenceId = resolveEntityReference(state, predicate.entity, context) ?: return false
-                val referenceColors = projected.getColors(referenceId).ifEmpty {
-                    state.getEntity(referenceId)?.get<CardComponent>()?.colors?.map { it.name }?.toSet()
-                        ?: emptySet()
-                }
+                val referenceId = resolveEntityReference(state, predicate.entity, context, projected) ?: return false
+                val referenceColors = projected.getProjectedValues(referenceId)?.colors
+                    ?: state.getEntity(referenceId)?.get<CardComponent>()?.colors?.map { it.name }?.toSet()
+                    ?: emptySet()
                 if (referenceColors.isEmpty()) return false
                 colors.any { it in referenceColors }
             }
 
             is CardPredicate.SharesManaValueWith -> {
-                val referenceId = resolveEntityReference(state, predicate.entity, context) ?: return false
+                val referenceId = resolveEntityReference(state, predicate.entity, context, projected) ?: return false
                 // Mana value is not a projected characteristic — no layer changes it — so both sides
                 // read their card component directly. That is also what lets the reference be a card
                 // outside the battlefield (an Imprint pile's exiled card).
@@ -1297,9 +1296,18 @@ class PredicateEvaluator {
     private fun resolveEntityReference(
         state: GameState,
         ref: EntityReference,
-        context: PredicateContext?
+        context: PredicateContext?,
+        projected: ProjectedState
     ): EntityId? {
         return when (ref) {
+            is EntityReference.LibraryTop -> context?.let {
+                val effectContext = EffectContext(
+                    controllerId = it.controllerId, sourceId = it.sourceId, targets = it.targets,
+                    triggeringEntityId = it.triggeringEntityId, triggeringPlayerId = it.triggeringPlayerId
+                )
+                com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
+                    .resolveLibraryTop(ref.player, effectContext, state, projected)
+            }
             is EntityReference.Source -> context?.sourceId
             // The card exiled with the source (Imprint). Resolvable here because the pile hangs off
             // the source entity, which every predicate context that names a source already knows —

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/LastKnownInformation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/LastKnownInformation.kt
@@ -47,6 +47,7 @@ fun lkiPolicyFor(reference: EntityReference): LkiPolicy = when (reference) {
     // characteristics are the printed ones. There is nothing to snapshot, and asking for a snapshot
     // would be wrong: the read must fall through to base characteristics, which is what LIVE_ONLY
     // does. The reference itself already resolves to null once the card leaves exile.
+    is EntityReference.LibraryTop,
     is EntityReference.LinkedExiledCard,
     -> LkiPolicy.LIVE_ONLY
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -56,6 +56,9 @@ object TargetResolutionUtils {
      * that need to look up attachment relationships).
      */
     fun resolveTarget(effectTarget: EffectTarget, context: EffectContext, state: GameState): EntityId? {
+        if (effectTarget is EffectTarget.LibraryTop) {
+            return resolveLibraryTop(effectTarget.player, context, state)
+        }
         if (effectTarget == EffectTarget.Self && !context.objectReferences.isSelfCurrent(state)) return null
         if (effectTarget == EffectTarget.TriggeringEntity && context.triggeringEntityId !in state.turnOrder &&
             !context.objectReferences.isCurrent(context.objectReferences.triggering, state)) return null
@@ -427,6 +430,8 @@ object TargetResolutionUtils {
      */
     fun resolveEntityReference(ref: EntityReference, context: EffectContext, state: GameState): EntityId? =
         when (ref) {
+            is EntityReference.LibraryTop ->
+                resolveLibraryTop(ref.player, context, state)
             is EntityReference.Source -> context.sourceId
             is EntityReference.EnchantedCreature ->
                 context.sourceId?.let { state.getEntity(it)?.get<AttachedToComponent>()?.targetId }
@@ -462,6 +467,19 @@ object TargetResolutionUtils {
                 com.wingedsheep.engine.handlers.effects.linkedexile.LinkedExileLookup
                     .exiledCard(state, context.sourceId, ref.index)
         }
+
+    /** Library membership is read live, without revealing the card or retaining an old top. */
+    fun resolveLibraryTop(
+        player: Player,
+        context: EffectContext,
+        state: GameState,
+        projected: com.wingedsheep.engine.mechanics.layers.ProjectedState? = null
+    ): EntityId? {
+        val playerId = if (player == Player.ControllerOfSource && projected != null) {
+            context.sourceId?.let { projected.getController(it) } ?: context.controllerId
+        } else resolvePlayerRef(player, context, state)
+        return playerId?.takeIf { it in state.turnOrder }?.let { state.getLibrary(it).firstOrNull() }
+    }
 
     /**
      * Convert a ChosenTarget to an EntityId.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
@@ -59,7 +59,8 @@ class MoveToZoneEffectExecutor(
     ): EffectResult {
         val targetId = context.resolveTarget(effect.target, state)
             ?: return if (effect.target == com.wingedsheep.sdk.scripting.targets.EffectTarget.Self ||
-                effect.target == com.wingedsheep.sdk.scripting.targets.EffectTarget.TriggeringEntity) {
+                effect.target == com.wingedsheep.sdk.scripting.targets.EffectTarget.TriggeringEntity ||
+                effect.target is com.wingedsheep.sdk.scripting.targets.EffectTarget.LibraryTop) {
                 EffectResult.success(state)
             } else EffectResult.error(state, "No valid target for move to zone")
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -300,6 +300,14 @@ internal class AffectsFilterResolver {
             state.getEntity(sourceId)?.chosenColor() ?: return emptySet()
         } else null
 
+        // Relational predicates need the source and the intermediate projection, not base cards.
+        // Build the snapshot only when such a predicate is actually encountered, once per filter.
+        val relationalProjection by lazy { buildIntermediateProjectedState(state, projectedValues) }
+        val relationalEvaluator by lazy { com.wingedsheep.engine.handlers.PredicateEvaluator() }
+        val relationalContext by lazy {
+            controller?.let { com.wingedsheep.engine.handlers.PredicateContext(controllerId = it, sourceId = sourceId) }
+        }
+
         return state.getBattlefield().filter { entityId ->
             if (groupFilter.excludeSelf && entityId == sourceId) return@filter false
 
@@ -341,6 +349,18 @@ internal class AffectsFilterResolver {
             val keywords = projected?.keywords ?: (card.baseKeywords.map { it.name } + card.baseFlags.map { it.name }).toSet()
             val isFaceDown = projected?.isFaceDown ?: container.has<FaceDownComponent>()
 
+            fun matchesPredicate(predicate: CardPredicate): Boolean = when (predicate) {
+                is CardPredicate.And -> predicate.predicates.all(::matchesPredicate)
+                is CardPredicate.Or -> predicate.predicates.any(::matchesPredicate)
+                is CardPredicate.Not -> !matchesPredicate(predicate.predicate)
+                is CardPredicate.SharesColorWith -> relationalEvaluator.matchesCardPredicate(
+                    state, relationalProjection, entityId, predicate, relationalContext
+                )
+                else -> matchesCardPredicateForProjection(
+                    predicate, card, container, projected, types, subtypes, colors, keywords, isFaceDown
+                )
+            }
+
             for (predicate in baseFilter.cardPredicates) {
                 // The source-chosen-name predicate is resolved once above (sourceChosenName) and
                 // applied as a separate constraint below — skip it in the generic projection loop,
@@ -350,7 +370,7 @@ internal class AffectsFilterResolver {
                 // separate constraint below; the generic projection has no source in scope and
                 // would fail it closed.
                 if (predicate == CardPredicate.HasChosenColor) continue
-                if (!matchesCardPredicateForProjection(predicate, card, container, projected, types, subtypes, colors, keywords, isFaceDown)) {
+                if (!matchesPredicate(predicate)) {
                     return@filter false
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
@@ -292,7 +292,7 @@ class Visibility(
         playerId: EntityId,
         predicate: (StaticAbility) -> Boolean,
     ): Boolean {
-        for (entityId in state.getBattlefield(playerId)) {
+        for (entityId in state.controlledBattlefield(playerId)) {
             val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
             if (cardDef.script.staticAbilities.any { ability ->

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LibraryTopReferenceTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LibraryTopReferenceTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.effects.permanent.types.ChangeColorExecutor
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.effects.ChangeColorEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.EntityReference
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class LibraryTopReferenceTest : FunSpec({
+    fun driver() = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+    }
+
+    test("a target-player reference uses the chosen player in effect and predicate contexts") {
+        val d = driver()
+        val top = d.putCardOnTopOfLibrary(d.player2, "Grizzly Bears")
+        val creature = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        val ctx = EffectContext(sourceId = null, controllerId = d.player1, targets = listOf(ChosenTarget.Player(d.player2)))
+        TargetResolutionUtils.resolveTarget(EffectTarget.LibraryTop(Player.TargetPlayer), ctx, d.state) shouldBe top
+        PredicateEvaluator().matches(d.state, d.state.projectedState, creature,
+            GameObjectFilter.Creature.sharingColorWith(EntityReference.LibraryTop(Player.TargetPlayer)),
+            PredicateContext.fromEffectContext(ctx)) shouldBe true
+        d.putCardOnTopOfLibrary(d.player2, "Lightning Bolt")
+        PredicateEvaluator().matches(d.state, d.state.projectedState, creature,
+            GameObjectFilter.Creature.sharingColorWith(EntityReference.LibraryTop(Player.TargetPlayer)),
+            PredicateContext.fromEffectContext(ctx)) shouldBe false
+    }
+
+    test("projection supports nested color relationships and respects a colorless reference") {
+        val d = driver()
+        val leader = card("Color leader") {
+            manaCost = "{G}"
+            typeLine = "Creature — Bear"
+            power = 2
+            toughness = 2
+            staticAbility {
+                ability = ModifyStats(1, 1, GroupFilter(GameObjectFilter.Creature.youControl().copy(
+                    cardPredicates = listOf(CardPredicate.IsCreature,
+                        CardPredicate.Or(listOf(CardPredicate.SharesColorWith(EntityReference.Source))))
+                )))
+            }
+        }
+        d.registerCards(listOf(leader))
+        val source = d.putCreatureOnBattlefield(d.player1, "Color leader")
+        val bear = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        d.state.projectedState.getPower(bear) shouldBe 3
+        d.replaceState(ChangeColorExecutor().execute(d.state,
+            ChangeColorEffect(target = EffectTarget.SpecificEntity(source), colors = emptySet()),
+            EffectContext(sourceId = source, controllerId = d.player1)).state)
+        d.state.projectedState.getPower(bear) shouldBe 2
+        d.state.projectedState.getPower(source) shouldBe 2
+    }
+
+    test("unbound and group player references do not silently choose a library") {
+        val d = driver()
+        val ctx = EffectContext(sourceId = null, controllerId = d.player1)
+        for (player in listOf(Player.TargetPlayer, Player.Each, Player.EachOpponent)) {
+            TargetResolutionUtils.resolveTarget(EffectTarget.LibraryTop(player), ctx, d.state) shouldBe null
+            TargetResolutionUtils.resolveEntityReference(EntityReference.LibraryTop(player), ctx, d.state) shouldBe null
+        }
+    }
+})


### PR DESCRIPTION
Adds **Crown of Convergence** to Ravnica: City of Guilds. Its +1/+1 bonus follows the current library top, projected creature colors, and current controller; its activation moves the resolution-time top card to the bottom. Kept this to one card because it needs new engine vocabulary.

- Add reusable `EntityReference.LibraryTop` and `EffectTarget.LibraryTop` references, including empty-library handling and condition support.
- Enable relational color comparisons in continuous group filters, preserving colorless projected results. Public library-reveal abilities now follow projected control after their source is stolen.
- Add eight Crown scenarios, three engine regression tests, serialization coverage, a manual scenario, SDK documentation, the RAV snapshot, and backlog bookkeeping (275/291).

Validation: `just test` passed (17,032 tests, 0 failures/errors, 24 skipped); `just rebless-cards` changed only Crown's snapshot; canonical-printing and backlog checks passed. Fresh Scryfall fields and the artwork URL were verified.

`just assay-differential --set RAV`: 103 compared cards agree, zero divergences or decode failures. Crown itself is declined by the grammar, so its rules behavior is verified by scenarios, not claimed as an Assay pass. No new decision UI is required; client-view tests cover public top-card visibility. A manual board is included but was not played in a browser.
