### PR TITLE
Add Needle Drop with filtered any-target support

### DIFF
--- a/backlog/sets/lorwyn/cards.md
+++ b/backlog/sets/lorwyn/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 cards
 **Release Date:** October 12, 2007
-**Implemented:** 280 / 286
+**Implemented:** 281 / 286
 | Section    | Total | Done |
 |------------|-------|------|
 | White      | 49    | 43   |
@@ -210,7 +210,7 @@
 - [x] Lash Out
 - [x] Lowland Oaf
 - [x] Mudbutton Torchrunner
-- [ ] Needle Drop
+- [x] Needle Drop
 - [x] Nova Chaser
 - [x] Rebellion of the Flamekin
 - [x] Smokebraider

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3821,7 +3821,12 @@ A resolving nonpermanent spell retains its stack instance through serialized eff
 
 ### Cast-time (`Targets.*` / `TargetRequirement`)
 
-- `Targets.Any` — any creature, player, or planeswalker.
+- `Targets.Any` — any creature, player, planeswalker, or battle.
+- `Targets.Any(filter)` — the same domain narrowed by a `GameObjectFilter`, applied to both players
+  and permanents at announcement, resolution, and retargeting. For example,
+  `Targets.Any(GameObjectFilter.Any.wasDealtDamageThisTurn())` (Needle Drop) uses damage history,
+  including combat damage and damage dealt through counters. Prevented damage and life loss do not
+  qualify. History survives removing marked damage, but resets on zone changes and turn cleanup.
 - `Targets.AnyChosenByOpponent` — "any target **of an opponent's choice**" (Cuombajj Witches). A real
   target of *your* spell/ability that an **opponent** selects: announced at the same time as your own
   targets, equally respondable, and with legality (hexproof/protection/shroud) measured relative to

--- a/e2e-scenarios/tests/lorwyn/needle-drop.spec.ts
+++ b/e2e-scenarios/tests/lorwyn/needle-drop.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '../../fixtures/scenarioFixture'
+import { cardByName, OPPONENT_BATTLEFIELD } from '../../helpers/selectors'
+
+for (const recipient of ['creature', 'player'] as const) {
+  test(`Needle Drop targets the damaged ${recipient} and draws a card`, async ({ createGame }) => {
+    test.setTimeout(60_000)
+    const { player1, player2 } = await createGame({
+      player1: {
+        hand: ['Shock', 'Needle Drop'],
+        battlefield: [{ name: 'Mountain' }, { name: 'Mountain' }],
+        library: ['Forest', 'Forest', 'Forest'],
+      },
+      player2: {
+        battlefield: [{ name: 'Hill Giant' }, { name: 'Grizzly Bears' }],
+        library: ['Forest', 'Forest', 'Forest'],
+      },
+      phase: 'PRECOMBAT_MAIN',
+      activePlayer: 1,
+    })
+    const p1 = player1.gamePage
+    await p1.selectCardInHand('Shock')
+    await p1.selectAction('Cast')
+    if (recipient === 'creature') await p1.selectTarget('Hill Giant')
+    else await p1.selectPlayer(player2.playerId)
+    await p1.confirmTargets()
+    await player2.gamePage.resolveStack('Shock')
+    await p1.expectNotInHand('Shock')
+    if (recipient === 'player') await p1.expectLifeTotal(player2.playerId, 18)
+
+    await p1.selectCardInHand('Needle Drop')
+    await p1.selectAction('Cast')
+    if (recipient === 'creature') await p1.selectTarget('Hill Giant')
+    else await p1.selectPlayer(player2.playerId)
+    await p1.confirmTargets()
+    await player2.gamePage.resolveStack('Needle Drop')
+    await p1.expectInHand('Forest')
+    if (recipient === 'creature') {
+      await p1.expectNotOnBattlefield('Hill Giant')
+      await expect(player2.page.locator(cardByName('Grizzly Bears')).first()).toBeVisible()
+    } else {
+      await p1.expectLifeTotal(player2.playerId, 17)
+      await player2.gamePage.expectLifeTotal(player2.playerId, 17)
+    }
+    await expect(player1.page.locator(OPPONENT_BATTLEFIELD).locator(cardByName('Grizzly Bears'))).toBeVisible()
+  })
+}

--- a/manual-scenarios/cards/n/needle-drop.json
+++ b/manual-scenarios/cards/n/needle-drop.json
@@ -1,0 +1,25 @@
+{
+  "player1Name": "Needle Drop",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Needle Drop", "Shock"],
+    "battlefield": [{"name": "Mountain"}, {"name": "Mountain"}],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [{"name": "Hill Giant"}],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
@@ -219,9 +219,12 @@ object Targets {
     // =========================================================================
 
     /**
-     * Any target (creature, player, or planeswalker).
+     * Any target (creature, player, planeswalker, or battle).
      */
     val Any: TargetRequirement = AnyTarget()
+
+    /** Any damageable target satisfying [filter], including player candidates. */
+    fun Any(filter: GameObjectFilter): TargetRequirement = AnyTarget(filter = filter)
 
     /**
      * "Any target of an opponent's choice" — a real target of your spell/ability that an

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
@@ -244,7 +244,7 @@ fun TargetPermanent(
 // =============================================================================
 
 /**
- * "Any target" - can target any creature, player, or planeswalker.
+ * "Any target" - can target any creature, player, planeswalker, or battle.
  */
 @SerialName("AnyTarget")
 @Serializable
@@ -254,11 +254,19 @@ data class AnyTarget(
     override val optional: Boolean = false,
     override val id: String? = null,
     override val chooser: TargetChooser = TargetChooser.Controller,
-    private val descriptionOverride: String? = null
+    private val descriptionOverride: String? = null,
+    /** Additional predicates shared by permanent and player candidates. */
+    val filter: GameObjectFilter = GameObjectFilter.Any
 ) : TargetRequirement {
+    override fun applyTextReplacement(replacer: TextReplacer): TargetRequirement {
+        val replaced = filter.applyTextReplacement(replacer)
+        return if (replaced !== filter) copy(filter = replaced) else this
+    }
+
     override val description: String = descriptionOverride
         ?: buildString {
             append(if (count == 1) "any target" else "$count targets")
+            if (filter != GameObjectFilter.Any) append(" that ${filter.description}")
             if (chooser == TargetChooser.Opponent) append(" of an opponent's choice")
         }
 }

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/targets/FilteredAnyTargetTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/targets/FilteredAnyTargetTest.kt
@@ -1,0 +1,27 @@
+package com.wingedsheep.sdk.scripting.targets
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class FilteredAnyTargetTest : FunSpec({
+    test("filtered any target round trips as a polymorphic target requirement") {
+        val requirement = Targets.Any(GameObjectFilter.Any.wasDealtDamageThisTurn())
+        Json.decodeFromString<TargetRequirement>(Json.encodeToString(requirement)) shouldBe requirement
+    }
+
+    test("unfiltered any targets retain their existing serialized shape") {
+        Json.encodeToString<TargetRequirement>(AnyTarget()) shouldBe "{\"type\":\"AnyTarget\"}"
+    }
+
+    test("naming and count changes preserve the filter") {
+        val filter = GameObjectFilter.Any.wasDealtDamageThisTurn()
+        val requirement = Targets.Any(filter).withCount(2).withId("recipients") as AnyTarget
+        requirement.filter shouldBe filter
+        requirement.count shouldBe 2
+        requirement.id shouldBe "recipients"
+    }
+})

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/NeedleDrop.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/NeedleDrop.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+val NeedleDrop = card("Needle Drop") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Needle Drop deals 1 damage to any target that was dealt damage this turn.\nDraw a card."
+
+    spell {
+        val recipient = target("target that was dealt damage this turn",
+            Targets.Any(GameObjectFilter.Any.wasDealtDamageThisTurn()))
+        effect = Effects.DealDamage(1, recipient) then Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "186"
+        artist = "Greg Staples"
+        flavorText = "\"First it was plovers and mulldrifters. Now it's knitting needles the size of javelins.\"\n—Calydd, kithkin farmer"
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d3f89bcf-46f8-4598-a949-7f10134606aa.jpg?1783942871"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NeedleDropScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NeedleDropScenarioTest.kt
@@ -1,0 +1,167 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.handlers.TargetFinder
+import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.legalactions.utils.TargetEnumerationUtils
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.battlefield.WasDealtDamageThisTurnComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class NeedleDropScenarioTest : ScenarioTestBase() {
+    private val requirement = Targets.Any(GameObjectFilter.Any.wasDealtDamageThisTurn())
+
+    private fun board() = scenario()
+        .withPlayers("Caster", "Opponent")
+        .withCardInHand(1, "Needle Drop")
+        .withCardInHand(1, "Shock")
+        .withCardInHand(1, "Unsummon")
+        .withLandsOnBattlefield(1, "Mountain", 3)
+        .withLandsOnBattlefield(1, "Island", 1)
+        .withCardOnBattlefield(2, "Hill Giant")
+        .withCardInLibrary(1, "Forest")
+        .withCardInLibrary(1, "Forest")
+        .withCardInLibrary(2, "Forest")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    private fun TestGame.damage(id: EntityId, amount: Int = 1) {
+        state = DamageUtils.dealDamageToTarget(state, id, amount, null).state
+    }
+
+    private fun TestGame.checkTargets(expected: List<EntityId> = emptyList()) {
+        val source = findCardsInHand(1, "Needle Drop").single()
+        TargetFinder().findLegalTargets(state, requirement, player1Id, source)
+            .shouldContainExactlyInAnyOrder(expected)
+        TargetEnumerationUtils(PredicateEvaluator()).findValidTargets(state, player1Id, requirement, source)
+            .shouldContainExactlyInAnyOrder(expected)
+    }
+
+    init {
+        test("no damaged targets means no legal cast, including forged undamaged player and permanent targets") {
+            val game = board()
+            game.checkTargets()
+            game.castSpellTargetingPlayer(1, "Needle Drop", 2).error shouldNotBe null
+            game.castSpell(1, "Needle Drop", game.findPermanent("Hill Giant")!!).error shouldNotBe null
+        }
+
+        for (player in listOf(1, 2)) {
+            test("damaged player $player is targetable and resolution deals one then draws") {
+                val game = board()
+                val recipient = if (player == 1) game.player1Id else game.player2Id
+                game.damage(recipient)
+                game.checkTargets(listOf(recipient))
+                game.castSpellTargetingPlayer(1, "Needle Drop", player).error shouldBe null
+                game.resolveStack()
+                game.getLifeTotal(player) shouldBe 18
+                game.isInHand(1, "Forest") shouldBe true
+            }
+        }
+
+        test("Shock damage enables a creature target and Needle Drop draws even when its damage is lethal") {
+            val game = board()
+            val giant = game.findPermanent("Hill Giant")!!
+            game.castSpell(1, "Shock", giant).error shouldBe null
+            game.resolveStack()
+            game.checkTargets(listOf(giant))
+            game.castSpell(1, "Needle Drop", giant).error shouldBe null
+            game.resolveStack()
+            game.isInGraveyard(2, "Hill Giant") shouldBe true
+            game.isInHand(1, "Forest") shouldBe true
+        }
+
+        test("removing marked damage preserves damage history") {
+            val game = board()
+            val giant = game.findPermanent("Hill Giant")!!
+            game.damage(giant)
+            game.state = game.state.updateEntity(giant) { it.without<DamageComponent>() }
+            game.checkTargets(listOf(giant))
+            game.castSpell(1, "Needle Drop", giant).error shouldBe null
+            game.resolveStack()
+            game.state.getEntity(giant)!!.get<DamageComponent>()!!.amount shouldBe 1
+        }
+
+        test("life loss and zero damage do not enable a player target") {
+            val game = board()
+            game.state = game.state.withLifeTotal(game.player2Id, 15)
+            game.damage(game.player2Id, 0)
+            game.checkTargets()
+            game.castSpellTargetingPlayer(1, "Needle Drop", 2).error shouldNotBe null
+        }
+
+        test("fully prevented damage does not enable a target") {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardInHand(1, "Needle Drop")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withCardOnBattlefield(2, "Dawn Elemental")
+                .build()
+            val elemental = game.findPermanent("Dawn Elemental")!!
+            game.damage(elemental)
+            game.checkTargets()
+            game.castSpell(1, "Needle Drop", elemental).error shouldNotBe null
+        }
+
+        test("a target removed in response makes the whole spell fail to resolve, including its draw") {
+            val game = board()
+            val giant = game.findPermanent("Hill Giant")!!
+            game.damage(giant)
+            game.castSpell(1, "Needle Drop", giant).error shouldBe null
+            game.castSpell(1, "Unsummon", giant).error shouldBe null
+            game.resolveStack()
+            game.isInHand(2, "Hill Giant") shouldBe true
+            game.isInHand(1, "Forest") shouldBe false
+            game.isInGraveyard(1, "Needle Drop") shouldBe true
+            game.state.getEntity(giant)?.has<WasDealtDamageThisTurnComponent>() shouldBe false
+        }
+
+        test("a restriction that stops holding is rechecked on resolution") {
+            val game = board()
+            game.damage(game.player2Id)
+            game.castSpellTargetingPlayer(1, "Needle Drop", 2).error shouldBe null
+            game.state = game.state.updateEntity(game.player2Id) { it.without<WasDealtDamageThisTurnComponent>() }
+            game.resolveStack()
+            game.getLifeTotal(2) shouldBe 19
+            game.isInHand(1, "Forest") shouldBe false
+        }
+
+        test("cleanup clears history for both players and permanents") {
+            val game = board()
+            val giant = game.findPermanent("Hill Giant")!!
+            game.damage(game.player2Id)
+            game.damage(giant)
+            game.checkTargets(listOf(game.player2Id, giant))
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            game.checkTargets()
+        }
+
+        test("noncombat damage to a planeswalker enables Needle Drop and removes loyalty") {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardInHand(1, "Needle Drop")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withCardOnBattlefield(2, "Jace Beleren")
+                .withCardInLibrary(1, "Forest")
+                .build()
+            val jace = game.findPermanent("Jace Beleren")!!
+            game.state = game.state.updateEntity(jace) { it.with(CountersComponent().withAdded(CounterType.LOYALTY, 5)) }
+            game.damage(jace)
+            game.checkTargets(listOf(jace))
+            game.castSpell(1, "Needle Drop", jace).error shouldBe null
+            game.resolveStack()
+            game.state.getEntity(jace)!!.get<CountersComponent>()!!.getCount(CounterType.LOYALTY) shouldBe 3
+            game.isInHand(1, "Forest") shouldBe true
+        }
+    }
+}

--- a/mtg-sets/2023/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/OjerPakpatiqDeepestEpochScenarioTest.kt
+++ b/mtg-sets/2023/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/OjerPakpatiqDeepestEpochScenarioTest.kt
@@ -125,11 +125,10 @@ class OjerPakpatiqDeepestEpochScenarioTest : ScenarioTestBase() {
 
                 val pakpatiq = game.findPermanent("Ojer Pakpatiq, Deepest Epoch")!!
 
-                repeat(2) { // 6 damage kills the 4/3
-                    game.castSpell(1, "Lightning Bolt", targetId = pakpatiq).error shouldBe null
-                    if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
-                    game.resolveStack()
-                }
+                // One Bolt kills the 4/3. After it returns as a land, it is no longer a legal Bolt target.
+                game.castSpell(1, "Lightning Bolt", targetId = pakpatiq).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
                 var guard = 0
                 while (game.findPermanent("Temple of Cyclical Time") == null && guard++ < 10) game.resolveStack()
 

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -12170,6 +12170,59 @@
     ]
 }
 
+// Needle Drop
+{
+    "name": "Needle Drop",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Needle Drop deals 1 damage to any target that was dealt damage this turn.\nDraw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target that was dealt damage this turn"
+                    }
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target that was dealt damage this turn",
+                "filter": {
+                    "statePredicates": [
+                        "WasDealtDamageThisTurn"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "artist": "Greg Staples",
+        "flavorText": "\"First it was plovers and mulldrifters. Now it's knitting needles the size of javelins.\"\n—Calydd, kithkin farmer",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d3f89bcf-46f8-4598-a949-7f10134606aa.jpg?1783942871"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Nettlevine Blight
 {
     "name": "Nettlevine Blight",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
@@ -103,7 +103,14 @@ class TargetFinder(
         return when (requirement) {
             is TargetPlayer -> findPlayerTargets(state, requirement, controllerId, sourceId)
             is TargetOpponent -> findOpponentTargets(state, requirement, controllerId, sourceId)
-            is AnyTarget -> findAnyTargets(state, controllerId, sourceId, targetingSourceType)
+            is AnyTarget -> {
+                val candidates = findAnyTargets(state, controllerId, sourceId, targetingSourceType)
+                if (requirement.filter == GameObjectFilter.Any) candidates else {
+                    val projected = state.projectedState
+                    val context = targetingContext(controllerId, sourceId, triggeringEntityId = triggeringEntityId, pipelineContext = pipelineContext)
+                    candidates.filter { predicateEvaluator.matches(state, projected, it, requirement.filter, context) }
+                }
+            }
             is TargetCreatureOrPlayer -> findCreatureOrPlayerTargets(state, controllerId, sourceId, targetingSourceType, pipelineContext)
             is TargetPermanentOrPlayer -> findPermanentOrPlayerTargets(state, requirement, controllerId, sourceId, targetingSourceType, pipelineContext)
             is TargetOpponentOrPlaneswalker -> findOpponentOrPlaneswalkerTargets(state, controllerId, sourceId, targetingSourceType)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -503,10 +503,6 @@ object DamageUtils {
                     ))
                 }
             }
-            // Mark creature as having been dealt damage this turn
-            newState = newState.updateEntity(targetId) { container ->
-                container.with(WasDealtDamageThisTurnComponent)
-            }
             // Track damage source for "creature dealt damage by this dies" triggers
             if (sourceId != null) {
                 newState = trackDamageDealtToCreature(newState, sourceId, targetId)
@@ -519,6 +515,7 @@ object DamageUtils {
             }
         }
 
+        newState = newState.updateEntity(targetId) { it.with(WasDealtDamageThisTurnComponent) }
         newState = trackDamageDealt(newState, sourceId, effectiveAmount)
         // Record the source on its controller's per-turn set of damage sources. Unlike the stamp
         // above this is not battlefield-only: a resolving burn spell is a source that dealt damage
@@ -665,6 +662,7 @@ object DamageUtils {
             val existingLifeLost = container.get<com.wingedsheep.engine.state.components.player.LifeLostAmountThisTurnComponent>()
                 ?: com.wingedsheep.engine.state.components.player.LifeLostAmountThisTurnComponent()
             var updated = container.with(com.wingedsheep.engine.state.components.player.DamageReceivedThisTurnComponent(existing.amount + amount))
+                .with(WasDealtDamageThisTurnComponent)
                 .with(com.wingedsheep.engine.state.components.player.LifeLostThisTurnComponent)
                 .with(
                     com.wingedsheep.engine.state.components.player.LifeLostAmountThisTurnComponent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ChangeSpellTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ChangeSpellTargetExecutor.kt
@@ -5,7 +5,9 @@ import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.state.components.stack.TargetsComponent
@@ -30,6 +32,7 @@ class ChangeSpellTargetExecutor : EffectExecutor<ChangeSpellTargetEffect> {
     override val effectType: KClass<ChangeSpellTargetEffect> = ChangeSpellTargetEffect::class
 
     private val decisionHandler = DecisionHandler()
+    private val targetFinder = TargetFinder()
 
     override fun execute(
         state: GameState,
@@ -74,10 +77,15 @@ class ChangeSpellTargetExecutor : EffectExecutor<ChangeSpellTargetEffect> {
 
         // 5. Find all other creatures on the battlefield as legal new targets
         val currentTargetId = singleTarget.entityId
-        val otherCreatures = state.getBattlefield()
-            .filter { entityId ->
-                entityId != currentTargetId && projected.hasType(entityId, "CREATURE")
-            }
+        val requirement = targetsComponent?.targetRequirements?.singleOrNull()
+        val spellController = spellEntity.get<ControllerComponent>()
+            ?.playerId ?: context.controllerId
+        val candidates = requirement?.let {
+            targetFinder.findLegalTargets(state, it, spellController, targetSpell.spellEntityId)
+        } ?: state.getBattlefield()
+        val otherCreatures = candidates.filter { entityId ->
+            entityId != currentTargetId && projected.isCreature(entityId)
+        }
 
         if (otherCreatures.isEmpty()) {
             // No other creatures to redirect to

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ChangeTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ChangeTargetExecutor.kt
@@ -8,7 +8,9 @@ import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.state.components.stack.TargetsComponent
@@ -35,6 +37,7 @@ class ChangeTargetExecutor : EffectExecutor<ChangeTargetEffect> {
 
     private val decisionHandler = DecisionHandler()
     private val predicateEvaluator = PredicateEvaluator()
+    private val targetFinder = TargetFinder()
 
     override fun execute(
         state: GameState,
@@ -71,7 +74,10 @@ class ChangeTargetExecutor : EffectExecutor<ChangeTargetEffect> {
         }
 
         // 3. Find all legal new targets based on target requirements
-        var legalNewTargets = findLegalNewTargets(state, currentTarget, targetRequirements, context.controllerId)
+        val spellController = stackEntity.get<ControllerComponent>()?.playerId ?: context.controllerId
+        var legalNewTargets = findLegalNewTargets(
+            state, currentTarget, targetRequirements, spellController, targetSpell.spellEntityId
+        )
 
         // "The new target must be a player" (Reflecting Mirror) — narrowed *after* the spell's own
         // requirement, so the redirect can never make an otherwise-illegal choice legal.
@@ -119,7 +125,8 @@ class ChangeTargetExecutor : EffectExecutor<ChangeTargetEffect> {
         state: GameState,
         currentTarget: ChosenTarget,
         targetRequirements: List<TargetRequirement>,
-        controllerId: EntityId
+        controllerId: EntityId,
+        sourceId: EntityId
     ): List<EntityId> {
         val projected = state.projectedState
         val currentTargetId = getTargetEntityId(currentTarget)
@@ -130,11 +137,7 @@ class ChangeTargetExecutor : EffectExecutor<ChangeTargetEffect> {
         return when {
             // AnyTarget: creatures/planeswalkers on battlefield + players
             requirement is AnyTarget -> {
-                val permanents = state.getBattlefield().filter { entityId ->
-                    projected.hasType(entityId, "CREATURE") || projected.hasType(entityId, "PLANESWALKER")
-                }
-                val players = state.turnOrder.filter { state.hasEntity(it) }
-                (permanents + players).filter { it != currentTargetId }
+                targetFinder.findLegalTargets(state, requirement, controllerId, sourceId).filter { it != currentTargetId }
             }
 
             // TargetCreatureOrPlayer: creatures on battlefield + players

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ReselectTargetRandomlyExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ReselectTargetRandomlyExecutor.kt
@@ -6,7 +6,9 @@ import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.state.components.stack.TargetsComponent
@@ -29,6 +31,7 @@ class ReselectTargetRandomlyExecutor : EffectExecutor<ReselectTargetRandomlyEffe
     override val effectType: KClass<ReselectTargetRandomlyEffect> = ReselectTargetRandomlyEffect::class
 
     private val predicateEvaluator = PredicateEvaluator()
+    private val targetFinder = TargetFinder()
 
     override fun execute(
         state: GameState,
@@ -55,7 +58,10 @@ class ReselectTargetRandomlyExecutor : EffectExecutor<ReselectTargetRandomlyEffe
         val targetRequirements = targetsComponent.targetRequirements
 
         // 3. Find all legal targets
-        val legalTargets = findLegalTargets(state, currentTarget, targetRequirements, context.controllerId)
+        val spellController = stackEntity.get<ControllerComponent>()?.playerId ?: context.controllerId
+        val legalTargets = findLegalTargets(
+            state, currentTarget, targetRequirements, spellController, triggeringEntityId
+        )
 
         if (legalTargets.isEmpty()) {
             // No legal targets at all — keep current target
@@ -112,18 +118,15 @@ class ReselectTargetRandomlyExecutor : EffectExecutor<ReselectTargetRandomlyEffe
         state: GameState,
         currentTarget: ChosenTarget,
         targetRequirements: List<TargetRequirement>,
-        controllerId: EntityId
+        controllerId: EntityId,
+        sourceId: EntityId
     ): List<EntityId> {
         val projected = state.projectedState
         val requirement = targetRequirements.firstOrNull()
 
         return when {
             requirement is AnyTarget -> {
-                val permanents = state.getBattlefield().filter { entityId ->
-                    projected.hasType(entityId, "CREATURE") || projected.hasType(entityId, "PLANESWALKER")
-                }
-                val players = state.turnOrder.filter { state.hasEntity(it) }
-                permanents + players
+                targetFinder.findLegalTargets(state, requirement, controllerId, sourceId)
             }
 
             requirement is TargetCreatureOrPlayer -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
@@ -13,11 +13,12 @@ import com.wingedsheep.engine.mechanics.targeting.StackObjectTargeting
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
-import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
@@ -45,11 +46,16 @@ class TargetEnumerationUtils(
                 !playerHasHexproof(state, it) && !playerHasProtectionFrom(state, it, sourceId, playerId) &&
                 PlayerTargetRestriction.isSatisfied(state, requirement.restriction, it, playerId, sourceId) }
             is AnyTarget -> {
-                val creatures = findValidPermanentTargets(state, playerId, TargetFilter.Creature, sourceId)
-                val planeswalkers = findValidPermanentTargets(state, playerId, TargetFilter.Planeswalker, sourceId)
+                val projected = state.projectedState
+                val permanents = findValidPermanentTargets(state, playerId, TargetFilter(GameObjectFilter.Any), sourceId)
+                    .filter { projected.isCreature(it) || projected.isPlaneswalker(it) || projected.isBattle(it) }
                 val players = state.turnOrder.filter { state.hasEntity(it) && !playerHasShroud(state, it) &&
                     !playerHasHexproofAgainst(state, it, playerId) && !playerHasProtectionFrom(state, it, sourceId, playerId) }
-                (creatures + planeswalkers).distinct() + players
+                val candidates = permanents + players
+                if (requirement.filter == GameObjectFilter.Any) candidates else {
+                    val context = PredicateContext(controllerId = playerId, sourceId = sourceId)
+                    candidates.filter { predicateEvaluator.matches(state, projected, it, requirement.filter, context) }
+                }
             }
             is TargetCreatureOrPlayer -> {
                 val creatures = findValidPermanentTargets(state, playerId, TargetFilter.Creature, sourceId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -1142,6 +1142,7 @@ internal class CombatDamageManager(
         val currentCount = counters.getCount(counterType)
         newState = newState.updateEntity(targetId) { container ->
             container.with(counters.withRemoved(counterType, amount))
+                .with(WasDealtDamageThisTurnComponent)
         }
 
         // Combat damage that takes a Siege's last defense counter defeats it (CR 310.12b). Arm the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -3417,6 +3417,21 @@ class StackResolver(
         )
 
         return targets.filterIndexed { index, target ->
+            var baseRequirement = getRequirementForTargetIndex(index, targetRequirements)
+            while (baseRequirement is TargetOther) baseRequirement = baseRequirement.baseRequirement
+            if (baseRequirement is AnyTarget) {
+                val recipient = when (target) {
+                    is ChosenTarget.Player -> target.playerId
+                    is ChosenTarget.Permanent -> target.entityId
+                    else -> return@filterIndexed false
+                }
+                if (target is ChosenTarget.Permanent && !projected.isCreature(recipient) &&
+                    !projected.isPlaneswalker(recipient) && !projected.isBattle(recipient)
+                ) return@filterIndexed false
+                if (!predicateEvaluator.matches(state, projected, recipient, baseRequirement.filter, predicateContext)) {
+                    return@filterIndexed false
+                }
+            }
             when (target) {
                 is ChosenTarget.Player -> {
                     // Player is valid if they exist and haven't lost...

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -310,7 +310,20 @@ class TargetValidator {
         val error = when (requirement) {
             is TargetPlayer -> validatePlayerTarget(state, target, requirement, casterId, sourceId)
             is TargetOpponent -> validateOpponentTarget(state, target, requirement, casterId, sourceId)
-            is AnyTarget -> validateAnyTarget(state, target, casterId)
+            is AnyTarget -> {
+                val baseError = validateAnyTarget(state, target, casterId)
+                val entityId = when (target) {
+                    is ChosenTarget.Player -> target.playerId
+                    is ChosenTarget.Permanent -> target.entityId
+                    else -> null
+                }
+                if (baseError != null) baseError
+                else if (entityId == null || !predicateEvaluator.matches(
+                        state, state.projectedState, entityId, requirement.filter,
+                        PredicateContext(controllerId = casterId, sourceId = sourceId, xValue = xValue)
+                    )) "Target does not match ${requirement.description}"
+                else null
+            }
             is TargetCreatureOrPlayer -> validateCreatureOrPlayerTarget(state, target, casterId)
             is TargetPermanentOrPlayer ->
                 validatePermanentOrPlayerTarget(state, target, requirement, casterId, sourceId, xValue, chosenPlayerTarget)
@@ -764,7 +777,11 @@ class TargetValidator {
                 else null
             }
             is ChosenTarget.Permanent -> {
-                if (target.entityId !in state.getBattlefield()) "Target not on battlefield" else null
+                val projected = state.projectedState
+                if (target.entityId !in state.getBattlefield()) "Target not on battlefield"
+                else if (!projected.isCreature(target.entityId) && !projected.isPlaneswalker(target.entityId) &&
+                    !projected.isBattle(target.entityId)) "Target must be a creature, player, planeswalker, or battle"
+                else null
             }
             else -> "Invalid target type"
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -1253,7 +1253,7 @@ data class CraftedFromExiledComponent(
 ) : Component
 
 /**
- * Marks a permanent as having been dealt damage this turn.
+ * Marks a permanent or player as having been dealt damage this turn.
  * Cleared at end of turn by CleanupPhaseManager.
  * Used for StatePredicate.WasDealtDamageThisTurn.
  */

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FilteredAnyTargetScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FilteredAnyTargetScenarioTest.kt
@@ -1,0 +1,191 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.handlers.TargetFinder
+import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.legalactions.utils.TargetEnumerationUtils
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class FilteredAnyTargetScenarioTest : ScenarioTestBase() {
+    private val filter = GameObjectFilter.Any.wasDealtDamageThisTurn()
+    private val bolt = card("Filtered Test Bolt") {
+        manaCost = "{R}"
+        typeLine = "Instant"
+        spell {
+            val recipient = target("damaged target", Targets.Any(filter))
+            effect = Effects.DealDamage(1, recipient)
+        }
+    }
+    private val siege = card("Damage History Siege") {
+        manaCost = "{3}"
+        typeLine = "Battle — Siege"
+        startingDefense = 8
+    }
+    private val hexproofCreature = card("History Hexproof Creature") {
+        manaCost = "{2}"
+        typeLine = "Creature — Beast"
+        power = 2
+        toughness = 4
+        keywords(Keyword.HEXPROOF)
+    }
+    private val witherer = card("History Witherer") {
+        manaCost = "{2}"
+        typeLine = "Creature — Elemental"
+        power = 1
+        toughness = 3
+        keywords(Keyword.WITHER)
+    }
+
+    private fun TestGame.checkEligible(id: EntityId) {
+        TargetFinder().findLegalTargets(state, Targets.Any(filter), player1Id) shouldContain id
+        TargetEnumerationUtils(PredicateEvaluator()).findValidTargets(state, player1Id, Targets.Any(filter)) shouldContain id
+    }
+
+    init {
+        cardRegistry.register(bolt)
+        cardRegistry.register(siege)
+        cardRegistry.register(witherer)
+        cardRegistry.register(hexproofCreature)
+
+        for (targetKind in listOf("player", "planeswalker", "battle")) {
+            test("combat damage history enables filtered targeting of a $targetKind") {
+                val builder = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Filtered Test Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                if (targetKind == "planeswalker") builder.withCardOnBattlefield(2, "Jace Beleren")
+                if (targetKind == "battle") builder.withCardOnBattlefield(1, "Damage History Siege")
+                val game = builder.build()
+                val name = if (targetKind == "planeswalker") "Jace Beleren" else "Damage History Siege"
+                val recipient = if (targetKind == "player") game.player2Id else game.findPermanent(name)!!
+                if (targetKind == "planeswalker") {
+                    game.state = game.state.updateEntity(recipient) { it.with(CountersComponent().withAdded(CounterType.LOYALTY, 8)) }
+                }
+                game.checkStateBasedActions()
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                if (targetKind == "player") game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                else game.declareAttackersWithPermanentTargets(permanentAttackers = mapOf("Grizzly Bears" to name)).error shouldBe null
+                game.declareNoBlockers()
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                game.checkEligible(recipient)
+                val result = if (targetKind == "player") game.castSpellTargetingPlayer(1, "Filtered Test Bolt", 2)
+                    else game.castSpell(1, "Filtered Test Bolt", recipient)
+                result.error shouldBe null
+                game.resolveStack()
+                if (targetKind == "player") game.getLifeTotal(2) shouldBe 17
+                else game.state.getEntity(recipient)!!.get<CountersComponent>()!!.getCount(
+                    if (targetKind == "planeswalker") CounterType.LOYALTY else CounterType.DEFENSE
+                ) shouldBe 5
+            }
+        }
+
+        test("noncombat damage to a battle is recorded and its defense is removed") {
+            val game = scenario().withPlayers("Caster", "Opponent").withCardOnBattlefield(1, "Damage History Siege").build()
+            val battle = game.findPermanent("Damage History Siege")!!
+            game.state = DamageUtils.dealDamageToTarget(game.state, battle, 1, null).state
+            game.checkEligible(battle)
+            game.state.getEntity(battle)!!.get<CountersComponent>()!!.getCount(CounterType.DEFENSE) shouldBe 7
+        }
+
+        test("wither damage qualifies even though it leaves no marked damage") {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardOnBattlefield(1, "History Witherer", summoningSickness = false)
+                .withCardOnBattlefield(2, "Hill Giant")
+                .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                .build()
+            val giant = game.findPermanent("Hill Giant")!!
+            game.declareAttackers(mapOf("History Witherer" to 2)).error shouldBe null
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            game.declareBlockers(mapOf("Hill Giant" to listOf("History Witherer"))).error shouldBe null
+            game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+            game.checkEligible(giant)
+            game.state.getEntity(giant)!!.get<DamageComponent>()?.amount shouldBe null
+            game.state.getEntity(giant)!!.get<CountersComponent>()!!.getCount(CounterType.MINUS_ONE_MINUS_ONE) shouldBe 1
+        }
+
+        test("damage history does not bypass hexproof") {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardOnBattlefield(2, "History Hexproof Creature")
+                .withCardInHand(1, "Filtered Test Bolt")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .build()
+            val bogle = game.findPermanent("History Hexproof Creature")!!
+            game.state = DamageUtils.dealDamageToTarget(game.state, bogle, 1, null).state
+            TargetFinder().findLegalTargets(game.state, Targets.Any(filter), game.player1Id) shouldNotContain bogle
+            game.castSpell(1, "Filtered Test Bolt", bogle).error shouldNotBe null
+        }
+
+        test("a damaged noncreature land cannot be submitted as an any-target permanent") {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withLandsOnBattlefield(2, "Forest", 1)
+                .withCardInHand(1, "Filtered Test Bolt")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .build()
+            val forest = game.findPermanent("Forest")!!
+            game.state = game.state.updateEntity(forest) {
+                it.with(com.wingedsheep.engine.state.components.battlefield.WasDealtDamageThisTurnComponent)
+            }
+            game.castSpell(1, "Filtered Test Bolt", forest).error shouldNotBe null
+        }
+
+        test("chosen and random retargeting keep the original spell's damage restriction") {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardInHand(1, "Filtered Test Bolt")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withCardOnBattlefield(2, "Hill Giant")
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .build()
+            val giant = game.findPermanent("Hill Giant")!!
+            game.state = DamageUtils.dealDamageToTarget(game.state, giant, 1, null).state
+            game.state = DamageUtils.dealDamageToTarget(game.state, game.player2Id, 1, null).state
+            val spell = game.findCardsInHand(1, "Filtered Test Bolt").single()
+            game.castSpell(1, "Filtered Test Bolt", giant).error shouldBe null
+            val context = com.wingedsheep.engine.handlers.EffectContext(
+                sourceId = null, controllerId = game.player2Id,
+                targets = listOf(com.wingedsheep.engine.state.components.stack.ChosenTarget.Spell(spell))
+            )
+            val changed = com.wingedsheep.engine.handlers.effects.stack.ChangeTargetExecutor().execute(
+                game.state, com.wingedsheep.sdk.scripting.effects.ChangeTargetEffect(), context
+            )
+            (changed.state.pendingDecision as com.wingedsheep.engine.core.SelectCardsDecision).options shouldBe listOf(game.player2Id)
+            val random = com.wingedsheep.engine.handlers.effects.stack.ReselectTargetRandomlyExecutor().execute(
+                game.state, com.wingedsheep.sdk.scripting.effects.ReselectTargetRandomlyEffect,
+                context.copy(triggeringEntityId = spell)
+            )
+            val selected = random.state.getEntity(spell)!!
+                .get<com.wingedsheep.engine.state.components.stack.TargetsComponent>()!!.targets.single()
+            (selected in listOf(
+                com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent(giant),
+                com.wingedsheep.engine.state.components.stack.ChosenTarget.Player(game.player2Id)
+            )) shouldBe true
+            val creatureRedirect = com.wingedsheep.engine.handlers.effects.stack.ChangeSpellTargetExecutor().execute(
+                game.state, com.wingedsheep.sdk.scripting.effects.ChangeSpellTargetEffect(), context
+            )
+            creatureRedirect.state.pendingDecision shouldBe null
+        }
+    }
+}

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -2221,10 +2221,10 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       {!spectatorMode && <ActionMenu />}
 
       {/* Targeting overlay for spell/ability target selection */}
-      {!spectatorMode && <TargetingOverlay key={interactionEpoch} />}
+      {!spectatorMode && <TargetingOverlay key={`targeting:${interactionEpoch}`} />}
 
       {/* Mana color selection overlay */}
-      {!spectatorMode && <ManaColorSelectionOverlay key={interactionEpoch} />}
+      {!spectatorMode && <ManaColorSelectionOverlay key={`mana-color:${interactionEpoch}`} />}
 
       {/* Combat arrows for blocker assignments - rendered by SpectatorGameBoard in spectator mode to avoid stacking context issues */}
       {!spectatorMode && <CombatArrows />}


### PR DESCRIPTION
Add Needle Drop to Lorwyn with reusable `Targets.Any(filter)` support. The spell can target only a creature, player, planeswalker, or battle that was dealt damage this turn, then deals 1 damage and draws a card. With six Lorwyn cards remaining and new engine support required, this PR keeps to one card.

The filter is enforced during target enumeration, casting, resolution, and target changes. Damage history now includes players, planeswalkers, and battles across combat and noncombat paths; prevention, damage removal, zone changes, and cleanup retain their intended behavior. Includes the SDK reference update, Lorwyn snapshot/backlog update (281/286), and a manual scenario at `manual-scenarios/cards/n/needle-drop.json`.

Validation:
- Full `just test` passes, including 11 Needle Drop scenarios, 8 engine scenarios, and 3 SDK serialization tests.
- Production `just client-build` passes. Both Playwright flows in `lorwyn/needle-drop.spec.ts` pass against isolated server/client ports.
- Card snapshots re-blessed: only Needle Drop was added.
- Scryfall fields, artwork URL, and earliest-printing gate verified.
- Assay touchstone: 2,000 cards, zero ambiguities, print mismatches, or inverse failures.
- Lorwyn differential: 108 agree; three existing structural folds (Boggart Sprite-Chaser and Kithkin Greatheart group their conditional statics; Epic Proportions groups statics and omits an unused aura-target ID). No unrelated snapshots changed.
- Assay declines Needle Drop's restricted-any-target wording; behavioral tests provide coverage, not an Assay pass.

Browser verification found two sibling overlays sharing the same React key; distinct targeting/mana-color keys now prevent stale targeting controls after casting. The end-to-end tests exercise this through Shock followed by Needle Drop from both seats. The stricter any-target validation also required correcting the Ojer Pakpatiq death test: one Bolt kills its 4/3 front face; a second Bolt at the returned land was illegal.
